### PR TITLE
fix(mcp-server): sync CLI version with package metadata

### DIFF
--- a/mcp-server/src/bin/agentrelay-cli.test.ts
+++ b/mcp-server/src/bin/agentrelay-cli.test.ts
@@ -1,12 +1,15 @@
 import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { access } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { dirname, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
 const PACKAGE_ROOT = pathResolve(__dirname, "../..");
 const AGENTRELAY_BIN_PATH = pathResolve(PACKAGE_ROOT, "dist/bin/agentrelay.js");
 
@@ -65,6 +68,21 @@ describeIfBuilt("agentrelay CLI mcp subcommand", () => {
 
 		expect(result.status, result.stderr).toBe(0);
 		expect(result.stdout).toMatch(/mcp\s+Start the AgentRelay MCP server/);
+	});
+
+	it("reports the package version", () => {
+		const result = spawnSync("node", [AGENTRELAY_BIN_PATH, "--version"], {
+			cwd: PACKAGE_ROOT,
+			encoding: "utf8",
+			stdio: "pipe",
+		});
+
+		if (result.error !== undefined) {
+			throw result.error;
+		}
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(result.stdout.trim()).toContain(`agentrelay/${pkg.version}`);
 	});
 });
 

--- a/mcp-server/src/bin/agentrelay.ts
+++ b/mcp-server/src/bin/agentrelay.ts
@@ -5,6 +5,7 @@
  * exercised directly by the test suite.
  */
 
+import { createRequire } from "node:module";
 import { cac } from "cac";
 import {
 	blockCmd,
@@ -29,6 +30,8 @@ import { listTrust } from "../cli/trust-mutate.js";
 import { logger } from "../logger.js";
 import { FALLBACK_TRUST, loadTrust } from "../trust.js";
 
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
 const cli = cac("agentrelay");
 
 cli
@@ -285,7 +288,7 @@ cli.command("mcp", "Start the AgentRelay MCP server (stdio)").action(async () =>
 });
 
 cli.help();
-cli.version("0.0.1");
+cli.version(pkg.version);
 
 try {
 	cli.parse(process.argv, { run: false });


### PR DESCRIPTION
## Summary

Fixes the `agentrelay` CLI version output so it stays in sync with the published `agentrelay-mcp` package metadata instead of reporting the scaffold literal `0.0.1`.

`agentrelay --version` and the help header now read `mcp-server/package.json` via `createRequire(import.meta.url)`, which keeps the current Node `>=20.0.0` engine contract intact while avoiding newer JSON import-attribute syntax.

## Changes

- Read the CLI version from `mcp-server/package.json`
- Add a built-CLI regression test for `agentrelay --version`

## Verification

- `pnpm --filter agentrelay-mcp build`
- `pnpm --filter agentrelay-mcp exec vitest run src/bin/agentrelay-cli.test.ts`
- `pnpm -r typecheck`
- `pnpm exec biome check mcp-server/src/bin/agentrelay.ts mcp-server/src/bin/agentrelay-cli.test.ts`
- `node mcp-server/dist/bin/agentrelay.js --version`
- `pnpm pack --json --pack-destination $env:TEMP\agentrelay-pack-check` confirms `package.json` is included in the published package

Notes:
- A full `pnpm lint` currently reports existing repository-wide line-ending/format diagnostics unrelated to this two-file change, so I kept formatting scoped to the touched files.

Closes #47.