### PR TITLE
feat(protocol): add executable Mission contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
 
       - run: pnpm -r typecheck
 
+      - run: pnpm -r build
+
+      - run: pnpm --filter @agentrelay/protocol test:exports
+
   unit:
     needs: lint-typecheck
     runs-on: ubuntu-latest
@@ -49,7 +53,7 @@ jobs:
 
       # Skip the e2e workspace — it needs Postgres + builds + a real
       # relay subprocess and is covered by the dedicated `e2e` job.
-      - run: pnpm --filter relay --filter agentrelay-mcp test
+      - run: pnpm --filter @agentrelay/protocol --filter relay --filter agentrelay-mcp test
 
   relay-integration:
     needs: lint-typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,9 @@ need.
   - `docs/hld.md` for the implemented mailbox flow.
   - `docs/lld.md` for current schemas, routes, tools, and known gaps.
   - `docs/rfcs/001-agentrelay-node-and-missions.md` for the next architecture.
-- Trace cross-package behavior through both `relay/` and `mcp-server/`. A contract
-  is not understood until both producer and consumer have been checked.
+- Trace cross-package behavior through `protocol/`, `relay/`, and `mcp-server/` as
+  applicable. A contract is not understood until its producer and consumer have
+  both been checked.
 - Treat active code and tests as current behavior. Treat an accepted RFC as target
   behavior. If they disagree, state the discrepancy instead of silently choosing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ pnpm --filter agentrelay-mcp dev
 ## Repository layout
 
 ```text
+protocol/       shared Mission, delivery, and runtime-adapter contracts
 relay/          Hono + Drizzle + Postgres relay
 mcp-server/     agentrelay-mcp package and agentrelay CLI
 tests/e2e/      real relay plus two MCP processes
@@ -119,12 +120,13 @@ pnpm -r build
 Database-free package tests, matching CI's unit job:
 
 ```bash
-pnpm --filter relay --filter agentrelay-mcp test
+pnpm --filter @agentrelay/protocol --filter relay --filter agentrelay-mcp test
 ```
 
 Focused iteration:
 
 ```bash
+pnpm --filter @agentrelay/protocol exec vitest run src/path/file.test.ts
 pnpm --filter relay exec vitest run src/path/file.test.ts
 pnpm --filter agentrelay-mcp exec vitest run src/path/file.test.ts
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ full autonomous runtime described above.
 - Seven stdio MCP tools for Claude Code and Codex.
 - Typed engineering artifacts, plus provenance markers when `accept_handoff` or
   `view_thread` returns teammate-authored summaries/messages.
+- An executable `@agentrelay/protocol` workspace with bounded Mission contracts,
+  strict lifecycle reducers, and a deterministic fake runtime adapter.
 - CLI setup, invite/join, install, doctor/fix, key rotation, audit, block, and trust.
 - An in-process Slack dispatcher, although the current card-update path does not
   produce the encrypted webhook form it consumes, so setup is not end-to-end usable.
@@ -176,7 +178,7 @@ Use [`CONTRIBUTING.md`](CONTRIBUTING.md) for exact test tiers. The database-free
 unit command is:
 
 ```bash
-pnpm --filter relay --filter agentrelay-mcp test
+pnpm --filter @agentrelay/protocol --filter relay --filter agentrelay-mcp test
 ```
 
 `pnpm -r test` also includes the Postgres-backed E2E workspace.
@@ -221,6 +223,7 @@ this README does not claim full A2A conformance.
 .
 ├── AGENTS.md             coding-agent instructions: understand first, keep code clear
 ├── CLAUDE.md             Claude-specific entry point; delegates to AGENTS.md
+├── protocol/             Mission schemas, state machines, and adapter contract
 ├── relay/                current Hono + Drizzle + Postgres relay
 ├── mcp-server/           current MCP server and agentrelay CLI
 ├── tests/e2e/            relay + two-MCP-process test harness

--- a/docs/lld.md
+++ b/docs/lld.md
@@ -1,6 +1,6 @@
 # Low-level design: current mailbox contracts
 
-> **Scope:** Implemented code on `main` as of 2026-08-01.
+> **Scope:** Implemented code on `main` as of 2026-08-02.
 > This is a compact source-oriented reference, not a promise that planned fields or
 > routes exist. Future Node and Mission contracts belong to
 > [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md) until implemented.
@@ -10,6 +10,7 @@
 ```text
 .
 ├── landing/             GitHub Pages landing page
+├── protocol/            Mission schemas, state machines, and adapter contract
 ├── relay/               Hono, Drizzle, Postgres relay
 ├── mcp-server/          agentrelay-mcp package and agentrelay CLI
 ├── tests/e2e/           relay plus two-MCP-process integration harness
@@ -18,8 +19,8 @@
 └── package.json         pnpm workspace scripts
 ```
 
-There is currently no `node/` package, runtime adapter, persistent event consumer, or
-Mission schema.
+There is currently no `node/` daemon, persistent event consumer, or real runtime
+adapter. The executable Mission contracts and fake adapter live in `protocol/`.
 
 ## Relay tables
 
@@ -293,7 +294,7 @@ From the repository root:
 pnpm lint
 pnpm -r typecheck
 pnpm -r build
-pnpm --filter relay --filter agentrelay-mcp test
+pnpm --filter @agentrelay/protocol --filter relay --filter agentrelay-mcp test
 ```
 
 Database-backed tests require Postgres and migrations:

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -20,13 +20,16 @@ or trust gaps.
 
 ## 2. Write executable Mission schemas
 
-- [ ] Add Mission, participant, revision, typed message, artifact, policy, delivery,
+- [x] Add Mission, participant, revision, typed message, artifact, policy, delivery,
   and run schemas.
-- [ ] Add Mission and delivery state-machine transition tests.
+- [x] Add Mission and delivery state-machine transition tests.
 - [ ] Define one fake backend repository and one fake Android repository at frozen
   commits.
 - [ ] Define a hidden cross-repository acceptance scenario.
-- [ ] Add a fake runtime adapter and deterministic transcript fixtures.
+- [x] Add a fake runtime adapter with duplicate, recovery, and cancellation tests.
+- [ ] Add deterministic transcript fixtures.
+- [ ] Publish JSON Schema and OpenAPI bindings before a non-TypeScript Node or public
+  A2A gateway consumes this contract.
 
 Keep this layer small. Do not implement multi-party Missions, parallel actors, smart
 routing, or provider-specific fields.

--- a/docs/rfcs/001-agentrelay-node-and-missions.md
+++ b/docs/rfcs/001-agentrelay-node-and-missions.md
@@ -113,7 +113,7 @@ interface AgentHostAdapter {
 	probe(): Promise<AdapterInfo>;
 	ensureSession(input: SessionInput): Promise<HostSessionRef>;
 	lookupTurn(deliveryId: string): Promise<HostTurnRef | null>;
-	startTurn(input: TurnInput & { deliveryId: string }): AsyncIterable<HostEvent>;
+	startTurn(input: StartTurnInput): AsyncIterable<HostEvent>;
 	recoverTurn(ref: HostTurnRef): AsyncIterable<HostEvent>;
 	cancelTurn(ref: HostTurnRef): Promise<void>;
 }
@@ -121,6 +121,28 @@ interface AgentHostAdapter {
 
 `startTurn` is idempotent by `deliveryId`: if the host already accepted that delivery,
 the adapter returns or recovers the existing turn rather than starting another one.
+Lease authority does not enter the runtime adapter or `HostTurnRef`. Before starting,
+recovering, cancelling, or publishing a host result, the Node atomically checks the
+delivery's current lease ID, fencing token, and unexpired deadline in durable state. A
+newly leased Node may recover the same delivery's existing host turn; an expired
+holder is rejected before it reaches the adapter.
+
+Every normalized host event has one stable, turn-local sequence number so full replay
+can be deduplicated after recovery. Events cover acceptance, bounded output, tool and
+permission lifecycle, artifact references, cumulative turn token usage or explicit
+usage unavailability, completion, failure, and cancellation. A later usage event
+supersedes an earlier usage event; consumers do not sum snapshots, and no terminal
+event is accepted before usage or explicit unavailability. Provider events do not
+become a side channel around Node policy or evidence capture.
+
+The Node applies one stream reducer across live events and full recovery replay. It
+requires contiguous acceptance-first sequencing, monotonic cumulative usage, one
+terminal event, and locally configured aggregate event, output-byte, artifact-count,
+artifact-byte, and reported-token limits. Every event must retain the accepted host
+turn correlation, and the initial acceptance must match the requested Mission,
+delivery, session, and contract version. The delivery-to-host-turn mapping is durable
+as soon as the host accepts; a malformed later provider event cannot erase it and
+cause a second host turn.
 
 The first adapter pins one supported Codex app-server version. Preview host channels,
 Codex remote control, remote ACP, and generic MCP notifications are not dependencies
@@ -168,6 +190,11 @@ The immutable creation manifest contains:
 The remote manifest may request a policy profile. Only local configuration defines
 what that profile permits.
 
+The relay authenticates the Mission creator and attaches that actor separately from
+the immutable manifest. The Node derives objective, assignment, and acceptance text
+from this authenticated Mission context; a runtime caller cannot select its own
+provenance label.
+
 ### Shared-contract revisions
 
 Do not version the entire Mission for every discussion change. Version one shared
@@ -186,10 +213,10 @@ Every runtime turn returns exactly one structured disposition:
 
 ```typescript
 type TurnDisposition =
-	| { kind: "reply"; message: string; artifacts?: ArtifactRef[] }
+	| { kind: "reply"; message_type: MessageType; message: string; artifacts?: ArtifactRef[] }
 	| { kind: "propose_contract"; artifact: ArtifactRef }
 	| { kind: "ready"; evidence: VerificationEvidence[] }
-	| { kind: "blocked"; reason: string; requestedInput?: string }
+	| { kind: "blocked"; reason: string; requested_input?: string }
 	| { kind: "failed"; class: "transient" | "permanent" | "policy_denied" };
 ```
 
@@ -256,6 +283,11 @@ Delivery is at least once. Each retry increments attempt count and applies bound
 backoff. A true terminal delivery failure becomes `dead_lettered`; Mission policy then
 moves the Mission to `blocked` or `failed`.
 
+Each new lease also advances a monotonic fencing token. Lease-owned execution,
+acknowledgement, retry, cancellation, and result publication must present the active
+lease ID and token before the lease deadline, so a delayed or expired holder cannot
+mutate a re-leased delivery.
+
 "Written to a socket" is not a delivery state. Polling the durable Node cursor is the
 first correct implementation. SSE may later reduce pickup latency without changing
 these states.
@@ -268,7 +300,8 @@ The relay coordinator reduces typed events; it does not reason about repository 
 - `reply` schedules the other participant.
 - `propose_contract` pauses turns until both acknowledge.
 - `blocked` stops scheduling until required input is supplied.
-- `ready` marks that participant ready for the current contract version.
+- `ready` marks that participant ready for the current contract version. Its evidence
+  array may be empty because required Node verification runs only after both are ready.
 - When both are ready, each Node runs locally registered verification command IDs.
 - A command ID resolves locally to structured argv, workspace alias, timeout, and
   environment allowlist. Peer-provided shell strings are never executable authority.
@@ -290,6 +323,10 @@ acceptance. It does not influence the agents' shared contract or runtime complet
   sandbox, approval policy, or credentials through conversation.
 - Provenance-mark every peer-originated text-bearing field while preserving typed
   artifact structure.
+- Preserve the exact bounded UTF-8 artifact text identified by its hash. JSON input
+  carries that source text and a structured value derived from it; the Node rejects a
+  supplied mismatch instead of silently reserializing it. Artifact version and source
+  actor remain attached.
 - Deny push, merge, publish, deploy, credentials, and arbitrary network effects.
 - Observe cancellation, expiry, and credential revocation before claiming new work.
 - Bound outbound text and artifacts so AgentRelay cannot become an unrestricted data

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,22 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)
 
+  protocol:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)
+
   relay:
     dependencies:
       '@hono/node-server':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - 'protocol'
   - 'relay'
   - 'mcp-server'
   - 'tests/e2e'

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -1,0 +1,51 @@
+# @agentrelay/protocol
+
+Executable contracts for AgentRelay's bounded two-participant Mission loop.
+
+The package contains:
+
+- strict Zod schemas for Mission manifests, contract revisions, typed messages,
+  artifact references, policy requests, delivery leases, runs, and evidence;
+- pure Mission and fenced-delivery reducers that reject invalid transitions; and
+- a runtime-neutral host adapter contract, with a deterministic fake under
+  `@agentrelay/protocol/testing`.
+
+Wire schemas use `snake_case`. Adapter lifecycle fields use local TypeScript naming;
+embedded relay payloads such as `TurnDisposition` and `ArtifactRef` deliberately keep
+their exact wire shape so the Node validates what it publishes without an implicit
+translation.
+
+```typescript
+import {
+	missionManifestSchema,
+	transitionMissionStatus,
+} from "@agentrelay/protocol";
+
+const manifest = missionManifestSchema.parse(untrustedInput);
+const next = transitionMissionStatus("awaiting_acceptance", {
+	type: "participants_accepted",
+});
+```
+
+The adapter contract makes replay semantics explicit: every event has a stable
+turn-local sequence, available usage is a monotonic cumulative turn snapshot, and
+artifact input retains its version, source actor, exact hashed UTF-8 text, and a
+validated typed value derived from that text. `acceptHostEvent` enforces
+acceptance-first sequencing, one terminal event, and aggregate event/output/artifact
+and reported-token limits across live delivery and full replay. A terminal event
+requires a usage snapshot or explicit unavailability first. Initialize its state with
+the requested host-turn correlation so the first acceptance cannot bind a different
+delivery. Mission prompt fields should be built with `deriveHostMissionInputs` from
+the relay-authenticated Mission context.
+
+Delivery lease IDs and fencing tokens are intentionally Node-owned. They are checked
+with the lease deadline against durable delivery state before runtime
+start/recovery/cancellation and result publication; they are not copied into host turn
+references.
+
+This package defines data and state transitions. It does not persist Missions,
+execute policy, start a model runtime, or claim A2A conformance.
+
+Version 0.1 is the TypeScript/Zod binding used to prove the first Node. Committed
+JSON Schema and OpenAPI bindings remain required before a non-TypeScript Node or
+public A2A gateway treats this package as a language-neutral wire specification.

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@agentrelay/protocol",
+	"version": "0.1.0",
+	"description": "Executable protocol contracts for AgentRelay Missions, deliveries, and runtime adapters.",
+	"license": "MIT",
+	"type": "module",
+	"engines": {
+		"node": ">=20.0.0"
+	},
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./testing": {
+			"types": "./dist/testing/index.d.ts",
+			"import": "./dist/testing/index.js"
+		}
+	},
+	"files": ["dist"],
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"prepack": "pnpm run build",
+		"test": "vitest run",
+		"test:exports": "node --input-type=module -e \"const p = await import('@agentrelay/protocol'); const t = await import('@agentrelay/protocol/testing'); if (!p.missionManifestSchema || !p.transitionDeliveryState || !p.acceptHostEvent || !t.FakeAgentHostAdapter) throw new Error('protocol exports missing')\"",
+		"test:watch": "vitest",
+		"typecheck": "tsc -p tsconfig.json --noEmit"
+	},
+	"dependencies": {
+		"zod": "^3.23.8"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.0",
+		"typescript": "^5.7.2",
+		"vitest": "^2.1.8"
+	}
+}

--- a/protocol/src/adapter.test.ts
+++ b/protocol/src/adapter.test.ts
@@ -1,0 +1,728 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_HOST_EVENT_STREAM_POLICY,
+	type HostEvent,
+	type HostSessionRef,
+	InvalidHostEventStreamError,
+	type StartTurnInput,
+	acceptHostEvent,
+	createHostEventStreamState,
+	deriveHostMissionInputs,
+	hostInputArtifactSchema,
+} from "./adapter.js";
+import type { TurnDisposition } from "./schemas.js";
+import { FakeAgentHostAdapter } from "./testing/fake-adapter.js";
+
+const IDS = {
+	mission: "00000000-0000-4000-8000-000000000001",
+	backendAgent: "00000000-0000-4000-8000-000000000002",
+	androidAgent: "00000000-0000-4000-8000-000000000003",
+	artifact: "00000000-0000-4000-8000-000000000004",
+	message: "00000000-0000-4000-8000-000000000005",
+	delivery: "00000000-0000-4000-8000-000000000006",
+	owner: "00000000-0000-4000-8000-000000000010",
+	otherMission: "00000000-0000-4000-8000-000000000011",
+	impersonator: "00000000-0000-4000-8000-000000000012",
+	unknownParticipant: "00000000-0000-4000-8000-000000000013",
+} as const;
+
+const REPLY: TurnDisposition = {
+	kind: "reply",
+	message_type: "progress",
+	message: "implementation complete",
+};
+
+describe("FakeAgentHostAdapter", () => {
+	it("suppresses duplicate host turns by deliveryId", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		adapter.queueOutcome({ kind: "completed", disposition: REPLY });
+
+		const first = await collect(adapter.startTurn(input));
+		const duplicate = await collect(adapter.startTurn(input));
+
+		expect(duplicate).toEqual(first);
+		expect(first.map((event) => event.kind)).toEqual(["accepted", "usage", "completed"]);
+		expect(adapter.counters.startTurnCalls).toBe(2);
+		expect(adapter.counters.turnsCreated).toBe(1);
+	});
+
+	it("rejects changed work or provenance that reuses an accepted deliveryId", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		adapter.queueOutcome({ kind: "completed", disposition: REPLY });
+		await collect(adapter.startTurn(input));
+
+		expect(() =>
+			adapter.startTurn({
+				...input,
+				peerMessages: [
+					{
+						...input.peerMessages[0]!,
+						authorAgentId: IDS.impersonator,
+					},
+				],
+			}),
+		).toThrow(/deliveryId reused with different turn correlation/);
+		expect(() =>
+			adapter.startTurn({
+				...input,
+				artifacts: [
+					{
+						...input.artifacts[0]!,
+						source: {
+							...input.artifacts[0]!.source,
+							principal_id: IDS.impersonator,
+						},
+					},
+				],
+			}),
+		).toThrow(/deliveryId reused with different turn correlation/);
+		expect(() =>
+			adapter.startTurn({
+				...input,
+				objective: { ...input.objective, authorPrincipalId: IDS.androidAgent },
+			}),
+		).toThrow(/deliveryId reused with different turn correlation/);
+		expect(adapter.counters.startTurnCalls).toBe(4);
+		expect(adapter.counters.turnsCreated).toBe(1);
+		expect((await adapter.lookupTurn(input.deliveryId))?.turnId).toBe("fake-turn-1");
+	});
+
+	it("snapshots accepted input so caller mutation cannot redefine a delivery", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const peerMessage = {
+			messageId: IDS.message,
+			authorAgentId: IDS.androidAgent,
+			kind: "proposal" as const,
+			body: "Use the agreed contract.",
+		};
+		const input = { ...createTurnInput(session), peerMessages: [peerMessage] };
+		await collect(adapter.startTurn(input));
+
+		peerMessage.body = "Replace the accepted work after host invocation.";
+
+		expect(() => adapter.startTurn(input)).toThrow(
+			/deliveryId reused with different turn correlation/,
+		);
+		expect(adapter.counters.turnsCreated).toBe(1);
+	});
+
+	it("looks up and recovers accepted and completed turns", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		adapter.queueOutcome({ kind: "pending" });
+
+		const accepted = await collect(adapter.startTurn(input));
+		const ref = await adapter.lookupTurn(input.deliveryId);
+		expect(ref).toEqual(accepted[0]?.turn);
+		expect((await collect(adapter.recoverTurn(ref!))).map((event) => event.kind)).toEqual([
+			"accepted",
+		]);
+
+		adapter.completeTurn(input.deliveryId, REPLY);
+		const recovered = await collect(adapter.recoverTurn(ref!));
+
+		expect(recovered.map((event) => event.kind)).toEqual(["accepted", "usage", "completed"]);
+		expect(recovered[2]).toMatchObject({ kind: "completed", disposition: REPLY });
+		expect(adapter.counters.turnsCreated).toBe(1);
+		expect(adapter.counters.recoverTurnCalls).toBe(2);
+	});
+
+	it("replays normalized output, tool, and usage evidence without exposing mutable history", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		const queuedDisposition = { ...REPLY };
+		adapter.queueOutcome({
+			kind: "completed",
+			events: [
+				{ kind: "output", text: "working" },
+				{
+					kind: "tool",
+					activity: { toolCallId: "tool-1", name: "read_file", phase: "completed" },
+				},
+				{
+					kind: "permission",
+					activity: { requestId: "permission-1", capability: "write_workspace", phase: "granted" },
+				},
+				{
+					kind: "artifact",
+					artifact: {
+						artifact_id: "00000000-0000-4000-8000-000000000004",
+						type: "patch",
+						version: 1,
+						sha256: "b".repeat(64),
+						media_type: "text/x-diff",
+						byte_size: 128,
+					},
+				},
+				{
+					kind: "usage",
+					usage: {
+						available: true,
+						scope: "turn_cumulative",
+						inputTokens: 120,
+						outputTokens: 30,
+					},
+				},
+			],
+			disposition: queuedDisposition,
+		});
+		queuedDisposition.message = "mutated after queueing";
+
+		const first = await collect(adapter.startTurn(input));
+		expect(first.map((event) => event.kind)).toEqual([
+			"accepted",
+			"output",
+			"tool",
+			"permission",
+			"artifact",
+			"usage",
+			"completed",
+		]);
+		expect(first.map((event) => event.sequence)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+		const output = first.find((event) => event.kind === "output");
+		if (output?.kind === "output") {
+			(output as { text: string }).text = "mutated replay";
+		}
+		const completed = first.find((event) => event.kind === "completed");
+		if (completed?.kind === "completed" && completed.disposition.kind === "reply") {
+			completed.disposition.message = "mutated replay";
+		}
+
+		const recovered = await collect(
+			adapter.recoverTurn((await adapter.lookupTurn(input.deliveryId))!),
+		);
+		expect(recovered[1]).toMatchObject({ kind: "output", sequence: 2, text: "working" });
+		expect(recovered.at(-1)).toMatchObject({
+			kind: "completed",
+			disposition: { message: "implementation complete" },
+		});
+	});
+
+	it("replays the complete stable sequence after a consumer stops partway", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		adapter.queueOutcome({
+			kind: "completed",
+			events: [
+				{ kind: "output", text: " " },
+				{ kind: "output", text: "done" },
+			],
+			disposition: REPLY,
+		});
+
+		const iterator = adapter.startTurn(input)[Symbol.asyncIterator]();
+		expect((await iterator.next()).value).toMatchObject({ kind: "accepted", sequence: 1 });
+		await iterator.return?.();
+
+		const ref = await adapter.lookupTurn(input.deliveryId);
+		const recovered = await collect(adapter.recoverTurn(ref!));
+		expect(recovered.map((event) => event.sequence)).toEqual([1, 2, 3, 4, 5]);
+		expect(recovered.map((event) => event.kind)).toEqual([
+			"accepted",
+			"output",
+			"output",
+			"usage",
+			"completed",
+		]);
+	});
+
+	it("reuses a session for the same Mission participant and workspace alias", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const input = {
+			missionId: IDS.mission,
+			participantId: IDS.backendAgent,
+			workspaceAlias: "backend-primary",
+		};
+
+		const first = await adapter.ensureSession(input);
+		const second = await adapter.ensureSession(input);
+
+		expect(second).toEqual(first);
+		expect(adapter.counters.ensureSessionCalls).toBe(2);
+		expect(adapter.counters.sessionsCreated).toBe(1);
+	});
+
+	it("cancels an accepted turn idempotently and recovers the cancellation", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		adapter.queueOutcome({ kind: "pending" });
+		await collect(adapter.startTurn(input));
+		const ref = await adapter.lookupTurn(input.deliveryId);
+
+		await adapter.cancelTurn(ref!);
+		await adapter.cancelTurn(ref!);
+		const recovered = await collect(adapter.recoverTurn(ref!));
+
+		expect(recovered.map((event) => event.kind)).toEqual(["accepted", "usage", "cancelled"]);
+		expect(adapter.counters.cancelTurnCalls).toBe(2);
+		expect(adapter.counters.turnsCancelled).toBe(1);
+		expect(adapter.counters.turnsCreated).toBe(1);
+	});
+
+	it("rejects a forged recovery reference with different Mission correlation", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		await collect(adapter.startTurn(input));
+		const ref = await adapter.lookupTurn(input.deliveryId);
+
+		expect(() => adapter.recoverTurn({ ...ref!, missionId: IDS.otherMission })).toThrow(
+			/unknown fake host turn/,
+		);
+		await expect(adapter.cancelTurn({ ...ref!, contractVersion: 2 })).rejects.toThrow(
+			/unknown fake host turn/,
+		);
+	});
+
+	it("rejects artifact content that does not match its declared bytes, hash, or typed JSON", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+
+		expect(() =>
+			adapter.startTurn({
+				...input,
+				artifacts: [
+					{
+						...input.artifacts[0]!,
+						artifact: { ...input.artifacts[0]!.artifact, sha256: "a".repeat(64) },
+					},
+				],
+			}),
+		).toThrow(/Artifact hash does not match/);
+		expect(() =>
+			adapter.startTurn({
+				...input,
+				artifacts: [
+					{
+						...input.artifacts[0]!,
+						payload: {
+							kind: "json",
+							rawText: '{"status":"string"}',
+							value: { status: "number" },
+						},
+					},
+				],
+			}),
+		).toThrow(/Parsed JSON does not match/);
+		expect(adapter.counters.turnsCreated).toBe(0);
+	});
+
+	it("rejects oversized host events before accepting a turn", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		adapter.queueOutcome({
+			kind: "pending",
+			events: [{ kind: "output", text: "x".repeat(16_001) }],
+		});
+
+		expect(() => adapter.startTurn(input)).toThrow();
+		expect(adapter.counters.turnsCreated).toBe(1);
+		expect(await adapter.lookupTurn(input.deliveryId)).not.toBeNull();
+		expect((await collect(adapter.startTurn(input))).map((event) => event.kind)).toEqual([
+			"accepted",
+		]);
+		expect(adapter.counters.turnsCreated).toBe(1);
+	});
+
+	it("rejects decreasing cumulative usage without losing the accepted turn", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const input = createTurnInput(session);
+		adapter.queueOutcome({
+			kind: "pending",
+			events: [
+				{
+					kind: "usage",
+					usage: {
+						available: true,
+						scope: "turn_cumulative",
+						inputTokens: 100,
+						outputTokens: 20,
+					},
+				},
+				{
+					kind: "usage",
+					usage: {
+						available: true,
+						scope: "turn_cumulative",
+						inputTokens: 90,
+						outputTokens: 20,
+					},
+				},
+			],
+		});
+
+		expect(() => adapter.startTurn(input)).toThrow(InvalidHostEventStreamError);
+		const recovered = await collect(adapter.startTurn(input));
+		expect(recovered.map((event) => event.kind)).toEqual(["accepted", "usage"]);
+		expect(recovered[1]).toMatchObject({
+			kind: "usage",
+			usage: { available: true, inputTokens: 100, outputTokens: 20 },
+		});
+		expect(adapter.counters.turnsCreated).toBe(1);
+	});
+
+	it("enforces aggregate output and artifact limits across individually valid events", async () => {
+		const outputAdapter = new FakeAgentHostAdapter();
+		const outputSession = await createSession(outputAdapter);
+		const outputInput = createTurnInput(outputSession);
+		outputAdapter.queueOutcome({
+			kind: "pending",
+			events: Array.from({ length: 17 }, () => ({
+				kind: "output" as const,
+				text: "x".repeat(16_000),
+			})),
+		});
+		expect(() => outputAdapter.startTurn(outputInput)).toThrow(InvalidHostEventStreamError);
+		expect((await collect(outputAdapter.startTurn(outputInput))).length).toBe(17);
+
+		const artifactAdapter = new FakeAgentHostAdapter();
+		const artifactSession = await createSession(artifactAdapter);
+		const artifactInput = createTurnInput(artifactSession);
+		artifactAdapter.queueOutcome({
+			kind: "pending",
+			events: Array.from({ length: 17 }, (_, index) => ({
+				kind: "artifact" as const,
+				artifact: createOutputArtifactRef(index),
+			})),
+		});
+		expect(() => artifactAdapter.startTurn(artifactInput)).toThrow(InvalidHostEventStreamError);
+		expect((await collect(artifactAdapter.startTurn(artifactInput))).length).toBe(17);
+	});
+});
+
+describe("acceptHostEvent", () => {
+	it("requires contiguous acceptance-first sequencing and rejects post-terminal events", async () => {
+		const adapter = new FakeAgentHostAdapter();
+		const session = await createSession(adapter);
+		const accepted = (await collect(adapter.startTurn(createTurnInput(session))))[0]!;
+		expect(() =>
+			acceptHostEvent(
+				createHostEventStreamState({
+					...accepted.turn,
+					deliveryId: "00000000-0000-4000-8000-000000000099",
+				}),
+				accepted,
+			),
+		).toThrow(InvalidHostEventStreamError);
+		const first = acceptHostEvent(createHostEventStreamState(accepted.turn), accepted);
+		if (first.event.kind === "accepted") {
+			first.event.turn.deliveryId = IDS.otherMission;
+		}
+		expect(first.state.turn?.deliveryId).toBe(IDS.delivery);
+
+		expect(() =>
+			acceptHostEvent(first.state, {
+				kind: "output",
+				turn: accepted.turn,
+				sequence: 3,
+				text: "gap",
+			}),
+		).toThrow(InvalidHostEventStreamError);
+		expect(() =>
+			acceptHostEvent(first.state, {
+				kind: "output",
+				turn: { ...accepted.turn, turnId: "different-provider-turn" },
+				sequence: 2,
+				text: "wrong turn",
+			}),
+		).toThrow(InvalidHostEventStreamError);
+		expect(() =>
+			acceptHostEvent(
+				first.state,
+				{
+					kind: "usage",
+					turn: accepted.turn,
+					sequence: 2,
+					usage: {
+						available: true,
+						scope: "turn_cumulative",
+						inputTokens: 8,
+						outputTokens: 3,
+					},
+				},
+				{ ...DEFAULT_HOST_EVENT_STREAM_POLICY, maxTokens: 10 },
+			),
+		).toThrow(InvalidHostEventStreamError);
+
+		expect(() =>
+			acceptHostEvent(first.state, {
+				kind: "completed",
+				turn: accepted.turn,
+				sequence: 2,
+				disposition: REPLY,
+			}),
+		).toThrow(InvalidHostEventStreamError);
+		const withUsage = acceptHostEvent(first.state, {
+			kind: "usage",
+			turn: accepted.turn,
+			sequence: 2,
+			usage: { available: false, reason: "not_reported" },
+		});
+		expect(() =>
+			acceptHostEvent(
+				withUsage.state,
+				{
+					kind: "completed",
+					turn: accepted.turn,
+					sequence: 3,
+					disposition: REPLY,
+				},
+				{ ...DEFAULT_HOST_EVENT_STREAM_POLICY, maxOutputBytes: 1 },
+			),
+		).toThrow(InvalidHostEventStreamError);
+		const terminal = acceptHostEvent(withUsage.state, {
+			kind: "completed",
+			turn: accepted.turn,
+			sequence: 3,
+			disposition: REPLY,
+		});
+		expect(() =>
+			acceptHostEvent(terminal.state, {
+				kind: "output",
+				turn: accepted.turn,
+				sequence: 4,
+				text: "late output",
+			}),
+		).toThrow(InvalidHostEventStreamError);
+	});
+});
+
+describe("deriveHostMissionInputs", () => {
+	it("derives objective, assignment, and criteria from authenticated Mission context", () => {
+		const context = createMissionContext();
+		const derived = deriveHostMissionInputs(context, context.manifest.participants[0].agent_id);
+
+		expect(derived).toEqual({
+			objective: {
+				text: context.manifest.objective,
+				authorPrincipalId: context.created_by.principal_id,
+				provenance: "mission_manifest",
+			},
+			assignment: {
+				text: context.manifest.participants[0].initial_assignment,
+				authorPrincipalId: context.created_by.principal_id,
+				provenance: "mission_manifest",
+			},
+			acceptanceCriteria: context.manifest.public_acceptance_criteria.map((text) => ({
+				text,
+				authorPrincipalId: context.created_by.principal_id,
+				provenance: "mission_manifest",
+			})),
+		});
+		expect(() => deriveHostMissionInputs(context, IDS.unknownParticipant)).toThrow(
+			/Mission participant not found/,
+		);
+	});
+});
+
+describe("hostInputArtifactSchema", () => {
+	it("safely rejects JSON nested beyond the adapter limit", () => {
+		let value: unknown = "leaf";
+		for (let depth = 0; depth < 2_500; depth += 1) {
+			value = [value];
+		}
+		const rawText = JSON.stringify(value);
+		let success: boolean | undefined;
+
+		expect(() => {
+			success = hostInputArtifactSchema.safeParse({
+				artifact: {
+					artifact_id: IDS.artifact,
+					type: "api_contract",
+					version: 1,
+					media_type: "application/json",
+					sha256: "a".repeat(64),
+					byte_size: rawText.length,
+				},
+				source: { principal_id: IDS.androidAgent, kind: "agent" },
+				payload: { kind: "json", rawText, value },
+			}).success;
+		}).not.toThrow();
+		expect(success).toBe(false);
+	});
+
+	it("derives sanitized JSON from raw text and rejects mismatched media kinds", () => {
+		const asserted: Record<PropertyKey, unknown> = { status: "string" };
+		Object.defineProperty(asserted, "hidden", { value: "not-json", enumerable: false });
+		Object.defineProperty(asserted, "toJSON", {
+			value: () => "x".repeat(20_000),
+			enumerable: false,
+		});
+		asserted[Symbol("secret")] = "not-json";
+		const parsed = hostInputArtifactSchema.parse({
+			artifact: {
+				artifact_id: IDS.artifact,
+				type: "api_contract",
+				version: 3,
+				media_type: "application/problem+json; charset=utf-8",
+				sha256: "057dbc6d9bf35958a0f764d184ecf850c626587898ac20c4868c8b37625db1f7",
+				byte_size: 19,
+			},
+			source: { principal_id: IDS.owner, kind: "owner" },
+			payload: { kind: "json", rawText: '{"status":"string"}', value: asserted },
+		});
+
+		expect(parsed.artifact.version).toBe(3);
+		expect(parsed.source).toEqual({ principal_id: IDS.owner, kind: "owner" });
+		expect(parsed.payload).toEqual({
+			kind: "json",
+			rawText: '{"status":"string"}',
+			value: { status: "string" },
+		});
+		expect(
+			hostInputArtifactSchema.safeParse({
+				artifact: {
+					artifact_id: IDS.artifact,
+					type: "api_contract",
+					version: 1,
+					media_type: "application/json",
+					sha256: "2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881",
+					byte_size: 1,
+				},
+				source: { principal_id: IDS.owner, kind: "owner" },
+				payload: { kind: "text", text: "x" },
+			}).success,
+		).toBe(false);
+	});
+});
+
+async function createSession(adapter: FakeAgentHostAdapter): Promise<HostSessionRef> {
+	return adapter.ensureSession({
+		missionId: IDS.mission,
+		participantId: IDS.backendAgent,
+		workspaceAlias: "backend-primary",
+	});
+}
+
+function createTurnInput(session: HostSessionRef): StartTurnInput {
+	return {
+		session,
+		missionId: session.missionId,
+		deliveryId: IDS.delivery,
+		contractVersion: 1,
+		missionSequence: 3,
+		objective: {
+			text: "Implement the backend half of the shared feature",
+			authorPrincipalId: IDS.owner,
+			provenance: "mission_manifest",
+		},
+		assignment: {
+			text: "Add the versioned API endpoint",
+			authorPrincipalId: IDS.owner,
+			provenance: "mission_manifest",
+		},
+		acceptanceCriteria: [
+			{
+				text: "contract fixture passes",
+				authorPrincipalId: IDS.owner,
+				provenance: "mission_manifest",
+			},
+		],
+		peerMessages: [
+			{
+				messageId: IDS.message,
+				authorAgentId: IDS.androidAgent,
+				kind: "proposal",
+				body: "Android client needs field `status`",
+			},
+		],
+		artifacts: [
+			{
+				artifact: {
+					artifact_id: IDS.artifact,
+					type: "api_contract",
+					version: 1,
+					media_type: "application/json",
+					sha256: "057dbc6d9bf35958a0f764d184ecf850c626587898ac20c4868c8b37625db1f7",
+					byte_size: 19,
+				},
+				source: { principal_id: IDS.androidAgent, kind: "agent" },
+				payload: {
+					kind: "json",
+					rawText: '{"status":"string"}',
+					value: { status: "string" },
+				},
+			},
+		],
+	};
+}
+
+function createMissionContext() {
+	return {
+		manifest: {
+			schema_version: 1 as const,
+			mission_id: "00000000-0000-4000-8000-000000000001",
+			objective: "Ship compatible backend and Android changes.",
+			public_acceptance_criteria: ["The contract fixture passes."],
+			participants: [
+				{
+					agent_id: "00000000-0000-4000-8000-000000000002",
+					role: "backend",
+					workspace_alias: "backend-api",
+					repository_url: "https://github.com/acme/backend.git",
+					expected_base_commit: "1".repeat(40),
+					initial_assignment: "Implement the versioned endpoint.",
+					requested_local_policy_profile: "coding",
+				},
+				{
+					agent_id: "00000000-0000-4000-8000-000000000003",
+					role: "android",
+					workspace_alias: "android-app",
+					repository_url: "https://github.com/acme/android.git",
+					expected_base_commit: "2".repeat(40),
+					initial_assignment: "Consume the versioned endpoint.",
+					requested_local_policy_profile: "coding",
+				},
+			],
+			shared_contract: {
+				artifact_id: "00000000-0000-4000-8000-000000000004",
+				type: "api_contract",
+				version: 1 as const,
+				sha256: "a".repeat(64),
+				media_type: "application/json",
+				byte_size: 128,
+			},
+			max_turns: 20,
+			max_wall_time_seconds: 7_200,
+			token_budget: 200_000,
+			expires_at: "2026-08-02T12:00:00.000Z",
+			allowed_artifact_types: ["api_contract", "patch"],
+			created_at: "2026-08-02T10:00:00.000Z",
+		},
+		created_by: {
+			principal_id: "00000000-0000-4000-8000-000000000010",
+			kind: "owner" as const,
+		},
+	};
+}
+
+function createOutputArtifactRef(index = 0) {
+	return {
+		artifact_id: `00000000-0000-4000-8000-${String(20 + index).padStart(12, "0")}`,
+		type: "patch",
+		version: 1,
+		sha256: "b".repeat(64),
+		media_type: "text/x-diff",
+		byte_size: 128,
+	};
+}
+
+async function collect(events: AsyncIterable<HostEvent>): Promise<HostEvent[]> {
+	const collected: HostEvent[] = [];
+	for await (const event of events) {
+		collected.push(event);
+	}
+	return collected;
+}

--- a/protocol/src/adapter.ts
+++ b/protocol/src/adapter.ts
@@ -1,0 +1,763 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import {
+	MAX_ARTIFACT_BYTES,
+	type MessageType,
+	actorRefSchema,
+	artifactRefSchema,
+	contractVersionSchema,
+	messageTypeSchema,
+	missionContextSchema,
+	opaqueReferenceSchema,
+	runtimeNameSchema,
+	runtimeVersionSchema,
+	turnDispositionSchema,
+	uuidSchema,
+} from "./schemas.js";
+
+const MAX_HOST_TEXT_LENGTH = 16_000;
+const MAX_HOST_ITEMS = 64;
+const MAX_PROVIDER_TOKENS = 100_000_000;
+const MAX_JSON_DEPTH = 32;
+const MAX_JSON_NODES = 4_096;
+const workspaceAliasSchema = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/);
+const hostTextSchema = z
+	.string()
+	.min(1)
+	.max(MAX_HOST_TEXT_LENGTH)
+	.refine((value) => value.trim().length > 0, "Host text cannot be blank");
+const hostOutputChunkSchema = z.string().min(1).max(MAX_HOST_TEXT_LENGTH);
+const hostArtifactTextSchema = z.string().max(MAX_ARTIFACT_BYTES);
+
+export type JsonValue =
+	| null
+	| boolean
+	| number
+	| string
+	| JsonValue[]
+	| { [key: string]: JsonValue };
+
+export const jsonValueSchema = z.unknown().transform((value, ctx): JsonValue => {
+	try {
+		return sanitizeJsonValue(value);
+	} catch (error) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: error instanceof Error ? error.message : "Value is not bounded JSON",
+		});
+		return null;
+	}
+});
+
+export const adapterInfoSchema = z
+	.object({
+		name: runtimeNameSchema,
+		version: runtimeVersionSchema,
+		capabilities: z
+			.object({
+				cancellation: z.boolean(),
+				recovery: z.boolean(),
+				usage: z.enum(["turn_cumulative", "unavailable"]),
+			})
+			.strict(),
+	})
+	.strict();
+
+export const sessionInputSchema = z
+	.object({
+		missionId: uuidSchema,
+		participantId: uuidSchema,
+		workspaceAlias: workspaceAliasSchema,
+	})
+	.strict();
+
+export const hostSessionRefSchema = sessionInputSchema.extend({
+	sessionId: opaqueReferenceSchema,
+});
+
+export const hostMissionTextInputSchema = z
+	.object({
+		text: hostTextSchema,
+		authorPrincipalId: uuidSchema,
+		provenance: z.literal("mission_manifest"),
+	})
+	.strict();
+
+export const hostPeerMessageInputSchema = z
+	.object({
+		messageId: uuidSchema,
+		authorAgentId: uuidSchema,
+		kind: messageTypeSchema,
+		body: hostTextSchema,
+	})
+	.strict();
+
+const hostArtifactPayloadInputSchema = z.discriminatedUnion("kind", [
+	z.object({ kind: z.literal("text"), text: hostArtifactTextSchema }).strict(),
+	z
+		.object({
+			kind: z.literal("json"),
+			rawText: hostArtifactTextSchema,
+			value: z.unknown().optional(),
+		})
+		.strict(),
+]);
+
+export const hostArtifactPayloadSchema = hostArtifactPayloadInputSchema.transform(
+	(payload, ctx) => {
+		if (payload.kind === "text") {
+			return payload;
+		}
+
+		let rawValue: unknown;
+		try {
+			rawValue = JSON.parse(payload.rawText);
+		} catch {
+			ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Artifact rawText is not valid JSON" });
+			return { kind: "json" as const, rawText: payload.rawText, value: null };
+		}
+		const parsed = jsonValueSchema.safeParse(rawValue);
+		if (!parsed.success) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Artifact rawText must contain bounded JSON",
+			});
+			return { kind: "json" as const, rawText: payload.rawText, value: null };
+		}
+		if (payload.value !== undefined) {
+			const asserted = jsonValueSchema.safeParse(payload.value);
+			if (!asserted.success || canonicalJson(asserted.data) !== canonicalJson(parsed.data)) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Parsed JSON does not match the supplied typed artifact value",
+				});
+			}
+		}
+		return { kind: "json" as const, rawText: payload.rawText, value: parsed.data };
+	},
+);
+
+type SerializableHostArtifactPayload =
+	| { readonly kind: "text"; readonly text: string }
+	| { readonly kind: "json"; readonly rawText: string; readonly value: JsonValue };
+
+/** Returns the exact UTF-8 text whose bytes are identified by the artifact hash. */
+export function serializeHostArtifactPayload(payload: SerializableHostArtifactPayload): string {
+	return payload.kind === "text" ? payload.text : payload.rawText;
+}
+
+export const hostInputArtifactSchema = z
+	.object({
+		artifact: artifactRefSchema,
+		source: actorRefSchema,
+		payload: hostArtifactPayloadSchema,
+	})
+	.strict()
+	.superRefine((artifact, ctx) => {
+		const serialized = serializeHostArtifactPayload(artifact.payload);
+		const byteLength = Buffer.byteLength(serialized, "utf8");
+		const sha256 = createHash("sha256").update(serialized, "utf8").digest("hex");
+		const isJsonMediaType = hasJsonMediaType(artifact.artifact.media_type);
+		if (isJsonMediaType !== (artifact.payload.kind === "json")) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "JSON media types require a JSON payload, and vice versa",
+				path: ["payload", "kind"],
+			});
+		}
+		if (byteLength !== artifact.artifact.byte_size) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Artifact byte length does not match its UTF-8 payload",
+				path: ["artifact", "byte_size"],
+			});
+		}
+		if (sha256 !== artifact.artifact.sha256) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Artifact hash does not match its UTF-8 payload",
+				path: ["artifact", "sha256"],
+			});
+		}
+	});
+
+const turnInputObjectSchema = z
+	.object({
+		session: hostSessionRefSchema,
+		missionId: uuidSchema,
+		contractVersion: contractVersionSchema,
+		missionSequence: z.number().int().safe().positive(),
+		objective: hostMissionTextInputSchema,
+		assignment: hostMissionTextInputSchema,
+		acceptanceCriteria: z.array(hostMissionTextInputSchema).min(1).max(32),
+		peerMessages: z.array(hostPeerMessageInputSchema).max(MAX_HOST_ITEMS),
+		artifacts: z.array(hostInputArtifactSchema).max(16),
+	})
+	.strict();
+
+export const turnInputSchema = turnInputObjectSchema.refine(
+	(input) => input.missionId === input.session.missionId,
+	{
+		message: "Turn Mission must match its host session",
+		path: ["missionId"],
+	},
+);
+
+export const startTurnInputSchema = turnInputObjectSchema
+	.extend({
+		deliveryId: uuidSchema,
+	})
+	.refine((input) => input.missionId === input.session.missionId, {
+		message: "Turn Mission must match its host session",
+		path: ["missionId"],
+	});
+
+export const hostTurnRefSchema = z
+	.object({
+		turnId: opaqueReferenceSchema,
+		sessionId: opaqueReferenceSchema,
+		missionId: uuidSchema,
+		deliveryId: uuidSchema,
+		contractVersion: contractVersionSchema,
+	})
+	.strict();
+
+export const hostFailureSchema = z
+	.object({
+		class: z.enum(["transient", "permanent", "policy_denied"]),
+		message: z.string().min(1).max(4_000),
+	})
+	.strict();
+
+export const hostUsageSchema = z.discriminatedUnion("available", [
+	z
+		.object({
+			available: z.literal(true),
+			scope: z.literal("turn_cumulative"),
+			inputTokens: z.number().int().nonnegative().max(MAX_PROVIDER_TOKENS),
+			outputTokens: z.number().int().nonnegative().max(MAX_PROVIDER_TOKENS),
+		})
+		.strict(),
+	z
+		.object({
+			available: z.literal(false),
+			reason: z.enum(["unsupported", "not_reported"]),
+		})
+		.strict(),
+]);
+
+export const hostToolActivitySchema = z
+	.object({
+		toolCallId: opaqueReferenceSchema,
+		name: runtimeNameSchema,
+		phase: z.enum(["started", "completed", "failed"]),
+	})
+	.strict();
+
+export const hostPermissionActivitySchema = z
+	.object({
+		requestId: opaqueReferenceSchema,
+		capability: runtimeNameSchema,
+		phase: z.enum(["requested", "granted", "denied"]),
+	})
+	.strict();
+
+const hostEventSequenceSchema = z.number().int().safe().positive();
+
+export const hostEventSchema = z.discriminatedUnion("kind", [
+	z
+		.object({
+			kind: z.literal("accepted"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal("output"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+			text: hostOutputChunkSchema,
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal("tool"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+			activity: hostToolActivitySchema,
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal("permission"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+			activity: hostPermissionActivitySchema,
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal("artifact"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+			artifact: artifactRefSchema,
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal("usage"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+			usage: hostUsageSchema,
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal("completed"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+			disposition: turnDispositionSchema,
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal("failed"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+			failure: hostFailureSchema,
+		})
+		.strict(),
+	z
+		.object({
+			kind: z.literal("cancelled"),
+			turn: hostTurnRefSchema,
+			sequence: hostEventSequenceSchema,
+		})
+		.strict(),
+]);
+
+export interface HostMissionInputs {
+	readonly objective: HostMissionTextInput;
+	readonly assignment: HostMissionTextInput;
+	readonly acceptanceCriteria: readonly HostMissionTextInput[];
+}
+
+/** Derives host prompt text only from a relay-authenticated Mission context. */
+export function deriveHostMissionInputs(
+	contextInput: unknown,
+	participantAgentId: string,
+): HostMissionInputs {
+	const context = missionContextSchema.parse(contextInput);
+	const validatedParticipantAgentId = uuidSchema.parse(participantAgentId);
+	const participant = context.manifest.participants.find(
+		(candidate) => candidate.agent_id === validatedParticipantAgentId,
+	);
+	if (!participant) {
+		throw new Error(`Mission participant not found: ${participantAgentId}`);
+	}
+
+	const fromManifest = (text: string): HostMissionTextInput =>
+		hostMissionTextInputSchema.parse({
+			text,
+			authorPrincipalId: context.created_by.principal_id,
+			provenance: "mission_manifest",
+		});
+
+	return {
+		objective: fromManifest(context.manifest.objective),
+		assignment: fromManifest(participant.initial_assignment),
+		acceptanceCriteria: context.manifest.public_acceptance_criteria.map(fromManifest),
+	};
+}
+
+export type AdapterInfo = z.infer<typeof adapterInfoSchema>;
+export type SessionInput = z.infer<typeof sessionInputSchema>;
+export type HostSessionRef = z.infer<typeof hostSessionRefSchema>;
+export type HostMissionTextInput = z.infer<typeof hostMissionTextInputSchema>;
+export type PeerMessageKind = MessageType;
+export type HostPeerMessageInput = z.infer<typeof hostPeerMessageInputSchema>;
+export type HostArtifactPayload = z.infer<typeof hostArtifactPayloadSchema>;
+export type HostInputArtifact = z.infer<typeof hostInputArtifactSchema>;
+export type TurnInput = z.infer<typeof turnInputSchema>;
+export type StartTurnInput = z.infer<typeof startTurnInputSchema>;
+export type HostTurnRef = z.infer<typeof hostTurnRefSchema>;
+export type HostFailure = z.infer<typeof hostFailureSchema>;
+export type HostUsage = z.infer<typeof hostUsageSchema>;
+export type HostToolActivity = z.infer<typeof hostToolActivitySchema>;
+export type HostPermissionActivity = z.infer<typeof hostPermissionActivitySchema>;
+export type HostEvent = z.infer<typeof hostEventSchema>;
+export type HostTurnCorrelation = Omit<HostTurnRef, "turnId"> & { readonly turnId?: string };
+
+export interface HostEventStreamPolicy {
+	readonly maxEvents: number;
+	readonly maxOutputBytes: number;
+	readonly maxArtifacts: number;
+	readonly maxArtifactBytes: number;
+	readonly maxTokens: number;
+	readonly usage: AdapterInfo["capabilities"]["usage"];
+}
+
+export interface HostEventStreamState {
+	readonly phase: "awaiting_acceptance" | "active" | "terminal";
+	readonly lastSequence: number;
+	readonly outputBytes: number;
+	readonly artifactCount: number;
+	readonly artifactBytes: number;
+	readonly artifactKeys: readonly string[];
+	readonly usage: HostUsage | null;
+	readonly turn: HostTurnRef | null;
+	readonly expectedTurn: HostTurnCorrelation;
+}
+
+export const DEFAULT_HOST_EVENT_STREAM_POLICY: HostEventStreamPolicy = Object.freeze({
+	maxEvents: 256,
+	maxOutputBytes: 256 * 1_024,
+	maxArtifacts: 16,
+	maxArtifactBytes: 16 * MAX_ARTIFACT_BYTES,
+	maxTokens: MAX_PROVIDER_TOKENS,
+	usage: "turn_cumulative",
+});
+
+export class InvalidHostEventStreamError extends Error {
+	constructor(
+		readonly reason:
+			| "sequence"
+			| "acceptance"
+			| "terminal"
+			| "event_limit"
+			| "output_limit"
+			| "artifact_limit"
+			| "usage_regression"
+			| "usage_unavailable"
+			| "usage_limit"
+			| "usage_missing"
+			| "turn_mismatch",
+	) {
+		super(`Invalid host event stream: ${reason}`);
+		this.name = "InvalidHostEventStreamError";
+	}
+}
+
+export function createHostEventStreamState(
+	expectedTurn: HostTurnCorrelation,
+): HostEventStreamState {
+	return {
+		phase: "awaiting_acceptance",
+		lastSequence: 0,
+		outputBytes: 0,
+		artifactCount: 0,
+		artifactBytes: 0,
+		artifactKeys: [],
+		usage: null,
+		turn: null,
+		expectedTurn: structuredClone(expectedTurn),
+	};
+}
+
+/** Validates one replayable host event and returns its normalized event plus next stream state. */
+export function acceptHostEvent(
+	current: HostEventStreamState,
+	eventInput: unknown,
+	policy: HostEventStreamPolicy = DEFAULT_HOST_EVENT_STREAM_POLICY,
+): { readonly event: HostEvent; readonly state: HostEventStreamState } {
+	assertHostEventStreamPolicy(policy);
+	const event = hostEventSchema.parse(eventInput);
+	if (event.sequence !== current.lastSequence + 1) {
+		throw new InvalidHostEventStreamError("sequence");
+	}
+	if (
+		(current.phase === "awaiting_acceptance" && event.kind !== "accepted") ||
+		(current.phase !== "awaiting_acceptance" && event.kind === "accepted")
+	) {
+		throw new InvalidHostEventStreamError("acceptance");
+	}
+	if (
+		current.phase === "awaiting_acceptance" &&
+		event.kind === "accepted" &&
+		!matchesExpectedHostTurn(current.expectedTurn, event.turn)
+	) {
+		throw new InvalidHostEventStreamError("turn_mismatch");
+	}
+	if (current.phase === "terminal") {
+		throw new InvalidHostEventStreamError("terminal");
+	}
+	if (
+		current.phase !== "awaiting_acceptance" &&
+		(current.turn === null || !sameHostTurnRef(current.turn, event.turn))
+	) {
+		throw new InvalidHostEventStreamError("turn_mismatch");
+	}
+	if (event.sequence > policy.maxEvents) {
+		throw new InvalidHostEventStreamError("event_limit");
+	}
+
+	const outputBytes = current.outputBytes + textBytesInHostEvent(event);
+	if (outputBytes > policy.maxOutputBytes) {
+		throw new InvalidHostEventStreamError("output_limit");
+	}
+
+	const artifacts = artifactsInHostEvent(event);
+	const artifactKeys = [...current.artifactKeys];
+	let artifactBytes = current.artifactBytes;
+	for (const artifact of artifacts) {
+		const key = JSON.stringify([
+			artifact.artifact_id,
+			artifact.type,
+			artifact.version,
+			artifact.sha256,
+			artifact.media_type,
+			artifact.byte_size,
+		]);
+		if (!artifactKeys.includes(key)) {
+			artifactKeys.push(key);
+			artifactBytes += artifact.byte_size;
+		}
+	}
+	const artifactCount = artifactKeys.length;
+	if (artifactCount > policy.maxArtifacts || artifactBytes > policy.maxArtifactBytes) {
+		throw new InvalidHostEventStreamError("artifact_limit");
+	}
+
+	let usage = current.usage === null ? null : structuredClone(current.usage);
+	if (event.kind === "usage") {
+		if (event.usage.available && policy.usage === "unavailable") {
+			throw new InvalidHostEventStreamError("usage_unavailable");
+		}
+		if (
+			event.usage.available &&
+			event.usage.inputTokens + event.usage.outputTokens > policy.maxTokens
+		) {
+			throw new InvalidHostEventStreamError("usage_limit");
+		}
+		if (
+			usage?.available &&
+			(!event.usage.available ||
+				event.usage.inputTokens < usage.inputTokens ||
+				event.usage.outputTokens < usage.outputTokens)
+		) {
+			throw new InvalidHostEventStreamError("usage_regression");
+		}
+		usage = structuredClone(event.usage);
+	}
+
+	const terminal =
+		event.kind === "completed" || event.kind === "failed" || event.kind === "cancelled";
+	if (terminal && usage === null) {
+		throw new InvalidHostEventStreamError("usage_missing");
+	}
+	return {
+		event,
+		state: {
+			phase: terminal ? "terminal" : "active",
+			lastSequence: event.sequence,
+			outputBytes,
+			artifactCount,
+			artifactBytes,
+			artifactKeys,
+			usage,
+			turn: current.turn === null ? structuredClone(event.turn) : structuredClone(current.turn),
+			expectedTurn: structuredClone(current.expectedTurn),
+		},
+	};
+}
+
+export interface AgentHostAdapter {
+	probe(): Promise<AdapterInfo>;
+	ensureSession(input: SessionInput): Promise<HostSessionRef>;
+	lookupTurn(deliveryId: string): Promise<HostTurnRef | null>;
+	startTurn(input: StartTurnInput): AsyncIterable<HostEvent>;
+	recoverTurn(ref: HostTurnRef): AsyncIterable<HostEvent>;
+	cancelTurn(ref: HostTurnRef): Promise<void>;
+}
+
+function canonicalJson(value: JsonValue): string {
+	if (value === null || typeof value !== "object") {
+		return JSON.stringify(value) as string;
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(canonicalJson).join(",")}]`;
+	}
+	return `{${Object.keys(value)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key]!)}`)
+		.join(",")}}`;
+}
+
+function hasJsonMediaType(mediaType: string): boolean {
+	const essence = mediaType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+	return essence === "application/json" || /^application\/[^/;]+\+json$/.test(essence);
+}
+
+function artifactsInHostEvent(event: HostEvent) {
+	if (event.kind === "artifact") {
+		return [event.artifact];
+	}
+	if (event.kind !== "completed") {
+		return [];
+	}
+	if (event.disposition.kind === "reply") {
+		return event.disposition.artifacts ?? [];
+	}
+	if (event.disposition.kind === "propose_contract") {
+		return [event.disposition.artifact];
+	}
+	if (event.disposition.kind === "ready") {
+		return event.disposition.evidence.flatMap((evidence) => evidence.artifacts);
+	}
+	return [];
+}
+
+function textBytesInHostEvent(event: HostEvent): number {
+	if (event.kind === "output") {
+		return Buffer.byteLength(event.text, "utf8");
+	}
+	if (event.kind === "failed") {
+		return Buffer.byteLength(event.failure.message, "utf8");
+	}
+	if (event.kind !== "completed") {
+		return 0;
+	}
+	const disposition = event.disposition;
+	if (disposition.kind === "reply") {
+		return Buffer.byteLength(disposition.message, "utf8");
+	}
+	if (disposition.kind === "blocked") {
+		return Buffer.byteLength(
+			disposition.requested_input === undefined
+				? disposition.reason
+				: `${disposition.reason}${disposition.requested_input}`,
+			"utf8",
+		);
+	}
+	if (disposition.kind === "ready") {
+		return disposition.evidence.reduce(
+			(total, evidence) => total + Buffer.byteLength(evidence.summary, "utf8"),
+			0,
+		);
+	}
+	return 0;
+}
+
+function assertHostEventStreamPolicy(policy: HostEventStreamPolicy): void {
+	for (const value of [
+		policy.maxEvents,
+		policy.maxOutputBytes,
+		policy.maxArtifacts,
+		policy.maxArtifactBytes,
+		policy.maxTokens,
+	]) {
+		if (!Number.isSafeInteger(value) || value <= 0) {
+			throw new Error("Host event stream limits must be positive safe integers");
+		}
+	}
+}
+
+function sameHostTurnRef(left: HostTurnRef, right: HostTurnRef): boolean {
+	return (
+		left.turnId === right.turnId &&
+		left.sessionId === right.sessionId &&
+		left.missionId === right.missionId &&
+		left.deliveryId === right.deliveryId &&
+		left.contractVersion === right.contractVersion
+	);
+}
+
+function matchesExpectedHostTurn(expected: HostTurnCorrelation, received: HostTurnRef): boolean {
+	return (
+		(expected.turnId === undefined || expected.turnId === received.turnId) &&
+		expected.sessionId === received.sessionId &&
+		expected.missionId === received.missionId &&
+		expected.deliveryId === received.deliveryId &&
+		expected.contractVersion === received.contractVersion
+	);
+}
+
+function sanitizeJsonValue(value: unknown): JsonValue {
+	const seen = new WeakSet<object>();
+	let nodes = 0;
+
+	const visit = (item: unknown, depth: number): JsonValue => {
+		nodes += 1;
+		if (nodes > MAX_JSON_NODES) {
+			throw new Error("JSON value has too many nodes");
+		}
+		if (depth > MAX_JSON_DEPTH) {
+			throw new Error("JSON value is nested too deeply");
+		}
+
+		if (item === null || typeof item === "boolean") {
+			return item;
+		}
+		if (typeof item === "number") {
+			if (!Number.isFinite(item)) {
+				throw new Error("JSON numbers must be finite");
+			}
+			return item;
+		}
+		if (typeof item === "string") {
+			if (item.length > MAX_HOST_TEXT_LENGTH) {
+				throw new Error("JSON string is too long");
+			}
+			return item;
+		}
+		if (typeof item !== "object") {
+			throw new Error("Value is not JSON-compatible");
+		}
+		if (seen.has(item)) {
+			throw new Error("JSON value cannot be cyclic or aliased");
+		}
+		seen.add(item);
+
+		if (Array.isArray(item)) {
+			const descriptors = Object.getOwnPropertyDescriptors(item);
+			const length = Object.getOwnPropertyDescriptor(item, "length")?.value;
+			if (!Number.isSafeInteger(length) || length < 0 || length > MAX_HOST_ITEMS) {
+				throw new Error("JSON array has too many items");
+			}
+			const output: JsonValue[] = [];
+			for (let index = 0; index < length; index += 1) {
+				const descriptor = descriptors[String(index)];
+				if (!descriptor || !("value" in descriptor)) {
+					throw new Error("JSON arrays cannot contain holes or accessors");
+				}
+				output.push(visit(descriptor.value, depth + 1));
+			}
+			return output;
+		}
+
+		const prototype = Object.getPrototypeOf(item);
+		if (prototype !== Object.prototype && prototype !== null) {
+			throw new Error("JSON objects must be plain objects");
+		}
+		const descriptors = Object.getOwnPropertyDescriptors(item);
+		const keys = Object.keys(descriptors).filter((key) => descriptors[key]?.enumerable);
+		if (keys.length > MAX_HOST_ITEMS) {
+			throw new Error("JSON object has too many keys");
+		}
+		const output: { [key: string]: JsonValue } = {};
+		for (const key of keys) {
+			if (key.length > 256) {
+				throw new Error("JSON object key is too long");
+			}
+			const descriptor = descriptors[key];
+			if (!descriptor || !("value" in descriptor)) {
+				throw new Error("JSON objects cannot contain enumerable accessors");
+			}
+			Object.defineProperty(output, key, {
+				value: visit(descriptor.value, depth + 1),
+				enumerable: true,
+				writable: true,
+				configurable: true,
+			});
+		}
+		return output;
+	};
+
+	return visit(value, 0);
+}

--- a/protocol/src/index.ts
+++ b/protocol/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./adapter.js";
+export * from "./schemas.js";
+export * from "./state-machines.js";

--- a/protocol/src/schemas.test.ts
+++ b/protocol/src/schemas.test.ts
@@ -1,0 +1,613 @@
+import { describe, expect, it } from "vitest";
+import {
+	actorRefSchema,
+	artifactRefSchema,
+	contractRevisionSchema,
+	deliverySchema,
+	messageSchema,
+	missionContextSchema,
+	missionManifestSchema,
+	policyRequestSchema,
+	runSchema,
+	turnDispositionSchema,
+	verificationEvidenceSchema,
+} from "./schemas.js";
+
+const ids = {
+	mission: "00000000-0000-4000-8000-000000000001",
+	backendAgent: "00000000-0000-4000-8000-000000000002",
+	clientAgent: "00000000-0000-4000-8000-000000000003",
+	artifact: "00000000-0000-4000-8000-000000000004",
+	message: "00000000-0000-4000-8000-000000000005",
+	verification: "00000000-0000-4000-8000-000000000006",
+	node: "00000000-0000-4000-8000-000000000007",
+	event: "00000000-0000-4000-8000-000000000008",
+	delivery: "00000000-0000-4000-8000-000000000009",
+	lease: "00000000-0000-4000-8000-000000000010",
+	run: "00000000-0000-4000-8000-000000000011",
+	revision: "00000000-0000-4000-8000-000000000012",
+} as const;
+
+const artifact = {
+	artifact_id: ids.artifact,
+	type: "api_contract",
+	version: 1,
+	sha256: "a".repeat(64),
+	media_type: "application/json",
+	byte_size: 1_024,
+};
+
+const evidence = {
+	verification_id: ids.verification,
+	command_id: "contract-test",
+	outcome: "passed" as const,
+	exit_code: 0,
+	duration_ms: 1_200,
+	summary: "Contract fixture passed.",
+	output_sha256: "b".repeat(64),
+	artifacts: [],
+	recorded_at: "2026-08-02T10:05:00.000Z",
+};
+
+const manifest = {
+	schema_version: 1 as const,
+	mission_id: ids.mission,
+	objective: "Ship compatible backend and Android changes.",
+	public_acceptance_criteria: [
+		"Backend contract tests pass.",
+		"Android consumes the accepted contract.",
+	],
+	participants: [
+		{
+			agent_id: ids.backendAgent,
+			role: "backend",
+			workspace_alias: "backend-api",
+			repository_url: "https://github.com/acme/backend.git",
+			expected_base_commit: "1".repeat(40),
+			initial_assignment: "Implement the API and publish contract evidence.",
+			requested_local_policy_profile: "coding",
+		},
+		{
+			agent_id: ids.clientAgent,
+			role: "android",
+			workspace_alias: "android-app",
+			repository_url: "ssh://git@github.com/acme/android.git",
+			expected_base_commit: "2".repeat(40),
+			initial_assignment: "Consume the API contract and verify the user flow.",
+			requested_local_policy_profile: "coding",
+		},
+	],
+	shared_contract: artifact,
+	max_turns: 20,
+	max_wall_time_seconds: 7_200,
+	token_budget: 200_000,
+	expires_at: "2026-08-02T12:00:00.000Z",
+	allowed_artifact_types: ["api_contract", "patch", "verification_report"],
+	created_at: "2026-08-02T10:00:00.000Z",
+};
+
+function clone<T>(value: T): T {
+	return structuredClone(value);
+}
+
+describe("missionManifestSchema", () => {
+	it("accepts a bounded two-participant version-1 Mission", () => {
+		expect(missionManifestSchema.parse(manifest)).toEqual(manifest);
+	});
+
+	it("rejects any participant count other than two", () => {
+		const oneParticipant = clone(manifest);
+		oneParticipant.participants = [oneParticipant.participants[0]];
+
+		const threeParticipants = clone(manifest);
+		threeParticipants.participants.push({
+			...threeParticipants.participants[1],
+			agent_id: "00000000-0000-4000-8000-000000000099",
+		});
+
+		expect(missionManifestSchema.safeParse(oneParticipant).success).toBe(false);
+		expect(missionManifestSchema.safeParse(threeParticipants).success).toBe(false);
+	});
+
+	it("rejects duplicate logical agents", () => {
+		const duplicate = clone(manifest);
+		duplicate.participants[1].agent_id = duplicate.participants[0].agent_id;
+
+		expect(missionManifestSchema.safeParse(duplicate).success).toBe(false);
+	});
+
+	it("rejects local repository paths and credential-bearing URLs", () => {
+		const localPath = clone(manifest);
+		localPath.participants[0].repository_url = "file:///Users/alice/backend";
+		const credentialUrl = clone(manifest);
+		credentialUrl.participants[0].repository_url =
+			"https://secret-token@github.com/acme/backend.git";
+		const credentialSshUrl = clone(manifest);
+		credentialSshUrl.participants[0].repository_url =
+			"ssh://secret-token@github.com/acme/backend.git";
+
+		expect(missionManifestSchema.safeParse(localPath).success).toBe(false);
+		expect(missionManifestSchema.safeParse(credentialUrl).success).toBe(false);
+		expect(missionManifestSchema.safeParse(credentialSshUrl).success).toBe(false);
+	});
+
+	it("rejects repository URLs that WHATWG parsing would silently normalize", () => {
+		for (const repositoryUrl of [
+			"https://github.com/acme/re\npo.git",
+			"https://github.com/acme/repo.git\t",
+			"https://github.com/acme/repo.git ",
+			"https://github.com\\evil/repo.git",
+		]) {
+			const candidate = clone(manifest);
+			candidate.participants[0].repository_url = repositoryUrl;
+			expect(missionManifestSchema.safeParse(candidate).success).toBe(false);
+		}
+	});
+
+	it("rejects local authority fields and executable command strings", () => {
+		const withLocalAuthority = {
+			...manifest,
+			participants: manifest.participants.map((participant, index) =>
+				index === 0
+					? {
+							...participant,
+							working_directory: "/Users/alice/backend",
+							verification_command: "pnpm test && git push",
+						}
+					: participant,
+			),
+		};
+
+		expect(missionManifestSchema.safeParse(withLocalAuthority).success).toBe(false);
+	});
+
+	it("keeps the requested policy limited to a local profile name", () => {
+		expect(policyRequestSchema.parse({ profile_name: "coding" })).toEqual({
+			profile_name: "coding",
+		});
+		expect(
+			policyRequestSchema.safeParse({
+				profile_name: "coding",
+				working_directory: "/Users/alice/backend",
+				allowed_command: "git push origin main",
+			}).success,
+		).toBe(false);
+	});
+
+	it("requires contract version 1 and an allowed contract type", () => {
+		const laterContract = clone(manifest);
+		laterContract.shared_contract.version = 2;
+		const disallowedContract = clone(manifest);
+		disallowedContract.allowed_artifact_types = ["patch"];
+
+		expect(missionManifestSchema.safeParse(laterContract).success).toBe(false);
+		expect(missionManifestSchema.safeParse(disallowedContract).success).toBe(false);
+	});
+
+	it("rejects duplicate criteria, expired creation, and oversized peer text", () => {
+		const duplicateCriteria = clone(manifest);
+		duplicateCriteria.public_acceptance_criteria = ["Tests pass.", "Tests pass."];
+		const expired = clone(manifest);
+		expired.expires_at = expired.created_at;
+		const oversized = clone(manifest);
+		oversized.objective = "x".repeat(16_001);
+
+		expect(missionManifestSchema.safeParse(duplicateCriteria).success).toBe(false);
+		expect(missionManifestSchema.safeParse(expired).success).toBe(false);
+		expect(missionManifestSchema.safeParse(oversized).success).toBe(false);
+	});
+});
+
+describe("missionContextSchema", () => {
+	it("carries the authenticated creator separately from peer-supplied Mission text", () => {
+		const context = {
+			manifest,
+			created_by: { principal_id: ids.backendAgent, kind: "owner" as const },
+		};
+		expect(missionContextSchema.parse(context)).toEqual(context);
+		expect(actorRefSchema.safeParse({ ...context.created_by, kind: "unknown" }).success).toBe(
+			false,
+		);
+	});
+});
+
+describe("message and artifact schemas", () => {
+	it("accepts a bounded message with artifact references", () => {
+		const message = {
+			message_id: ids.message,
+			mission_id: ids.mission,
+			sequence_no: 1,
+			author_agent_id: ids.backendAgent,
+			type: "proposal",
+			body: "The contract artifact is ready for review.",
+			artifacts: [artifact],
+			contract_version: 1,
+			idempotency_key: "message:backend:1",
+			causal_parent_message_id: null,
+			created_at: "2026-08-02T10:02:00.000Z",
+		};
+
+		expect(messageSchema.parse(message)).toEqual(message);
+	});
+
+	it("does not allow artifacts to carry paths, URLs, or inline payloads", () => {
+		expect(
+			artifactRefSchema.safeParse({
+				...artifact,
+				local_path: "/Users/alice/backend/openapi.json",
+				url: "https://files.example/contract",
+				content: "unbounded inline content",
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects duplicate artifact references and malformed timestamps", () => {
+		const duplicateArtifacts = {
+			message_id: ids.message,
+			mission_id: ids.mission,
+			sequence_no: 1,
+			author_agent_id: ids.backendAgent,
+			type: "proposal",
+			body: "Duplicate references.",
+			artifacts: [artifact, artifact],
+			contract_version: 1,
+			idempotency_key: "message:backend:2",
+			causal_parent_message_id: null,
+			created_at: "tomorrow",
+		};
+
+		expect(messageSchema.safeParse(duplicateArtifacts).success).toBe(false);
+	});
+
+	it("rejects unknown message types", () => {
+		expect(
+			messageSchema.safeParse({
+				message_id: ids.message,
+				mission_id: ids.mission,
+				sequence_no: 1,
+				author_agent_id: ids.backendAgent,
+				type: "free_form_chat",
+				body: "Unclassified message.",
+				artifacts: [],
+				contract_version: 1,
+				idempotency_key: "message:backend:3",
+				causal_parent_message_id: null,
+				created_at: "2026-08-02T10:02:00.000Z",
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects sequence numbers that JSON cannot represent safely", () => {
+		expect(
+			messageSchema.safeParse({
+				message_id: ids.message,
+				mission_id: ids.mission,
+				sequence_no: Number.MAX_SAFE_INTEGER + 1,
+				author_agent_id: ids.backendAgent,
+				type: "progress",
+				body: "Unsafe sequence number.",
+				artifacts: [],
+				contract_version: 1,
+				idempotency_key: "message:backend:4",
+				causal_parent_message_id: null,
+				created_at: "2026-08-02T10:02:00.000Z",
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe("contractRevisionSchema", () => {
+	it("represents a consecutive contract revision and participant acknowledgements", () => {
+		const revision = {
+			revision_id: ids.revision,
+			mission_id: ids.mission,
+			previous_version: 1,
+			version: 2,
+			artifact: { ...artifact, version: 2, sha256: "c".repeat(64) },
+			proposed_by_agent_id: ids.backendAgent,
+			acknowledged_by_agent_ids: [ids.backendAgent, ids.clientAgent],
+			idempotency_key: "contract-revision:2",
+			created_at: "2026-08-02T10:03:00.000Z",
+		};
+
+		expect(contractRevisionSchema.parse(revision)).toEqual(revision);
+		expect(contractRevisionSchema.safeParse({ ...revision, version: 3 }).success).toBe(false);
+		expect(
+			contractRevisionSchema.safeParse({
+				...revision,
+				acknowledged_by_agent_ids: [ids.backendAgent, ids.backendAgent],
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe("turnDispositionSchema", () => {
+	it("accepts every bounded RFC disposition shape", () => {
+		expect(
+			turnDispositionSchema.safeParse({
+				kind: "reply",
+				message_type: "answer",
+				message: "Please use v1.",
+				artifacts: [],
+			}).success,
+		).toBe(true);
+		expect(turnDispositionSchema.safeParse({ kind: "propose_contract", artifact }).success).toBe(
+			true,
+		);
+		expect(turnDispositionSchema.safeParse({ kind: "ready", evidence: [evidence] }).success).toBe(
+			true,
+		);
+		expect(
+			turnDispositionSchema.safeParse({
+				kind: "blocked",
+				reason: "Contract decision required.",
+				requested_input: "Choose nullable or required.",
+			}).success,
+		).toBe(true);
+		expect(turnDispositionSchema.safeParse({ kind: "failed", class: "transient" }).success).toBe(
+			true,
+		);
+	});
+
+	it("rejects lifecycle mutation and executable command fields", () => {
+		expect(
+			turnDispositionSchema.safeParse({
+				kind: "reply",
+				message_type: "progress",
+				message: "I changed the Mission directly.",
+				mission_status: "completed",
+				command: "git push origin main",
+			}).success,
+		).toBe(false);
+	});
+
+	it("allows readiness before the coordinator schedules verification", () => {
+		expect(turnDispositionSchema.safeParse({ kind: "ready", evidence: [] }).success).toBe(true);
+	});
+});
+
+describe("verificationEvidenceSchema", () => {
+	it("accepts command-ID based evidence without raw output", () => {
+		expect(verificationEvidenceSchema.parse(evidence)).toEqual(evidence);
+	});
+
+	it("rejects shell command strings and inconsistent results", () => {
+		expect(
+			verificationEvidenceSchema.safeParse({
+				...evidence,
+				command: "pnpm test && curl https://example.com",
+			}).success,
+		).toBe(false);
+		expect(
+			verificationEvidenceSchema.safeParse({ ...evidence, outcome: "failed", exit_code: 0 })
+				.success,
+		).toBe(false);
+	});
+});
+
+describe("deliverySchema", () => {
+	const leasedDelivery = {
+		delivery_id: ids.delivery,
+		node_id: ids.node,
+		mission_id: ids.mission,
+		mission_event_id: ids.event,
+		kind: "turn" as const,
+		cursor: "1",
+		status: "leased" as const,
+		attempt_count: 1,
+		max_attempts: 3,
+		last_fencing_token: "1",
+		contract_version: 1,
+		lease: {
+			lease_id: ids.lease,
+			fencing_token: "1",
+			expires_at: "2026-08-02T10:06:00.000Z",
+		},
+		idempotency_key: "delivery:1",
+		causal_parent_delivery_id: null,
+		available_at: "2026-08-02T10:03:00.000Z",
+		created_at: "2026-08-02T10:03:00.000Z",
+		updated_at: "2026-08-02T10:04:00.000Z",
+		acknowledged_at: null,
+		dead_lettered_at: null,
+	};
+
+	it("accepts a leased durable delivery", () => {
+		expect(deliverySchema.parse(leasedDelivery)).toEqual(leasedDelivery);
+	});
+
+	it("requires active leases and matching terminal timestamps", () => {
+		expect(deliverySchema.safeParse({ ...leasedDelivery, lease: null }).success).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				lease: { ...leasedDelivery.lease, fencing_token: "0" },
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				status: "acknowledged",
+				lease: null,
+				available_at: "2026-08-02T10:03:30.000Z",
+				acknowledged_at: "2026-08-02T10:03:00.000Z",
+			}).success,
+		).toBe(false);
+		expect(deliverySchema.safeParse({ ...leasedDelivery, attempt_count: 0 }).success).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				status: "stored",
+				attempt_count: 0,
+				last_fencing_token: "1",
+				lease: null,
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				lease: { ...leasedDelivery.lease, fencing_token: "2" },
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				attempt_count: 4,
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				status: "acknowledged",
+				lease: null,
+				acknowledged_at: null,
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				status: "acknowledged",
+				attempt_count: 0,
+				last_fencing_token: "0",
+				lease: null,
+				acknowledged_at: leasedDelivery.updated_at,
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				status: "stored",
+				attempt_count: 3,
+				lease: null,
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects local paths and unexpected work payloads", () => {
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				local_path: "/Users/alice/backend",
+				shell_command: "pnpm test",
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				lease: {
+					...leasedDelivery.lease,
+					expires_at: leasedDelivery.updated_at,
+				},
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects impossible delivery chronology", () => {
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				updated_at: "2026-08-02T10:02:59.000Z",
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				status: "acknowledged",
+				lease: null,
+				available_at: "2026-08-02T10:05:00.000Z",
+				acknowledged_at: leasedDelivery.updated_at,
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				available_at: "2026-08-02T10:02:59.000Z",
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				lease: {
+					...leasedDelivery.lease,
+					expires_at: "2026-08-02T10:02:59.000Z",
+				},
+			}).success,
+		).toBe(false);
+		expect(
+			deliverySchema.safeParse({
+				...leasedDelivery,
+				status: "acknowledged",
+				lease: null,
+				acknowledged_at: "2026-08-02T10:05:00.000Z",
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe("runSchema", () => {
+	const completedRun = {
+		run_id: ids.run,
+		mission_id: ids.mission,
+		participant_agent_id: ids.backendAgent,
+		node_id: ids.node,
+		delivery_id: ids.delivery,
+		lease_id: ids.lease,
+		fencing_token: "1",
+		contract_version: 1,
+		runtime: { name: "openai/codex-app-server", version: "preview/0.146.0" },
+		turn_ref: "thread/123",
+		status: "completed" as const,
+		usage: { available: true as const, input_tokens: 1_500, output_tokens: 300 },
+		disposition: { kind: "ready" as const, evidence: [evidence] },
+		artifact_hashes: [artifact.sha256],
+		verification_evidence: [evidence],
+		started_at: "2026-08-02T10:04:00.000Z",
+		completed_at: "2026-08-02T10:05:00.000Z",
+	};
+
+	it("accepts relay-visible execution evidence", () => {
+		expect(runSchema.parse(completedRun)).toEqual(completedRun);
+		expect(
+			runSchema.safeParse({
+				...completedRun,
+				usage: { available: false, reason: "unsupported" },
+			}).success,
+		).toBe(true);
+	});
+
+	it("rejects local recovery metadata, raw output, and missing completion state", () => {
+		expect(
+			runSchema.safeParse({
+				...completedRun,
+				checkout_path: "/Users/alice/backend",
+				raw_tool_output: "secret output",
+			}).success,
+		).toBe(false);
+		expect(runSchema.safeParse({ ...completedRun, completed_at: null }).success).toBe(false);
+		expect(
+			runSchema.safeParse({
+				...completedRun,
+				status: "running",
+				completed_at: null,
+			}).success,
+		).toBe(false);
+		expect(
+			runSchema.safeParse({
+				...completedRun,
+				disposition: { kind: "failed", class: "permanent" },
+			}).success,
+		).toBe(false);
+		expect(
+			runSchema.safeParse({
+				...completedRun,
+				status: "cancelled",
+			}).success,
+		).toBe(false);
+		expect(
+			runSchema.safeParse({
+				...completedRun,
+				completed_at: "2026-08-02T10:03:00.000Z",
+			}).success,
+		).toBe(false);
+	});
+});

--- a/protocol/src/schemas.ts
+++ b/protocol/src/schemas.ts
@@ -1,0 +1,690 @@
+import { z } from "zod";
+
+const MAX_TEXT_LENGTH = 16_000;
+const MAX_ACCEPTANCE_CRITERIA = 32;
+const MAX_ARTIFACTS = 16;
+const MAX_ARTIFACT_TYPES = 16;
+const MAX_VERIFICATION_EVIDENCE = 16;
+export const MAX_ARTIFACT_BYTES = 1_048_576;
+const MAX_TURNS = 200;
+const MAX_WALL_TIME_SECONDS = 7 * 24 * 60 * 60;
+const MAX_TOKEN_BUDGET = 100_000_000;
+
+const boundedTextSchema = z
+	.string()
+	.min(1)
+	.max(MAX_TEXT_LENGTH)
+	.refine((value) => value.trim().length > 0, "Text cannot be blank");
+const acceptanceCriterionSchema = z
+	.string()
+	.min(1)
+	.max(2_000)
+	.refine((value) => value.trim().length > 0, "Acceptance criterion cannot be blank");
+const identifierSchema = z
+	.string()
+	.min(1)
+	.max(128)
+	.regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/);
+const aliasSchema = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/)
+	.refine((value) => value !== "." && value !== "..", "Alias cannot be a path segment");
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const baseCommitSchema = z.string().regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/);
+function boundedOpaqueReferenceSchema(maxLength: number) {
+	return z
+		.string()
+		.min(1)
+		.max(maxLength)
+		.refine(
+			(value) =>
+				[...value].every((character) => {
+					const code = character.charCodeAt(0);
+					return code > 0x1f && code !== 0x7f;
+				}),
+			"Reference cannot contain control characters",
+		);
+}
+
+export const opaqueReferenceSchema = boundedOpaqueReferenceSchema(256);
+const fencingTokenSchema = z
+	.string()
+	.regex(/^(?:0|[1-9][0-9]*)$/)
+	.max(64);
+export const uuidSchema = z.string().uuid();
+export const contractVersionSchema = z.number().int().positive().max(1_000_000);
+
+function hasUniqueValues(values: string[]): boolean {
+	return new Set(values).size === values.length;
+}
+
+export const isoTimestampSchema = z.string().datetime({ offset: true });
+
+export const missionStatusSchema = z.enum([
+	"awaiting_acceptance",
+	"active",
+	"verifying",
+	"blocked",
+	"completed",
+	"cancelled",
+	"expired",
+	"failed",
+]);
+
+export const deliveryStatusSchema = z.enum([
+	"stored",
+	"leased",
+	"executing",
+	"acknowledged",
+	"dead_lettered",
+]);
+
+export const runStatusSchema = z.enum(["running", "completed", "failed", "cancelled"]);
+
+export const artifactTypeSchema = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[a-z][a-z0-9._-]*$/);
+
+export const messageTypeSchema = z.enum([
+	"question",
+	"answer",
+	"proposal",
+	"decision",
+	"progress",
+	"blocker",
+]);
+
+export const policyProfileNameSchema = aliasSchema;
+
+export const policyRequestSchema = z
+	.object({
+		profile_name: policyProfileNameSchema,
+	})
+	.strict();
+
+export const actorRefSchema = z
+	.object({
+		principal_id: uuidSchema,
+		kind: z.enum(["owner", "agent"]),
+	})
+	.strict();
+
+export const repositoryUrlSchema = z
+	.string()
+	.max(2_048)
+	.url()
+	.superRefine((value, ctx) => {
+		if (
+			[...value].some((character) => {
+				const code = character.charCodeAt(0);
+				return code <= 0x20 || code === 0x7f || character === "\\";
+			})
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Repository URL must not contain whitespace, controls, or backslashes",
+			});
+			return;
+		}
+
+		const protocolMatch = /^(https|ssh):\/\//.exec(value);
+		if (!protocolMatch) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Repository URL must use https or ssh",
+			});
+			return;
+		}
+
+		const protocol = protocolMatch[1];
+		const authority = value.slice(protocolMatch[0].length).split("/", 1)[0] ?? "";
+		const atIndex = authority.lastIndexOf("@");
+		const userInfo = atIndex >= 0 ? authority.slice(0, atIndex) : "";
+		if ((protocol === "https" && userInfo) || (protocol === "ssh" && userInfo !== "git")) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Repository URL must not contain credentials",
+			});
+		}
+		if (value.includes("?") || value.includes("#")) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Repository URL must not contain query parameters or fragments",
+			});
+		}
+	});
+
+export const participantSchema = z
+	.object({
+		agent_id: uuidSchema,
+		role: aliasSchema,
+		workspace_alias: aliasSchema,
+		repository_url: repositoryUrlSchema,
+		expected_base_commit: baseCommitSchema,
+		initial_assignment: boundedTextSchema,
+		requested_local_policy_profile: policyProfileNameSchema,
+	})
+	.strict();
+
+export const artifactRefSchema = z
+	.object({
+		artifact_id: uuidSchema,
+		type: artifactTypeSchema,
+		version: contractVersionSchema,
+		sha256: sha256Schema,
+		media_type: z.string().min(1).max(128),
+		byte_size: z.number().int().nonnegative().max(MAX_ARTIFACT_BYTES),
+	})
+	.strict();
+
+export const sharedContractArtifactSchema = artifactRefSchema.extend({
+	version: z.literal(1),
+});
+
+export const contractRevisionSchema = z
+	.object({
+		revision_id: uuidSchema,
+		mission_id: uuidSchema,
+		previous_version: z.number().int().positive().max(999_999),
+		version: contractVersionSchema.min(2),
+		artifact: artifactRefSchema,
+		proposed_by_agent_id: uuidSchema,
+		acknowledged_by_agent_ids: z.array(uuidSchema).max(2),
+		idempotency_key: identifierSchema,
+		created_at: isoTimestampSchema,
+	})
+	.strict()
+	.superRefine((revision, ctx) => {
+		if (revision.version !== revision.previous_version + 1) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Contract revision versions must be consecutive",
+				path: ["version"],
+			});
+		}
+		if (revision.artifact.version !== revision.version) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Contract artifact version must match revision version",
+				path: ["artifact", "version"],
+			});
+		}
+		if (!hasUniqueValues(revision.acknowledged_by_agent_ids)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Contract acknowledgements must be unique",
+				path: ["acknowledged_by_agent_ids"],
+			});
+		}
+	});
+
+export const messageSchema = z
+	.object({
+		message_id: uuidSchema,
+		mission_id: uuidSchema,
+		sequence_no: z.number().int().safe().positive(),
+		author_agent_id: uuidSchema,
+		type: messageTypeSchema,
+		body: boundedTextSchema,
+		artifacts: z.array(artifactRefSchema).max(MAX_ARTIFACTS),
+		contract_version: contractVersionSchema,
+		idempotency_key: identifierSchema,
+		causal_parent_message_id: uuidSchema.nullable(),
+		created_at: isoTimestampSchema,
+	})
+	.strict()
+	.refine((message) => hasUniqueValues(message.artifacts.map((artifact) => artifact.artifact_id)), {
+		message: "Message artifact IDs must be unique",
+		path: ["artifacts"],
+	});
+
+export const verificationEvidenceSchema = z
+	.object({
+		verification_id: uuidSchema,
+		command_id: aliasSchema,
+		outcome: z.enum(["passed", "failed"]),
+		exit_code: z.number().int().min(0).max(255),
+		duration_ms: z
+			.number()
+			.int()
+			.nonnegative()
+			.max(MAX_WALL_TIME_SECONDS * 1_000),
+		summary: boundedTextSchema,
+		output_sha256: sha256Schema,
+		artifacts: z.array(artifactRefSchema).max(MAX_ARTIFACTS),
+		recorded_at: isoTimestampSchema,
+	})
+	.strict()
+	.superRefine((evidence, ctx) => {
+		if (evidence.outcome === "passed" && evidence.exit_code !== 0) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Passed verification must have exit code 0",
+				path: ["exit_code"],
+			});
+		}
+		if (evidence.outcome === "failed" && evidence.exit_code === 0) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Failed verification must have a non-zero exit code",
+				path: ["exit_code"],
+			});
+		}
+	});
+
+const replyDispositionSchema = z
+	.object({
+		kind: z.literal("reply"),
+		message_type: messageTypeSchema,
+		message: boundedTextSchema,
+		artifacts: z.array(artifactRefSchema).max(MAX_ARTIFACTS).optional(),
+	})
+	.strict();
+
+const proposeContractDispositionSchema = z
+	.object({
+		kind: z.literal("propose_contract"),
+		artifact: artifactRefSchema,
+	})
+	.strict();
+
+const readyDispositionSchema = z
+	.object({
+		kind: z.literal("ready"),
+		evidence: z.array(verificationEvidenceSchema).max(MAX_VERIFICATION_EVIDENCE),
+	})
+	.strict();
+
+const blockedDispositionSchema = z
+	.object({
+		kind: z.literal("blocked"),
+		reason: boundedTextSchema,
+		requested_input: boundedTextSchema.optional(),
+	})
+	.strict();
+
+const failedDispositionSchema = z
+	.object({
+		kind: z.literal("failed"),
+		class: z.enum(["transient", "permanent", "policy_denied"]),
+	})
+	.strict();
+
+export const turnDispositionSchema = z.discriminatedUnion("kind", [
+	replyDispositionSchema,
+	proposeContractDispositionSchema,
+	readyDispositionSchema,
+	blockedDispositionSchema,
+	failedDispositionSchema,
+]);
+
+export const missionManifestSchema = z
+	.object({
+		schema_version: z.literal(1),
+		mission_id: uuidSchema,
+		objective: boundedTextSchema,
+		public_acceptance_criteria: z
+			.array(acceptanceCriterionSchema)
+			.min(1)
+			.max(MAX_ACCEPTANCE_CRITERIA),
+		participants: z.array(participantSchema).length(2),
+		shared_contract: sharedContractArtifactSchema,
+		max_turns: z.number().int().positive().max(MAX_TURNS),
+		max_wall_time_seconds: z.number().int().positive().max(MAX_WALL_TIME_SECONDS),
+		token_budget: z.number().int().positive().max(MAX_TOKEN_BUDGET),
+		expires_at: isoTimestampSchema,
+		allowed_artifact_types: z.array(artifactTypeSchema).min(1).max(MAX_ARTIFACT_TYPES),
+		created_at: isoTimestampSchema,
+	})
+	.strict()
+	.superRefine((manifest, ctx) => {
+		if (!hasUniqueValues(manifest.participants.map((participant) => participant.agent_id))) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Mission participants must be unique",
+				path: ["participants"],
+			});
+		}
+		if (!hasUniqueValues(manifest.public_acceptance_criteria)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Public acceptance criteria must be unique",
+				path: ["public_acceptance_criteria"],
+			});
+		}
+		if (!hasUniqueValues(manifest.allowed_artifact_types)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Allowed artifact types must be unique",
+				path: ["allowed_artifact_types"],
+			});
+		}
+		if (!manifest.allowed_artifact_types.includes(manifest.shared_contract.type)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Shared contract type must be allowed by the Mission",
+				path: ["shared_contract", "type"],
+			});
+		}
+		if (Date.parse(manifest.expires_at) <= Date.parse(manifest.created_at)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Mission expiry must be after creation",
+				path: ["expires_at"],
+			});
+		}
+	});
+
+/** The relay attaches this actor after authenticating Mission creation. */
+export const missionContextSchema = z
+	.object({
+		manifest: missionManifestSchema,
+		created_by: actorRefSchema,
+	})
+	.strict();
+
+export const deliveryLeaseSchema = z
+	.object({
+		lease_id: uuidSchema,
+		fencing_token: fencingTokenSchema.refine((token) => token !== "0", {
+			message: "Active lease fencing token must be positive",
+		}),
+		expires_at: isoTimestampSchema,
+	})
+	.strict();
+
+export const deliverySchema = z
+	.object({
+		delivery_id: uuidSchema,
+		node_id: uuidSchema,
+		mission_id: uuidSchema,
+		mission_event_id: uuidSchema,
+		kind: z.enum(["turn", "verification"]),
+		cursor: z
+			.string()
+			.regex(/^[1-9][0-9]*$/)
+			.max(64),
+		status: deliveryStatusSchema,
+		attempt_count: z.number().int().nonnegative().max(100),
+		max_attempts: z.number().int().positive().max(100),
+		last_fencing_token: fencingTokenSchema,
+		contract_version: contractVersionSchema,
+		lease: deliveryLeaseSchema.nullable(),
+		idempotency_key: identifierSchema,
+		causal_parent_delivery_id: uuidSchema.nullable(),
+		available_at: isoTimestampSchema,
+		created_at: isoTimestampSchema,
+		updated_at: isoTimestampSchema,
+		acknowledged_at: isoTimestampSchema.nullable(),
+		dead_lettered_at: isoTimestampSchema.nullable(),
+	})
+	.strict()
+	.superRefine((delivery, ctx) => {
+		const needsLease = delivery.status === "leased" || delivery.status === "executing";
+		if (needsLease && delivery.lease === null) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: `${delivery.status} delivery requires a lease`,
+				path: ["lease"],
+			});
+		}
+		if (!needsLease && delivery.lease !== null) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: `${delivery.status} delivery cannot retain an active lease`,
+				path: ["lease"],
+			});
+		}
+		if (delivery.attempt_count > delivery.max_attempts) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Delivery attempt count cannot exceed its limit",
+				path: ["attempt_count"],
+			});
+		}
+		if (needsLease && delivery.attempt_count === 0) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Active delivery lease requires at least one attempt",
+				path: ["attempt_count"],
+			});
+		}
+		if (delivery.status === "acknowledged" && delivery.attempt_count === 0) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Acknowledged delivery requires at least one execution attempt",
+				path: ["attempt_count"],
+			});
+		}
+		if (delivery.status === "stored" && delivery.attempt_count >= delivery.max_attempts) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Stored delivery must retain capacity for another lease",
+				path: ["attempt_count"],
+			});
+		}
+		if ((delivery.attempt_count === 0) !== (delivery.last_fencing_token === "0")) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Initial attempt count and fencing token must advance together",
+				path: ["last_fencing_token"],
+			});
+		}
+		if (delivery.lease !== null && delivery.lease.fencing_token !== delivery.last_fencing_token) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Active lease must use the delivery's latest fencing token",
+				path: ["lease", "fencing_token"],
+			});
+		}
+		if ((delivery.status === "acknowledged") !== (delivery.acknowledged_at !== null)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Acknowledged timestamp must match acknowledged status",
+				path: ["acknowledged_at"],
+			});
+		}
+		if ((delivery.status === "dead_lettered") !== (delivery.dead_lettered_at !== null)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Dead-letter timestamp must match dead-lettered status",
+				path: ["dead_lettered_at"],
+			});
+		}
+		const createdAt = Date.parse(delivery.created_at);
+		for (const [field, value] of [
+			["available_at", delivery.available_at],
+			["updated_at", delivery.updated_at],
+			["acknowledged_at", delivery.acknowledged_at],
+			["dead_lettered_at", delivery.dead_lettered_at],
+		] as const) {
+			if (value !== null && Date.parse(value) < createdAt) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: `${field} cannot precede delivery creation`,
+					path: [field],
+				});
+			}
+		}
+		if (delivery.lease !== null && Date.parse(delivery.lease.expires_at) < createdAt) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Lease expiry cannot precede delivery creation",
+				path: ["lease", "expires_at"],
+			});
+		}
+		const updatedAt = Date.parse(delivery.updated_at);
+		if (
+			(needsLease || delivery.status === "acknowledged") &&
+			Date.parse(delivery.available_at) > updatedAt
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Delivery cannot be leased before it becomes available",
+				path: ["available_at"],
+			});
+		}
+		if (delivery.lease !== null && Date.parse(delivery.lease.expires_at) <= updatedAt) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Active lease must expire after the delivery update",
+				path: ["lease", "expires_at"],
+			});
+		}
+		for (const [field, value] of [
+			["acknowledged_at", delivery.acknowledged_at],
+			["dead_lettered_at", delivery.dead_lettered_at],
+		] as const) {
+			if (value !== null && Date.parse(value) > updatedAt) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: `${field} cannot follow the delivery update timestamp`,
+					path: [field],
+				});
+			}
+		}
+		if (
+			delivery.acknowledged_at !== null &&
+			Date.parse(delivery.acknowledged_at) < Date.parse(delivery.available_at)
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Delivery acknowledgement cannot precede availability",
+				path: ["acknowledged_at"],
+			});
+		}
+	});
+
+export const runtimeNameSchema = boundedOpaqueReferenceSchema(128);
+export const runtimeVersionSchema = boundedOpaqueReferenceSchema(128);
+
+export const runtimeSchema = z
+	.object({
+		name: runtimeNameSchema,
+		version: runtimeVersionSchema,
+	})
+	.strict();
+
+const availableTokenUsageSchema = z
+	.object({
+		available: z.literal(true),
+		input_tokens: z.number().int().nonnegative().max(MAX_TOKEN_BUDGET),
+		output_tokens: z.number().int().nonnegative().max(MAX_TOKEN_BUDGET),
+	})
+	.strict();
+
+const unavailableTokenUsageSchema = z
+	.object({
+		available: z.literal(false),
+		reason: z.enum(["unsupported", "not_reported"]),
+	})
+	.strict();
+
+export const tokenUsageSchema = z.discriminatedUnion("available", [
+	availableTokenUsageSchema,
+	unavailableTokenUsageSchema,
+]);
+
+export const runSchema = z
+	.object({
+		run_id: uuidSchema,
+		mission_id: uuidSchema,
+		participant_agent_id: uuidSchema,
+		node_id: uuidSchema,
+		delivery_id: uuidSchema,
+		lease_id: uuidSchema,
+		fencing_token: fencingTokenSchema.refine((token) => token !== "0", {
+			message: "Run fencing token must be positive",
+		}),
+		contract_version: contractVersionSchema,
+		runtime: runtimeSchema,
+		turn_ref: opaqueReferenceSchema,
+		status: runStatusSchema,
+		usage: tokenUsageSchema,
+		disposition: turnDispositionSchema.nullable(),
+		artifact_hashes: z.array(sha256Schema).max(MAX_ARTIFACTS),
+		verification_evidence: z.array(verificationEvidenceSchema).max(MAX_VERIFICATION_EVIDENCE),
+		started_at: isoTimestampSchema,
+		completed_at: isoTimestampSchema.nullable(),
+	})
+	.strict()
+	.superRefine((run, ctx) => {
+		if ((run.status === "running") !== (run.completed_at === null)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Only running runs may omit a completion timestamp",
+				path: ["completed_at"],
+			});
+		}
+		if (run.status === "completed" && run.disposition === null) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Completed run requires a disposition",
+				path: ["disposition"],
+			});
+		}
+		if (run.status === "running" && run.disposition !== null) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Running run cannot have a terminal disposition",
+				path: ["disposition"],
+			});
+		}
+		if (run.status === "failed" && run.disposition?.kind !== "failed") {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Failed run requires a failed disposition",
+				path: ["disposition"],
+			});
+		}
+		if (run.status === "completed" && run.disposition?.kind === "failed") {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Completed run cannot have a failed disposition",
+				path: ["disposition"],
+			});
+		}
+		if (run.status === "cancelled" && run.disposition !== null) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Cancelled run cannot have a turn disposition",
+				path: ["disposition"],
+			});
+		}
+		if (run.completed_at !== null && Date.parse(run.completed_at) < Date.parse(run.started_at)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Run completion cannot precede its start",
+				path: ["completed_at"],
+			});
+		}
+	});
+
+export type IsoTimestamp = z.infer<typeof isoTimestampSchema>;
+export type OpaqueReference = z.infer<typeof opaqueReferenceSchema>;
+export type MissionStatus = z.infer<typeof missionStatusSchema>;
+export type DeliveryStatus = z.infer<typeof deliveryStatusSchema>;
+export type DeliveryLease = z.infer<typeof deliveryLeaseSchema>;
+export type RunStatus = z.infer<typeof runStatusSchema>;
+export type TokenUsage = z.infer<typeof tokenUsageSchema>;
+export type Runtime = z.infer<typeof runtimeSchema>;
+export type ArtifactType = z.infer<typeof artifactTypeSchema>;
+export type MessageType = z.infer<typeof messageTypeSchema>;
+export type PolicyProfileName = z.infer<typeof policyProfileNameSchema>;
+export type PolicyRequest = z.infer<typeof policyRequestSchema>;
+export type ActorRef = z.infer<typeof actorRefSchema>;
+export type Participant = z.infer<typeof participantSchema>;
+export type ArtifactRef = z.infer<typeof artifactRefSchema>;
+export type SharedContractArtifact = z.infer<typeof sharedContractArtifactSchema>;
+export type ContractRevision = z.infer<typeof contractRevisionSchema>;
+export type Message = z.infer<typeof messageSchema>;
+export type VerificationEvidence = z.infer<typeof verificationEvidenceSchema>;
+export type TurnDisposition = z.infer<typeof turnDispositionSchema>;
+export type MissionManifest = z.infer<typeof missionManifestSchema>;
+export type MissionContext = z.infer<typeof missionContextSchema>;
+export type Delivery = z.infer<typeof deliverySchema>;
+export type Run = z.infer<typeof runSchema>;

--- a/protocol/src/state-machines.test.ts
+++ b/protocol/src/state-machines.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import {
+	type DeliveryStatus,
+	type MissionStatus,
+	deliveryStatusSchema,
+	missionStatusSchema,
+} from "./schemas.js";
+import {
+	type DeliveryTransitionEvent,
+	type DeliveryTransitionState,
+	InvalidFencingTokenError,
+	InvalidLeaseClaimError,
+	InvalidTransitionError,
+	type MissionTransitionEvent,
+	assertActiveDeliveryClaim,
+	deliveryTransitionEventTypes,
+	missionTransitionEventTypes,
+	transitionDeliveryState,
+	transitionMissionStatus,
+} from "./state-machines.js";
+
+const missionStatuses = missionStatusSchema.options;
+const missionEvents: MissionTransitionEvent[] = missionTransitionEventTypes.map((type) => ({
+	type,
+}));
+
+const allowedMissionTransitions = new Map<string, MissionStatus>([
+	["awaiting_acceptance:participants_accepted", "active"],
+	["awaiting_acceptance:cancel", "cancelled"],
+	["awaiting_acceptance:expire", "expired"],
+	["awaiting_acceptance:fail", "failed"],
+	["active:participants_ready", "verifying"],
+	["active:blocking_required", "blocked"],
+	["active:cancel", "cancelled"],
+	["active:expire", "expired"],
+	["active:fail", "failed"],
+	["verifying:blocking_required", "blocked"],
+	["verifying:verification_passed", "completed"],
+	["verifying:verification_failed", "active"],
+	["verifying:cancel", "cancelled"],
+	["verifying:expire", "expired"],
+	["verifying:fail", "failed"],
+	["blocked:block_resolved", "active"],
+	["blocked:cancel", "cancelled"],
+	["blocked:expire", "expired"],
+	["blocked:fail", "failed"],
+]);
+
+const deliveryStatuses = deliveryStatusSchema.options;
+const deliveryEvents: DeliveryTransitionEvent[] = deliveryTransitionEventTypes.map(deliveryEvent);
+
+const allowedDeliveryTransitions = new Map<string, DeliveryStatus>([
+	["stored:lease", "leased"],
+	["stored:terminal_failure", "dead_lettered"],
+	["leased:start_execution", "executing"],
+	["leased:retry", "stored"],
+	["leased:lease_expired", "stored"],
+	["leased:terminal_failure", "dead_lettered"],
+	["executing:acknowledge", "acknowledged"],
+	["executing:retry", "stored"],
+	["executing:lease_expired", "stored"],
+	["executing:terminal_failure", "dead_lettered"],
+]);
+
+describe("transitionMissionStatus", () => {
+	it("implements every allowed edge and rejects every other status/event pair", () => {
+		for (const status of missionStatuses) {
+			for (const event of missionEvents) {
+				const expected = allowedMissionTransitions.get(`${status}:${event.type}`);
+				if (expected !== undefined) {
+					expect(transitionMissionStatus(status, event)).toBe(expected);
+				} else {
+					expect(() => transitionMissionStatus(status, event)).toThrow(InvalidTransitionError);
+				}
+			}
+		}
+	});
+
+	it.each(["completed", "cancelled", "expired", "failed"] as const)(
+		"rejects delayed events after terminal status %s",
+		(status) => {
+			for (const event of missionEvents) {
+				expect(() => transitionMissionStatus(status, event)).toThrow(InvalidTransitionError);
+			}
+		},
+	);
+
+	it("reports the rejected mission transition", () => {
+		try {
+			transitionMissionStatus("awaiting_acceptance", { type: "participants_ready" });
+			expect.fail("transition should have failed");
+		} catch (error) {
+			expect(error).toBeInstanceOf(InvalidTransitionError);
+			expect(error).toMatchObject({
+				machine: "mission",
+				currentStatus: "awaiting_acceptance",
+				eventType: "participants_ready",
+			});
+		}
+	});
+});
+
+describe("transitionDeliveryState", () => {
+	it("implements every allowed edge and rejects every other status/event pair", () => {
+		for (const status of deliveryStatuses) {
+			for (const event of deliveryEvents) {
+				const expected = allowedDeliveryTransitions.get(`${status}:${event.type}`);
+				if (expected !== undefined) {
+					expect(transitionDeliveryState(deliveryState(status), event).status).toBe(expected);
+				} else {
+					expect(() => transitionDeliveryState(deliveryState(status), event)).toThrow(
+						InvalidTransitionError,
+					);
+				}
+			}
+		}
+	});
+
+	it.each(["acknowledged", "dead_lettered"] as const)(
+		"rejects delayed events after terminal status %s",
+		(status) => {
+			for (const event of deliveryEvents) {
+				expect(() => transitionDeliveryState(deliveryState(status), event)).toThrow(
+					InvalidTransitionError,
+				);
+			}
+		},
+	);
+
+	it("increments attempts and installs only a newer fencing token when leasing", () => {
+		expect(
+			transitionDeliveryState(deliveryState("stored"), {
+				type: "lease",
+				leaseId: "00000000-0000-4000-8000-000000000002",
+				fencingToken: "2",
+				now: "2026-08-02T10:00:00.000Z",
+				expiresAt: "2026-08-02T10:10:00.000Z",
+			}),
+		).toEqual({
+			status: "leased",
+			attemptCount: 2,
+			maxAttempts: 3,
+			lastFencingToken: "2",
+			activeLeaseId: "00000000-0000-4000-8000-000000000002",
+			activeFencingToken: "2",
+			leaseExpiresAt: "2026-08-02T10:10:00.000Z",
+		});
+		expect(() =>
+			transitionDeliveryState(deliveryState("stored"), {
+				type: "lease",
+				leaseId: "00000000-0000-4000-8000-000000000002",
+				fencingToken: "1",
+				now: "2026-08-02T10:00:00.000Z",
+				expiresAt: "2026-08-02T10:10:00.000Z",
+			}),
+		).toThrow(InvalidTransitionError);
+	});
+
+	it("rejects a stale owner and preserves the active fence while executing", () => {
+		const executing = transitionDeliveryState(deliveryState("leased"), {
+			type: "start_execution",
+			leaseId: "00000000-0000-4000-8000-000000000001",
+			fencingToken: "1",
+			now: "2026-08-02T10:01:00.000Z",
+		});
+		expect(executing.activeFencingToken).toBe("1");
+		expect(() =>
+			transitionDeliveryState(executing, {
+				type: "acknowledge",
+				leaseId: "00000000-0000-4000-8000-000000000001",
+				fencingToken: "0",
+				now: "2026-08-02T10:02:00.000Z",
+			}),
+		).toThrow(InvalidFencingTokenError);
+	});
+
+	it("lets a renewed claim recover while rejecting the expired owner", () => {
+		const expired = transitionDeliveryState(deliveryState("leased"), {
+			type: "lease_expired",
+			leaseId: "00000000-0000-4000-8000-000000000001",
+			fencingToken: "1",
+			now: "2026-08-02T10:05:00.000Z",
+		});
+		const renewed = transitionDeliveryState(expired, {
+			type: "lease",
+			leaseId: "00000000-0000-4000-8000-000000000002",
+			fencingToken: "2",
+			now: "2026-08-02T10:06:00.000Z",
+			expiresAt: "2026-08-02T10:10:00.000Z",
+		});
+
+		expect(() =>
+			assertActiveDeliveryClaim(renewed, {
+				leaseId: "00000000-0000-4000-8000-000000000001",
+				fencingToken: "1",
+				now: "2026-08-02T10:07:00.000Z",
+			}),
+		).toThrow(InvalidLeaseClaimError);
+		expect(() =>
+			assertActiveDeliveryClaim(renewed, {
+				leaseId: "00000000-0000-4000-8000-000000000002",
+				fencingToken: "2",
+				now: "2026-08-02T10:07:00.000Z",
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects a matching holder at lease expiry and premature expiry transitions", () => {
+		const leased = deliveryState("leased");
+		expect(() =>
+			assertActiveDeliveryClaim(leased, {
+				leaseId: "00000000-0000-4000-8000-000000000001",
+				fencingToken: "1",
+				now: "2026-08-02T10:05:00.000Z",
+			}),
+		).toThrow(InvalidLeaseClaimError);
+		expect(() =>
+			transitionDeliveryState(leased, {
+				type: "lease_expired",
+				leaseId: "00000000-0000-4000-8000-000000000001",
+				fencingToken: "1",
+				now: "2026-08-02T10:04:59.999Z",
+			}),
+		).toThrow(InvalidLeaseClaimError);
+	});
+
+	it("dead-letters retryable work when the attempt budget is exhausted", () => {
+		const exhausted = { ...deliveryState("executing"), attemptCount: 3 };
+		expect(
+			transitionDeliveryState(exhausted, {
+				type: "retry",
+				leaseId: "00000000-0000-4000-8000-000000000001",
+				fencingToken: "1",
+				now: "2026-08-02T10:02:00.000Z",
+			}),
+		).toMatchObject({
+			status: "dead_lettered",
+			activeLeaseId: null,
+			activeFencingToken: null,
+			leaseExpiresAt: null,
+		});
+	});
+});
+
+function deliveryState(status: DeliveryStatus): DeliveryTransitionState {
+	const active = status === "leased" || status === "executing";
+	return {
+		status,
+		attemptCount: 1,
+		maxAttempts: 3,
+		lastFencingToken: "1",
+		activeLeaseId: active ? "00000000-0000-4000-8000-000000000001" : null,
+		activeFencingToken: active ? "1" : null,
+		leaseExpiresAt: active ? "2026-08-02T10:05:00.000Z" : null,
+	};
+}
+
+function deliveryEvent(
+	type: (typeof deliveryTransitionEventTypes)[number],
+): DeliveryTransitionEvent {
+	if (type === "lease") {
+		return {
+			type,
+			leaseId: "00000000-0000-4000-8000-000000000002",
+			fencingToken: "2",
+			now: "2026-08-02T10:00:00.000Z",
+			expiresAt: "2026-08-02T10:10:00.000Z",
+		};
+	}
+	return {
+		type,
+		leaseId: "00000000-0000-4000-8000-000000000001",
+		fencingToken: "1",
+		now: type === "lease_expired" ? "2026-08-02T10:05:00.000Z" : "2026-08-02T10:01:00.000Z",
+	};
+}

--- a/protocol/src/state-machines.ts
+++ b/protocol/src/state-machines.ts
@@ -1,0 +1,279 @@
+import {
+	type DeliveryStatus,
+	type MissionStatus,
+	isoTimestampSchema,
+	uuidSchema,
+} from "./schemas.js";
+
+export const missionTransitionEventTypes = [
+	"participants_accepted",
+	"participants_ready",
+	"blocking_required",
+	"block_resolved",
+	"verification_passed",
+	"verification_failed",
+	"cancel",
+	"expire",
+	"fail",
+] as const;
+
+export type MissionTransitionEvent = {
+	type: (typeof missionTransitionEventTypes)[number];
+};
+
+export const deliveryTransitionEventTypes = [
+	"lease",
+	"start_execution",
+	"acknowledge",
+	"retry",
+	"lease_expired",
+	"terminal_failure",
+] as const;
+
+export interface DeliveryClaim {
+	readonly leaseId: string;
+	readonly fencingToken: string;
+	readonly now: string;
+}
+
+export type DeliveryTransitionEvent =
+	| ({ type: "lease"; expiresAt: string } & DeliveryClaim)
+	| ({ type: "start_execution" } & DeliveryClaim)
+	| ({ type: "acknowledge" } & DeliveryClaim)
+	| ({ type: "retry" } & DeliveryClaim)
+	| ({ type: "lease_expired" } & DeliveryClaim)
+	| ({ type: "terminal_failure" } & Partial<DeliveryClaim>);
+
+export interface DeliveryTransitionState {
+	readonly status: DeliveryStatus;
+	readonly attemptCount: number;
+	readonly maxAttempts: number;
+	readonly lastFencingToken: string;
+	readonly activeLeaseId: string | null;
+	readonly activeFencingToken: string | null;
+	readonly leaseExpiresAt: string | null;
+}
+
+type StateMachine = "mission" | "delivery";
+type TransitionStatus = MissionStatus | DeliveryStatus;
+type TransitionEventType = MissionTransitionEvent["type"] | DeliveryTransitionEvent["type"];
+
+export class InvalidTransitionError extends Error {
+	constructor(
+		readonly machine: StateMachine,
+		readonly currentStatus: TransitionStatus,
+		readonly eventType: TransitionEventType,
+	) {
+		super(`Invalid ${machine} transition from '${currentStatus}' on '${eventType}'`);
+		this.name = "InvalidTransitionError";
+	}
+}
+
+export class InvalidFencingTokenError extends Error {
+	constructor(
+		readonly currentStatus: DeliveryStatus,
+		readonly eventType: DeliveryTransitionEvent["type"],
+		readonly expected: string | null,
+		readonly received: string | undefined,
+	) {
+		super(`Invalid delivery fencing token for '${currentStatus}' on '${eventType}'`);
+		this.name = "InvalidFencingTokenError";
+	}
+}
+
+export class InvalidLeaseClaimError extends Error {
+	constructor(
+		readonly currentStatus: DeliveryStatus,
+		readonly eventType: DeliveryTransitionEvent["type"],
+		readonly reason: "inactive" | "lease_mismatch" | "expired" | "invalid_time",
+	) {
+		super(`Invalid delivery lease claim for '${currentStatus}' on '${eventType}': ${reason}`);
+		this.name = "InvalidLeaseClaimError";
+	}
+}
+
+type MissionEventType = MissionTransitionEvent["type"];
+type DeliveryEventType = DeliveryTransitionEvent["type"];
+
+const missionTransitions: Partial<
+	Record<MissionStatus, Partial<Record<MissionEventType, MissionStatus>>>
+> = {
+	awaiting_acceptance: {
+		participants_accepted: "active",
+		cancel: "cancelled",
+		expire: "expired",
+		fail: "failed",
+	},
+	active: {
+		participants_ready: "verifying",
+		blocking_required: "blocked",
+		cancel: "cancelled",
+		expire: "expired",
+		fail: "failed",
+	},
+	verifying: {
+		blocking_required: "blocked",
+		verification_passed: "completed",
+		verification_failed: "active",
+		cancel: "cancelled",
+		expire: "expired",
+		fail: "failed",
+	},
+	blocked: {
+		block_resolved: "active",
+		cancel: "cancelled",
+		expire: "expired",
+		fail: "failed",
+	},
+};
+
+const deliveryTransitions: Partial<
+	Record<DeliveryStatus, Partial<Record<DeliveryEventType, DeliveryStatus>>>
+> = {
+	stored: {
+		lease: "leased",
+		terminal_failure: "dead_lettered",
+	},
+	leased: {
+		start_execution: "executing",
+		retry: "stored",
+		lease_expired: "stored",
+		terminal_failure: "dead_lettered",
+	},
+	executing: {
+		acknowledge: "acknowledged",
+		retry: "stored",
+		lease_expired: "stored",
+		terminal_failure: "dead_lettered",
+	},
+};
+
+export function transitionMissionStatus(
+	current: MissionStatus,
+	event: MissionTransitionEvent,
+): MissionStatus {
+	const next = missionTransitions[current]?.[event.type];
+	if (next === undefined) {
+		throw new InvalidTransitionError("mission", current, event.type);
+	}
+	return next;
+}
+
+export function transitionDeliveryState(
+	current: DeliveryTransitionState,
+	event: DeliveryTransitionEvent,
+): DeliveryTransitionState {
+	const next = deliveryTransitions[current.status]?.[event.type];
+	if (next === undefined) {
+		throw new InvalidTransitionError("delivery", current.status, event.type);
+	}
+
+	if (event.type === "lease") {
+		if (
+			current.attemptCount >= current.maxAttempts ||
+			compareFencingTokens(event.fencingToken, current.lastFencingToken) <= 0
+		) {
+			throw new InvalidTransitionError("delivery", current.status, event.type);
+		}
+		if (!isTimestampBefore(event.now, event.expiresAt)) {
+			throw new InvalidLeaseClaimError(current.status, event.type, "invalid_time");
+		}
+		if (!uuidSchema.safeParse(event.leaseId).success) {
+			throw new InvalidLeaseClaimError(current.status, event.type, "lease_mismatch");
+		}
+		return {
+			...current,
+			status: next,
+			attemptCount: current.attemptCount + 1,
+			lastFencingToken: event.fencingToken,
+			activeLeaseId: event.leaseId,
+			activeFencingToken: event.fencingToken,
+			leaseExpiresAt: event.expiresAt,
+		};
+	}
+
+	if (current.status === "leased" || current.status === "executing") {
+		if (event.type === "lease_expired") {
+			assertMatchingDeliveryClaim(current, event, event.type);
+			if (isTimestampBefore(event.now, current.leaseExpiresAt)) {
+				throw new InvalidLeaseClaimError(current.status, event.type, "invalid_time");
+			}
+		} else {
+			assertActiveDeliveryClaim(current, event, event.type);
+		}
+	}
+
+	const attemptsExhausted =
+		(event.type === "retry" || event.type === "lease_expired") &&
+		current.attemptCount >= current.maxAttempts;
+
+	return {
+		...current,
+		status: attemptsExhausted ? "dead_lettered" : next,
+		activeLeaseId: next === "executing" ? current.activeLeaseId : null,
+		activeFencingToken: next === "executing" ? current.activeFencingToken : null,
+		leaseExpiresAt: next === "executing" ? current.leaseExpiresAt : null,
+	};
+}
+
+export function assertActiveDeliveryClaim(
+	current: DeliveryTransitionState,
+	received: Partial<DeliveryClaim>,
+	eventType: DeliveryTransitionEvent["type"] = "start_execution",
+): void {
+	assertMatchingDeliveryClaim(current, received, eventType);
+	if (!isTimestampBefore(received.now, current.leaseExpiresAt)) {
+		throw new InvalidLeaseClaimError(current.status, eventType, "expired");
+	}
+}
+
+function assertMatchingDeliveryClaim(
+	current: DeliveryTransitionState,
+	received: Partial<DeliveryClaim>,
+	eventType: DeliveryTransitionEvent["type"],
+): void {
+	if (current.status !== "leased" && current.status !== "executing") {
+		throw new InvalidLeaseClaimError(current.status, eventType, "inactive");
+	}
+	if (received.leaseId === undefined || received.leaseId !== current.activeLeaseId) {
+		throw new InvalidLeaseClaimError(current.status, eventType, "lease_mismatch");
+	}
+	if (received.fencingToken === undefined || received.fencingToken !== current.activeFencingToken) {
+		throw new InvalidFencingTokenError(
+			current.status,
+			eventType,
+			current.activeFencingToken,
+			received.fencingToken,
+		);
+	}
+	if (
+		received.now === undefined ||
+		!isTimestamp(received.now) ||
+		!isTimestamp(current.leaseExpiresAt)
+	) {
+		throw new InvalidLeaseClaimError(current.status, eventType, "invalid_time");
+	}
+}
+
+function compareFencingTokens(left: string, right: string): number {
+	if (!/^(?:0|[1-9][0-9]{0,63})$/.test(left) || !/^(?:0|[1-9][0-9]{0,63})$/.test(right)) {
+		return -1;
+	}
+	if (left.length !== right.length) {
+		return left.length > right.length ? 1 : -1;
+	}
+	return left === right ? 0 : left > right ? 1 : -1;
+}
+
+function isTimestamp(value: string | null): value is string {
+	return value !== null && isoTimestampSchema.safeParse(value).success;
+}
+
+function isTimestampBefore(left: string | undefined, right: string | null): boolean {
+	return (
+		left !== undefined &&
+		isTimestamp(left) &&
+		isTimestamp(right) &&
+		Date.parse(left) < Date.parse(right)
+	);
+}

--- a/protocol/src/testing/fake-adapter.ts
+++ b/protocol/src/testing/fake-adapter.ts
@@ -1,0 +1,334 @@
+import { isDeepStrictEqual } from "node:util";
+import {
+	type AdapterInfo,
+	type AgentHostAdapter,
+	DEFAULT_HOST_EVENT_STREAM_POLICY,
+	type HostEvent,
+	type HostEventStreamPolicy,
+	type HostEventStreamState,
+	type HostFailure,
+	type HostPermissionActivity,
+	type HostSessionRef,
+	type HostToolActivity,
+	type HostTurnRef,
+	type HostUsage,
+	type SessionInput,
+	type StartTurnInput,
+	acceptHostEvent,
+	adapterInfoSchema,
+	createHostEventStreamState,
+	hostSessionRefSchema,
+	hostTurnRefSchema,
+	sessionInputSchema,
+	startTurnInputSchema,
+} from "../adapter.js";
+import { type ArtifactRef, type TurnDisposition, uuidSchema } from "../schemas.js";
+
+export type FakeTurnProgress =
+	| { readonly kind: "output"; readonly text: string }
+	| { readonly kind: "tool"; readonly activity: HostToolActivity }
+	| { readonly kind: "permission"; readonly activity: HostPermissionActivity }
+	| { readonly kind: "artifact"; readonly artifact: ArtifactRef }
+	| { readonly kind: "usage"; readonly usage: HostUsage };
+
+export type FakeTurnOutcome =
+	| { readonly kind: "pending"; readonly events?: readonly FakeTurnProgress[] }
+	| {
+			readonly kind: "completed";
+			readonly events?: readonly FakeTurnProgress[];
+			readonly disposition: TurnDisposition;
+	  }
+	| {
+			readonly kind: "failed";
+			readonly events?: readonly FakeTurnProgress[];
+			readonly failure: HostFailure;
+	  };
+
+export interface FakeAdapterCounters {
+	readonly probeCalls: number;
+	readonly ensureSessionCalls: number;
+	readonly sessionsCreated: number;
+	readonly startTurnCalls: number;
+	readonly turnsCreated: number;
+	readonly recoverTurnCalls: number;
+	readonly cancelTurnCalls: number;
+	readonly turnsCancelled: number;
+}
+
+interface StoredTurn {
+	readonly input: StartTurnInput;
+	readonly ref: HostTurnRef;
+	readonly events: HostEvent[];
+	readonly policy: HostEventStreamPolicy;
+	streamState: HostEventStreamState;
+}
+
+const DEFAULT_INFO: AdapterInfo = {
+	name: "fake",
+	version: "1.0.0",
+	capabilities: {
+		cancellation: true,
+		recovery: true,
+		usage: "turn_cumulative",
+	},
+};
+
+/** Deterministic in-memory adapter for coordinator and Node tests. */
+export class FakeAgentHostAdapter implements AgentHostAdapter {
+	readonly #info: AdapterInfo;
+	readonly #outcomes: FakeTurnOutcome[] = [];
+	readonly #sessionsByKey = new Map<string, HostSessionRef>();
+	readonly #turnsByDelivery = new Map<string, StoredTurn>();
+	readonly #turnsById = new Map<string, StoredTurn>();
+	#probeCalls = 0;
+	#ensureSessionCalls = 0;
+	#sessionsCreated = 0;
+	#startTurnCalls = 0;
+	#turnsCreated = 0;
+	#recoverTurnCalls = 0;
+	#cancelTurnCalls = 0;
+	#turnsCancelled = 0;
+
+	constructor(info: AdapterInfo = DEFAULT_INFO) {
+		this.#info = adapterInfoSchema.parse(info);
+	}
+
+	get counters(): FakeAdapterCounters {
+		return {
+			probeCalls: this.#probeCalls,
+			ensureSessionCalls: this.#ensureSessionCalls,
+			sessionsCreated: this.#sessionsCreated,
+			startTurnCalls: this.#startTurnCalls,
+			turnsCreated: this.#turnsCreated,
+			recoverTurnCalls: this.#recoverTurnCalls,
+			cancelTurnCalls: this.#cancelTurnCalls,
+			turnsCancelled: this.#turnsCancelled,
+		};
+	}
+
+	queueOutcome(outcome: FakeTurnOutcome): void {
+		this.#outcomes.push(structuredClone(outcome));
+	}
+
+	eventsFor(deliveryId: string): readonly HostEvent[] {
+		return structuredClone(this.requireTurnByDelivery(deliveryId).events);
+	}
+
+	completeTurn(deliveryId: string, disposition: TurnDisposition): void {
+		const turn = this.requirePendingTurn(deliveryId);
+		ensureUsageEvent(turn);
+		appendEvent(turn, {
+			kind: "completed",
+			turn: turn.ref,
+			disposition: structuredClone(disposition),
+		});
+	}
+
+	failTurn(deliveryId: string, failure: HostFailure): void {
+		const turn = this.requirePendingTurn(deliveryId);
+		ensureUsageEvent(turn);
+		appendEvent(turn, { kind: "failed", turn: turn.ref, failure: structuredClone(failure) });
+	}
+
+	async probe(): Promise<AdapterInfo> {
+		this.#probeCalls += 1;
+		return structuredClone(this.#info);
+	}
+
+	async ensureSession(input: SessionInput): Promise<HostSessionRef> {
+		this.#ensureSessionCalls += 1;
+		const validated = sessionInputSchema.parse(input);
+		const key = sessionKey(validated);
+		const existing = this.#sessionsByKey.get(key);
+		if (existing) {
+			return { ...existing };
+		}
+
+		this.#sessionsCreated += 1;
+		const session = hostSessionRefSchema.parse({
+			...validated,
+			sessionId: `fake-session-${this.#sessionsCreated}`,
+		});
+		this.#sessionsByKey.set(key, session);
+		return structuredClone(session);
+	}
+
+	async lookupTurn(deliveryId: string): Promise<HostTurnRef | null> {
+		const validated = uuidSchema.parse(deliveryId);
+		const ref = this.#turnsByDelivery.get(validated)?.ref;
+		return ref ? structuredClone(ref) : null;
+	}
+
+	startTurn(input: StartTurnInput): AsyncIterable<HostEvent> {
+		this.#startTurnCalls += 1;
+		const validated = startTurnInputSchema.parse(input);
+		const existing = this.#turnsByDelivery.get(validated.deliveryId);
+		if (existing) {
+			assertSameCorrelation(existing.input, validated);
+			return replay(existing.events);
+		}
+
+		this.assertKnownSession(validated);
+		const turnNumber = this.#turnsCreated + 1;
+		const ref = hostTurnRefSchema.parse({
+			turnId: `fake-turn-${turnNumber}`,
+			sessionId: validated.session.sessionId,
+			missionId: validated.missionId,
+			deliveryId: validated.deliveryId,
+			contractVersion: validated.contractVersion,
+		});
+		const stored: StoredTurn = {
+			input: structuredClone(validated),
+			ref,
+			events: [],
+			policy: {
+				...DEFAULT_HOST_EVENT_STREAM_POLICY,
+				usage: this.#info.capabilities.usage,
+			},
+			streamState: createHostEventStreamState(ref),
+		};
+		appendEvent(stored, { kind: "accepted", turn: ref });
+		this.#turnsCreated = turnNumber;
+		this.#turnsByDelivery.set(validated.deliveryId, stored);
+		this.#turnsById.set(ref.turnId, stored);
+
+		const outcome = this.#outcomes.shift() ?? { kind: "pending" };
+		appendProgressEvents(stored, outcome.events ?? []);
+		if (outcome.kind === "completed") {
+			ensureUsageEvent(stored);
+			appendEvent(stored, { kind: "completed", turn: ref, disposition: outcome.disposition });
+		} else if (outcome.kind === "failed") {
+			ensureUsageEvent(stored);
+			appendEvent(stored, { kind: "failed", turn: ref, failure: outcome.failure });
+		}
+
+		return replay(stored.events);
+	}
+
+	recoverTurn(ref: HostTurnRef): AsyncIterable<HostEvent> {
+		this.#recoverTurnCalls += 1;
+		const stored = this.requireTurnByRef(hostTurnRefSchema.parse(ref));
+		return replay(stored.events);
+	}
+
+	async cancelTurn(ref: HostTurnRef): Promise<void> {
+		this.#cancelTurnCalls += 1;
+		const stored = this.requireTurnByRef(hostTurnRefSchema.parse(ref));
+		if (isTerminal(stored.events)) {
+			return;
+		}
+
+		ensureUsageEvent(stored);
+		appendEvent(stored, { kind: "cancelled", turn: stored.ref });
+		this.#turnsCancelled += 1;
+	}
+
+	private assertKnownSession(input: StartTurnInput): void {
+		const session = this.#sessionsByKey.get(sessionKey(input.session));
+		if (!session || session.sessionId !== input.session.sessionId) {
+			throw new Error(`unknown fake host session: ${input.session.sessionId}`);
+		}
+		if (input.missionId !== input.session.missionId) {
+			throw new Error("turn missionId does not match its host session");
+		}
+	}
+
+	private requirePendingTurn(deliveryId: string): StoredTurn {
+		const turn = this.requireTurnByDelivery(deliveryId);
+		if (isTerminal(turn.events)) {
+			throw new Error(`fake host turn is already terminal: ${deliveryId}`);
+		}
+		return turn;
+	}
+
+	private requireTurnByDelivery(deliveryId: string): StoredTurn {
+		const turn = this.#turnsByDelivery.get(deliveryId);
+		if (!turn) {
+			throw new Error(`unknown fake host delivery: ${deliveryId}`);
+		}
+		return turn;
+	}
+
+	private requireTurnByRef(ref: HostTurnRef): StoredTurn {
+		const turn = this.#turnsById.get(ref.turnId);
+		if (
+			!turn ||
+			turn.ref.deliveryId !== ref.deliveryId ||
+			turn.ref.sessionId !== ref.sessionId ||
+			turn.ref.missionId !== ref.missionId ||
+			turn.ref.contractVersion !== ref.contractVersion
+		) {
+			throw new Error(`unknown fake host turn: ${ref.turnId}`);
+		}
+		return turn;
+	}
+}
+
+function sessionKey(input: SessionInput): string {
+	return JSON.stringify([input.missionId, input.participantId, input.workspaceAlias]);
+}
+
+function assertSameCorrelation(existing: StartTurnInput, duplicate: StartTurnInput): void {
+	if (!isDeepStrictEqual(existing, duplicate)) {
+		throw new Error(`deliveryId reused with different turn correlation: ${duplicate.deliveryId}`);
+	}
+}
+
+function isTerminal(events: readonly HostEvent[]): boolean {
+	const last = events.at(-1);
+	return last?.kind === "completed" || last?.kind === "failed" || last?.kind === "cancelled";
+}
+
+function replay(events: readonly HostEvent[]): AsyncIterable<HostEvent> {
+	const snapshot = structuredClone(events);
+	return (async function* replaySnapshot(): AsyncIterable<HostEvent> {
+		for (const event of snapshot) {
+			yield structuredClone(event);
+		}
+	})();
+}
+
+function appendProgressEvents(turn: StoredTurn, progress: readonly FakeTurnProgress[]): void {
+	for (const event of progress) {
+		if (event.kind === "output") {
+			appendEvent(turn, {
+				kind: "output",
+				turn: turn.ref,
+				text: event.text,
+			});
+		} else if (event.kind === "tool") {
+			appendEvent(turn, { kind: "tool", turn: turn.ref, activity: event.activity });
+		} else if (event.kind === "permission") {
+			appendEvent(turn, { kind: "permission", turn: turn.ref, activity: event.activity });
+		} else if (event.kind === "artifact") {
+			appendEvent(turn, { kind: "artifact", turn: turn.ref, artifact: event.artifact });
+		} else {
+			appendEvent(turn, { kind: "usage", turn: turn.ref, usage: event.usage });
+		}
+	}
+}
+
+function ensureUsageEvent(turn: StoredTurn): void {
+	if (turn.streamState.usage === null) {
+		appendEvent(turn, {
+			kind: "usage",
+			turn: turn.ref,
+			usage: { available: false, reason: "not_reported" },
+		});
+	}
+}
+
+type UnsequencedHostEvent<T = HostEvent> = T extends HostEvent ? Omit<T, "sequence"> : never;
+
+function appendEvent(turn: StoredTurn, event: UnsequencedHostEvent): void {
+	const accepted = acceptHostEvent(
+		turn.streamState,
+		{
+			...event,
+			sequence: turn.events.length + 1,
+		},
+		turn.policy,
+	);
+	turn.events.push(accepted.event);
+	turn.streamState = accepted.state;
+}

--- a/protocol/src/testing/index.ts
+++ b/protocol/src/testing/index.ts
@@ -1,0 +1,6 @@
+export {
+	FakeAgentHostAdapter,
+	type FakeAdapterCounters,
+	type FakeTurnOutcome,
+	type FakeTurnProgress,
+} from "./fake-adapter.js";

--- a/protocol/tsconfig.json
+++ b/protocol/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.test.ts", "dist", "node_modules"]
+}


### PR DESCRIPTION
## Outcome

Adds the first executable foundation for the AgentRelay Node architecture as `@agentrelay/protocol`.

- bounded Zod contracts for Missions, revisions, messages, artifacts, deliveries, runs, evidence, and authenticated Mission context
- pure Mission and lease-ID/token/deadline-fenced delivery reducers
- runtime-neutral adapter contracts with replay-safe event reduction, correlation pinning, aggregate limits, monotonic usage, and explicit terminal usage
- deterministic fake adapter covering duplicate suppression, recovery, cancellation, malformed provider events, and immutable replay
- workspace CI, docs, and contributor guidance updated for the new package

## Boundary

This does not ship the Node daemon, durable relay ledger, Codex adapter, or public A2A gateway. JSON Schema/OpenAPI bindings remain required before non-TypeScript consumers.

## Validation

- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r build`
- `pnpm --filter @agentrelay/protocol --filter relay --filter agentrelay-mcp test`
- 58 protocol tests, 39 relay unit tests, 152 MCP tests
- package self-export smoke and tarball inspection
- three independent P0-P2 reviews: clean

Docker was unavailable locally, so Postgres integration and E2E coverage are left to the required GitHub CI jobs.

## Next

Add deterministic two-repository transcript fixtures, then persist the delivery ledger and build the foreground Node around these contracts.