### PR TITLE
feat(protocol): add deterministic Mission transcript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ pnpm --filter agentrelay-mcp dev
 ## Repository layout
 
 ```text
-protocol/       shared Mission, delivery, and runtime-adapter contracts
+protocol/       Mission contracts, coordinator, test fixtures, and runtime adapters
 relay/          Hono + Drizzle + Postgres relay
 mcp-server/     agentrelay-mcp package and agentrelay CLI
 tests/e2e/      real relay plus two MCP processes

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ full autonomous runtime described above.
 - Typed engineering artifacts, plus provenance markers when `accept_handoff` or
   `view_thread` returns teammate-authored summaries/messages.
 - An executable `@agentrelay/protocol` workspace with bounded Mission contracts,
-  strict lifecycle reducers, and a deterministic fake runtime adapter.
+  strict lifecycle and coordinator reducers, a deterministic fake runtime adapter,
+  and a reproducible backend-Android transcript fixture.
 - CLI setup, invite/join, install, doctor/fix, key rotation, audit, block, and trust.
 - An in-process Slack dispatcher, although the current card-update path does not
   produce the encrypted webhook form it consumes, so setup is not end-to-end usable.
@@ -223,7 +224,7 @@ this README does not claim full A2A conformance.
 .
 ├── AGENTS.md             coding-agent instructions: understand first, keep code clear
 ├── CLAUDE.md             Claude-specific entry point; delegates to AGENTS.md
-├── protocol/             Mission schemas, state machines, and adapter contract
+├── protocol/             Mission schemas, coordinator, fixtures, and adapter contract
 ├── relay/                current Hono + Drizzle + Postgres relay
 ├── mcp-server/           current MCP server and agentrelay CLI
 ├── tests/e2e/            relay + two-MCP-process test harness

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,8 @@ The repository currently ships an authenticated asynchronous mailbox:
 - A Hono relay with REST onboarding and an A2A-shaped JSON-RPC endpoint.
 - Seven stdio MCP tools for sending, receiving, replying to, inspecting, and
   completing handoff threads.
+- An executable protocol workspace with Mission/delivery/runtime contracts and an
+  in-memory deterministic backend-Android coordination proof.
 - Typed engineering artifacts and provenance wrapping for some inbound content.
 - An in-process Slack notification dispatcher, but no currently supported
   end-to-end webhook configuration path.

--- a/docs/experiments/001-backend-android-deterministic-proof.md
+++ b/docs/experiments/001-backend-android-deterministic-proof.md
@@ -1,0 +1,100 @@
+# Experiment 001: deterministic backend-Android Mission
+
+- **Date:** 2026-08-02
+- **Result:** passed
+- **Scope:** Stage 1 protocol and coordinator proof with fake runtimes
+
+## Question
+
+Can the executable Mission contract deterministically coordinate two isolated
+participants through clarification, one shared-contract revision, local readiness,
+and cross-repository verification without a human event after kickoff?
+
+This experiment tests coordination semantics. It deliberately removes model variance
+and durable networking so failures are attributable to the protocol projection.
+
+## Frozen inputs
+
+The checked-in fixture builder reproduces real Git commits from fixed files, author,
+timestamps, messages, modes, and SHA-1 object format.
+
+| Repository | Base commit | Scripted expected-result commit |
+|---|---|---|
+| Backend | `ce242c52841933788bc3b6a0a4e6c32ef38bf149` | `fdbb25c9dec30e47dbfbdeed193005150f1c63d7` |
+| Android | `a976d7c7967b3ef8e89cbd1b9add606e08dbbbca` | `6b5f8d29b22f4c4767fa7fd0ded01424f6457678` |
+
+Contract v1 is 371 exact UTF-8 bytes with SHA-256
+`ec4721811c959df1b7b2947b307c130104b67ec76adf74bcd00361732372f184`.
+Contract v2 is 542 bytes with SHA-256
+`d0eac237df4e364624eb5af7372c6beeadb566e939ccae9edec75920dd47ee11`.
+
+The initial Mission, exact contract locks, local verification registry, scripted
+proposal revision, and two explicit acknowledgement inputs are the kickoff boundary.
+Both fake adapters receive their complete outcome queues before the
+participant-acceptance event. After the single runner call starts, there is no
+owner-authored event, outcome injection, inbox nudge, blocked-input resolution, or
+participant selection by a human.
+
+## Golden transcript
+
+The canonical machine-readable projection is
+[`expected-transcript.json`](../../protocol/fixtures/backend-android/expected-transcript.json).
+
+| Mission sequence | Event | Contract |
+|---:|---|---:|
+| 1 | Both participants accept the exact kickoff manifest and contract | 1 |
+| 2 | Backend asks Android for nullable-avatar and fallback requirements | 1 |
+| 3 | Android answers; the same delivery is started twice and applied once | 1 |
+| 4 | Backend proposes contract v2 | 1 -> 2 pending |
+| 5 | The pre-kickoff plan supplies Backend's exact acknowledgement event | 2 pending |
+| 6 | The plan supplies Android's exact acknowledgement; v2 activates and Android owns the next turn | 2 |
+| 7 | Android reports compatible decoder/UI progress; consumer resumes from partial host replay | 2 |
+| 8 | Backend reports compatible response progress | 2 |
+| 9 | Android reports ready | 2 |
+| 10 | Backend reports ready; Mission enters verification | 2 |
+| 11 | Locally registered `backend-test` passes | 2 |
+| 12 | Locally registered `contract-test` passes | 2 |
+| 13 | Locally registered `android-test` passes | 2 |
+| 14 | Locally registered `public-user-scenario` passes; Mission completes | 2 |
+
+Only after completion does the separate hidden evaluator run. It exercises a profile
+name with leading and repeated whitespace that does not appear in runtime prompts or
+public acceptance data.
+
+## Observed result
+
+- Final state: `completed` on contract v2.
+- Host turns: 7.
+- Typed messages: 4 (`question`, `answer`, `progress`, `progress`).
+- Accepted contract revisions: 1.
+- Duplicate host starts suppressed: 1; host turns created for that delivery: 1.
+- Duplicate coordinator event and acknowledgement replay: no state mutation or turn
+  increment.
+- Partial host stream recoveries: 1, with the same contiguous stable event sequence.
+- Required registered checks passed: backend, Android, contract, and public scenario.
+- All four completion checks are fenced to verification round 1.
+- Hidden cross-repository evaluator: passed after Mission completion.
+- Human interventions after kickoff: 0 in the scripted event trace.
+- Replaying all 14 events into a fresh reducer yields a deep-equal final projection;
+  replaying them against the completed projection is a no-op.
+- A new delayed turn after completion is rejected.
+
+Run the proof with:
+
+```bash
+pnpm --filter @agentrelay/protocol exec vitest run \
+  src/testing/backend-android-transcript.test.ts
+```
+
+## What this does not prove
+
+The expected repository results and fake runtime dispositions are pre-authored. This
+does not prove that a coding model can discover or implement the solution, that a
+Postgres relay can transactionally persist and replay it, that receipts survive a
+process restart, that a Node enforces real local policy, that offline machines catch
+up, or that two devices communicate over A2A.
+
+Those are the next evidence gates: durable relay delivery, foreground Nodes with
+local journals and policy, then the pinned real-runtime two-machine pilot. The hidden
+check here measures only the scripted fixture result and never steers Mission
+completion.

--- a/docs/lld.md
+++ b/docs/lld.md
@@ -10,7 +10,7 @@
 ```text
 .
 ├── landing/             GitHub Pages landing page
-├── protocol/            Mission schemas, state machines, and adapter contract
+├── protocol/            Mission schemas, coordinator, fixtures, and adapter contract
 ├── relay/               Hono, Drizzle, Postgres relay
 ├── mcp-server/          agentrelay-mcp package and agentrelay CLI
 ├── tests/e2e/           relay plus two-MCP-process integration harness
@@ -20,7 +20,31 @@
 ```
 
 There is currently no `node/` daemon, persistent event consumer, or real runtime
-adapter. The executable Mission contracts and fake adapter live in `protocol/`.
+adapter. The executable Mission contracts, deterministic coordinator, fake adapter,
+and backend-Android proof fixture live in `protocol/`.
+
+## Protocol workspace
+
+`@agentrelay/protocol` currently implements:
+
+- strict Mission, contract, message, artifact, delivery, run, and evidence schemas;
+- pure Mission lifecycle and fenced-delivery reducers;
+- a replayable four-event coordinator boundary for participant acceptance, completed
+  turns, explicit contract acknowledgement, and local verification evidence;
+- one-current-participant routing, consecutive contract revision pause/activation,
+  contract-scoped readiness, required local command IDs, turn limits, terminal-event
+  rejection, verification-round fencing, and exact event/idempotency/delivery replay
+  handling;
+- a runtime-neutral host adapter plus deterministic fake; and
+- reproducible backend and Android fixture repositories, a golden 14-event transcript,
+  executable backend/Android/contract/public checks, and a separate hidden evaluator.
+
+The coordinator is pure and in memory. `applied_events` is test evidence, not a
+durable ledger or receipt store. The fixture uses pre-scripted fake outcomes, an
+explicit pre-kickoff acknowledgement queue, and pre-authored expected repository
+snapshots; it does not show a model writing code, a relay surviving restart, or two
+Nodes collaborating across machines. Exact evidence and nonclaims are recorded in
+[`experiment 001`](experiments/001-backend-android-deterministic-proof.md).
 
 ## Relay tables
 
@@ -315,6 +339,6 @@ command.
 ## Boundary with the next design
 
 Do not extend `accepted_by_session` or the four-state handoff table into a distributed
-runtime scheduler. The next slice introduces explicit Nodes, workspace bindings,
-Missions, events, deliveries, claims, runs, and acknowledgements while keeping the
-mailbox API as a compatibility and inspection surface.
+runtime scheduler. The next slice persists explicit Nodes, workspace bindings,
+Missions, events, deliveries, claims, runs, acknowledgements, and idempotency receipts
+while keeping the mailbox API as a compatibility and inspection surface.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -23,16 +23,22 @@ or trust gaps.
 - [x] Add Mission, participant, revision, typed message, artifact, policy, delivery,
   and run schemas.
 - [x] Add Mission and delivery state-machine transition tests.
-- [ ] Define one fake backend repository and one fake Android repository at frozen
+- [x] Define one fake backend repository and one fake Android repository at frozen
   commits.
-- [ ] Define a hidden cross-repository acceptance scenario.
+- [x] Define a hidden cross-repository acceptance scenario.
 - [x] Add a fake runtime adapter with duplicate, recovery, and cancellation tests.
-- [ ] Add deterministic transcript fixtures.
+- [x] Add a deterministic coordinator and transcript fixture with one accepted
+  contract revision, duplicate suppression, partial-stream recovery, registered
+  round-fenced verification, and zero scripted human interventions after kickoff.
 - [ ] Publish JSON Schema and OpenAPI bindings before a non-TypeScript Node or public
   A2A gateway consumes this contract.
 
 Keep this layer small. Do not implement multi-party Missions, parallel actors, smart
 routing, or provider-specific fields.
+
+Evidence for this checkpoint is in
+[`experiment 001`](experiments/001-backend-android-deterministic-proof.md). It is an
+in-memory scripted proof, not durable relay or real-runtime evidence.
 
 ## 3. Build durable delivery
 

--- a/docs/rfcs/001-agentrelay-node-and-missions.md
+++ b/docs/rfcs/001-agentrelay-node-and-missions.md
@@ -202,6 +202,11 @@ contract artifact, such as the API schema.
 
 - A participant proposes a new contract only as its turn disposition.
 - The relay pauses new turns while both participants acknowledge the new version.
+- A proposal does not implicitly acknowledge its proposer. Both authenticated
+  participants submit explicit coordinator acknowledgements for the exact revision
+  ID, version, artifact ID, and hash.
+- After both acknowledgements, the accepted version becomes active and the next turn
+  belongs deterministically to the participant opposite the proposer.
 - Revisions happen only between turns, so no host turn runs against two versions.
 - Every subsequent event records the accepted contract version.
 - Refusal or acknowledgement timeout moves the Mission to `blocked`, `cancelled`, or
@@ -307,10 +312,18 @@ The relay coordinator reduces typed events; it does not reason about repository 
   environment allowlist. Peer-provided shell strings are never executable authority.
 - Nodes submit pass/fail evidence. The relay completes only when every required local
   verification record passes for the current contract version.
-- A failed check returns the Mission to `active` if budget remains; otherwise it fails.
+- Every transition into `verifying` increments a verification round. Evidence must
+  name the active round, so a delayed result from an earlier readiness cycle cannot
+  complete a retry.
+- A failed check returns the Mission to `active` only when enough turn budget remains
+  for both participants to establish a fresh readiness cycle; otherwise it fails.
 
 The hidden evaluator used to measure the experiment is separate from public Mission
 acceptance. It does not influence the agents' shared contract or runtime completion.
+
+The Stage 1 implementation of these rules is a pure, replayable in-memory reducer.
+Durable receipts, transactional event append, and authenticated relay ingestion are
+part of the delivery-ledger slice, not implied by the fixture.
 
 ## Security invariants
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,6 +33,10 @@ and delivery guarantees.
 
 ## Stage 1: executable Mission contract
 
+**Status:** deterministic exit gate passed on 2026-08-02. See
+[`experiment 001`](experiments/001-backend-android-deterministic-proof.md). Durable
+relay delivery and real Nodes remain unproved.
+
 - Add a small shared protocol package or module with Mission, participant, message,
   artifact, delivery, run, and policy schemas.
 - Implement deterministic Mission and delivery state machines with invalid-transition

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -6,9 +6,13 @@ The package contains:
 
 - strict Zod schemas for Mission manifests, contract revisions, typed messages,
   artifact references, policy requests, delivery leases, runs, and evidence;
-- pure Mission and fenced-delivery reducers that reject invalid transitions; and
+- pure Mission, fenced-delivery, and deterministic coordinator reducers that reject
+  invalid transitions;
 - a runtime-neutral host adapter contract, with a deterministic fake under
-  `@agentrelay/protocol/testing`.
+  `@agentrelay/protocol/testing`; and
+- a packaged backend-Android fixture with reproducible Git commits, an accepted
+  contract revision, duplicate/recovery replay, executable verification, and a
+  post-completion hidden evaluator.
 
 Wire schemas use `snake_case`. Adapter lifecycle fields use local TypeScript naming;
 embedded relay payloads such as `TurnDisposition` and `ArtifactRef` deliberately keep
@@ -27,6 +31,16 @@ const next = transitionMissionStatus("awaiting_acceptance", {
 });
 ```
 
+`missionCoordinatorEventSchema` and `reduceMissionCoordinatorEvent` join the
+individually valid wire objects into one replayable Mission projection. The current
+coordinator slice allows one scheduled participant at a time. A contract proposal
+pauses turns, neither participant is implicitly acknowledged, both participant
+identities require explicit events for the exact revision artifact, and the next turn
+then belongs to the participant opposite the proposer. Each readiness cycle receives
+a new verification round, so delayed evidence from an older cycle is rejected.
+Required verification command IDs come from local coordinator configuration, never
+peer text. Authenticated event ingestion remains a relay responsibility.
+
 The adapter contract makes replay semantics explicit: every event has a stable
 turn-local sequence, available usage is a monotonic cumulative turn snapshot, and
 artifact input retains its version, source actor, exact hashed UTF-8 text, and a
@@ -43,8 +57,9 @@ with the lease deadline against durable delivery state before runtime
 start/recovery/cancellation and result publication; they are not copied into host turn
 references.
 
-This package defines data and state transitions. It does not persist Missions,
-execute policy, start a model runtime, or claim A2A conformance.
+This package defines data, state transitions, and an in-memory deterministic proof.
+It does not persist Missions or idempotency receipts, execute production policy,
+start a real model runtime, prove offline/restart recovery, or claim A2A conformance.
 
 Version 0.1 is the TypeScript/Zod binding used to prove the first Node. Committed
 JSON Schema and OpenAPI bindings remain required before a non-TypeScript Node or

--- a/protocol/fixtures/backend-android/README.md
+++ b/protocol/fixtures/backend-android/README.md
@@ -1,0 +1,25 @@
+# Backend and Android deterministic fixture
+
+This fixture proves the Stage 1 Mission-coordination contract without using a real
+coding-agent runtime.
+
+- `repositories/*/base` is the owner-approved starting checkout.
+- `repositories/*/expected` is the scripted fixture's review-ready result.
+- `repository-lock.json` records reproducible Git commit IDs for both snapshots.
+- `contract-lock.json` pins the exact artifact metadata, hashes, and byte sizes for
+  both contract versions.
+- `contracts/v1.json` is the kickoff contract; `v2.json` is the one accepted
+  revision.
+- `expected-transcript.json` is the golden coordinator projection and replay plan.
+- The TypeScript fixture declares the proposal revision and both exact
+  acknowledgement inputs before kickoff; the runner does not synthesize approval for
+  an arbitrary proposal.
+- `verification/public-user-scenario.mjs` is registered in local verification policy.
+- `verification/hidden-user-scenario.mjs` runs only after the Mission completes and
+  is never included in a host turn.
+
+The protocol test materializes each snapshot as a real Git repository with fixed
+author, timestamps, messages, file modes, and configuration, then checks the
+resulting commits against the lock file. The scripted result is evidence about
+deterministic coordination and replay, not evidence that a model wrote the changes
+or that relay persistence and cross-device Nodes already exist.

--- a/protocol/fixtures/backend-android/contract-lock.json
+++ b/protocol/fixtures/backend-android/contract-lock.json
@@ -1,0 +1,21 @@
+{
+	"schema_version": 1,
+	"contracts": {
+		"v1": {
+			"artifact_id": "10000000-0000-4000-8000-000000000005",
+			"type": "api_contract",
+			"version": 1,
+			"sha256": "ec4721811c959df1b7b2947b307c130104b67ec76adf74bcd00361732372f184",
+			"media_type": "application/schema+json",
+			"byte_size": 371
+		},
+		"v2": {
+			"artifact_id": "10000000-0000-4000-8000-000000000005",
+			"type": "api_contract",
+			"version": 2,
+			"sha256": "d0eac237df4e364624eb5af7372c6beeadb566e939ccae9edec75920dd47ee11",
+			"media_type": "application/schema+json",
+			"byte_size": 542
+		}
+	}
+}

--- a/protocol/fixtures/backend-android/contracts/v1.json
+++ b/protocol/fixtures/backend-android/contracts/v1.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"title": "ProfileResponse",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["id", "display_name", "avatar_url"],
+	"properties": {
+		"id": { "type": "string", "minLength": 1 },
+		"display_name": { "type": "string", "minLength": 1 },
+		"avatar_url": { "type": "string", "format": "uri" }
+	}
+}

--- a/protocol/fixtures/backend-android/contracts/v2.json
+++ b/protocol/fixtures/backend-android/contracts/v2.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"title": "ProfileResponse",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["id", "display_name", "avatar_url"],
+	"properties": {
+		"id": { "type": "string", "minLength": 1 },
+		"display_name": { "type": "string", "minLength": 1 },
+		"avatar_url": {
+			"oneOf": [{ "type": "string", "format": "uri" }, { "type": "null" }]
+		}
+	},
+	"x-avatar-fallback": "When avatar_url is null, show uppercase initials from the first and last non-empty display_name segments."
+}

--- a/protocol/fixtures/backend-android/expected-transcript.json
+++ b/protocol/fixtures/backend-android/expected-transcript.json
@@ -1,0 +1,127 @@
+{
+	"schema_version": 1,
+	"events": [
+		{
+			"sequence_no": 1,
+			"type": "participants_accepted",
+			"contract_version": 1
+		},
+		{
+			"sequence_no": 2,
+			"type": "turn_completed",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000003",
+			"contract_version": 1,
+			"disposition_kind": "reply",
+			"message_type": "question"
+		},
+		{
+			"sequence_no": 3,
+			"type": "turn_completed",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000004",
+			"contract_version": 1,
+			"disposition_kind": "reply",
+			"message_type": "answer"
+		},
+		{
+			"sequence_no": 4,
+			"type": "turn_completed",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000003",
+			"contract_version": 1,
+			"disposition_kind": "propose_contract",
+			"proposed_contract_version": 2
+		},
+		{
+			"sequence_no": 5,
+			"type": "contract_acknowledged",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000003",
+			"contract_version": 2
+		},
+		{
+			"sequence_no": 6,
+			"type": "contract_acknowledged",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000004",
+			"contract_version": 2
+		},
+		{
+			"sequence_no": 7,
+			"type": "turn_completed",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000004",
+			"contract_version": 2,
+			"disposition_kind": "reply",
+			"message_type": "progress"
+		},
+		{
+			"sequence_no": 8,
+			"type": "turn_completed",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000003",
+			"contract_version": 2,
+			"disposition_kind": "reply",
+			"message_type": "progress"
+		},
+		{
+			"sequence_no": 9,
+			"type": "turn_completed",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000004",
+			"contract_version": 2,
+			"disposition_kind": "ready"
+		},
+		{
+			"sequence_no": 10,
+			"type": "turn_completed",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000003",
+			"contract_version": 2,
+			"disposition_kind": "ready"
+		},
+		{
+			"sequence_no": 11,
+			"type": "verification_recorded",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000003",
+			"contract_version": 2,
+			"verification_round": 1,
+			"command_id": "backend-test"
+		},
+		{
+			"sequence_no": 12,
+			"type": "verification_recorded",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000003",
+			"contract_version": 2,
+			"verification_round": 1,
+			"command_id": "contract-test"
+		},
+		{
+			"sequence_no": 13,
+			"type": "verification_recorded",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000004",
+			"contract_version": 2,
+			"verification_round": 1,
+			"command_id": "android-test"
+		},
+		{
+			"sequence_no": 14,
+			"type": "verification_recorded",
+			"participant_agent_id": "10000000-0000-4000-8000-000000000004",
+			"contract_version": 2,
+			"verification_round": 1,
+			"command_id": "public-user-scenario"
+		}
+	],
+	"delivery_replays": [
+		{
+			"delivery_id": "30000000-0000-4000-8000-000000000002",
+			"mode": "duplicate_start"
+		},
+		{
+			"delivery_id": "30000000-0000-4000-8000-000000000004",
+			"mode": "recover_after_partial"
+		}
+	],
+	"expected": {
+		"status": "completed",
+		"contract_version": 2,
+		"turn_count": 7,
+		"message_count": 4,
+		"accepted_revision_count": 1,
+		"human_interventions": 0,
+		"hidden_user_scenario": "passed_after_completion"
+	}
+}

--- a/protocol/fixtures/backend-android/manifest.json
+++ b/protocol/fixtures/backend-android/manifest.json
@@ -1,0 +1,44 @@
+{
+	"schema_version": 1,
+	"mission_id": "10000000-0000-4000-8000-000000000001",
+	"objective": "Make the backend profile response and Android profile UI compatible when an avatar is absent.",
+	"public_acceptance_criteria": [
+		"The backend emits the accepted profile contract.",
+		"The Android client renders a deterministic initials fallback for a missing avatar.",
+		"The public cross-repository user scenario passes."
+	],
+	"participants": [
+		{
+			"agent_id": "10000000-0000-4000-8000-000000000003",
+			"role": "backend",
+			"workspace_alias": "profile-backend",
+			"repository_url": "https://fixtures.agentrelay.dev/backend-profile.git",
+			"expected_base_commit": "ce242c52841933788bc3b6a0a4e6c32ef38bf149",
+			"initial_assignment": "Own the profile response and propose any shared-contract change required by Android.",
+			"requested_local_policy_profile": "fixture-coding"
+		},
+		{
+			"agent_id": "10000000-0000-4000-8000-000000000004",
+			"role": "android",
+			"workspace_alias": "profile-android",
+			"repository_url": "https://fixtures.agentrelay.dev/android-profile.git",
+			"expected_base_commit": "a976d7c7967b3ef8e89cbd1b9add606e08dbbbca",
+			"initial_assignment": "Own profile decoding and UI fallback behavior against the accepted contract.",
+			"requested_local_policy_profile": "fixture-coding"
+		}
+	],
+	"shared_contract": {
+		"artifact_id": "10000000-0000-4000-8000-000000000005",
+		"type": "api_contract",
+		"version": 1,
+		"sha256": "ec4721811c959df1b7b2947b307c130104b67ec76adf74bcd00361732372f184",
+		"media_type": "application/schema+json",
+		"byte_size": 371
+	},
+	"max_turns": 12,
+	"max_wall_time_seconds": 3600,
+	"token_budget": 100000,
+	"expires_at": "2026-08-03T10:00:00.000Z",
+	"allowed_artifact_types": ["api_contract", "patch", "verification_report"],
+	"created_at": "2026-08-02T10:00:00.000Z"
+}

--- a/protocol/fixtures/backend-android/repositories/android/base/package.json
+++ b/protocol/fixtures/backend-android/repositories/android/base/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "agentrelay-fixture-android",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"verify": "node verify.mjs"
+	}
+}

--- a/protocol/fixtures/backend-android/repositories/android/base/src/profile-client.mjs
+++ b/protocol/fixtures/backend-android/repositories/android/base/src/profile-client.mjs
@@ -1,0 +1,10 @@
+export function renderProfile(profile) {
+	if (typeof profile.avatar_url !== "string") {
+		throw new TypeError("avatar_url must be a string");
+	}
+
+	return {
+		title: profile.display_name,
+		avatar: { kind: "remote", url: profile.avatar_url },
+	};
+}

--- a/protocol/fixtures/backend-android/repositories/android/base/verify.mjs
+++ b/protocol/fixtures/backend-android/repositories/android/base/verify.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { renderProfile } from "./src/profile-client.mjs";
+
+assert.deepEqual(
+	renderProfile({
+		id: "user-42",
+		display_name: "Ada Lovelace",
+		avatar_url: "https://images.example.test/profiles/default.png",
+	}),
+	{
+		title: "Ada Lovelace",
+		avatar: {
+			kind: "remote",
+			url: "https://images.example.test/profiles/default.png",
+		},
+	},
+);

--- a/protocol/fixtures/backend-android/repositories/android/expected/package.json
+++ b/protocol/fixtures/backend-android/repositories/android/expected/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "agentrelay-fixture-android",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"verify": "node verify.mjs"
+	}
+}

--- a/protocol/fixtures/backend-android/repositories/android/expected/src/profile-client.mjs
+++ b/protocol/fixtures/backend-android/repositories/android/expected/src/profile-client.mjs
@@ -1,0 +1,22 @@
+function initials(displayName) {
+	const segments = displayName.trim().split(/\s+/u).filter(Boolean);
+	const selected = segments.length <= 1 ? segments : [segments[0], segments.at(-1)];
+	return selected
+		.map((segment) => Array.from(segment ?? "")[0] ?? "")
+		.join("")
+		.toUpperCase();
+}
+
+export function renderProfile(profile) {
+	if (typeof profile.avatar_url !== "string" && profile.avatar_url !== null) {
+		throw new TypeError("avatar_url must be a string or null");
+	}
+
+	return {
+		title: profile.display_name,
+		avatar:
+			profile.avatar_url === null
+				? { kind: "initials", value: initials(profile.display_name) }
+				: { kind: "remote", url: profile.avatar_url },
+	};
+}

--- a/protocol/fixtures/backend-android/repositories/android/expected/verify.mjs
+++ b/protocol/fixtures/backend-android/repositories/android/expected/verify.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { renderProfile } from "./src/profile-client.mjs";
+
+assert.deepEqual(
+	renderProfile({
+		id: "user-42",
+		display_name: "Ada Lovelace",
+		avatar_url: null,
+	}),
+	{
+		title: "Ada Lovelace",
+		avatar: { kind: "initials", value: "AL" },
+	},
+);

--- a/protocol/fixtures/backend-android/repositories/backend/base/package.json
+++ b/protocol/fixtures/backend-android/repositories/backend/base/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "agentrelay-fixture-backend",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"verify": "node verify.mjs"
+	}
+}

--- a/protocol/fixtures/backend-android/repositories/backend/base/src/profile.mjs
+++ b/protocol/fixtures/backend-android/repositories/backend/base/src/profile.mjs
@@ -1,0 +1,7 @@
+export function getProfile(id, displayName = "Ada Lovelace") {
+	return {
+		id,
+		display_name: displayName,
+		avatar_url: "https://images.example.test/profiles/default.png",
+	};
+}

--- a/protocol/fixtures/backend-android/repositories/backend/base/verify.mjs
+++ b/protocol/fixtures/backend-android/repositories/backend/base/verify.mjs
@@ -1,0 +1,7 @@
+import assert from "node:assert/strict";
+import { getProfile } from "./src/profile.mjs";
+
+const profile = getProfile("user-42");
+assert.equal(profile.id, "user-42");
+assert.equal(typeof profile.display_name, "string");
+assert.equal(typeof profile.avatar_url, "string");

--- a/protocol/fixtures/backend-android/repositories/backend/expected/package.json
+++ b/protocol/fixtures/backend-android/repositories/backend/expected/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "agentrelay-fixture-backend",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"verify": "node verify.mjs"
+	}
+}

--- a/protocol/fixtures/backend-android/repositories/backend/expected/src/profile.mjs
+++ b/protocol/fixtures/backend-android/repositories/backend/expected/src/profile.mjs
@@ -1,0 +1,7 @@
+export function getProfile(id, { displayName = "Ada Lovelace", avatarUrl = null } = {}) {
+	return {
+		id,
+		display_name: displayName,
+		avatar_url: avatarUrl,
+	};
+}

--- a/protocol/fixtures/backend-android/repositories/backend/expected/verify.mjs
+++ b/protocol/fixtures/backend-android/repositories/backend/expected/verify.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import { getProfile } from "./src/profile.mjs";
+
+const profile = getProfile("user-42");
+assert.deepEqual(profile, {
+	id: "user-42",
+	display_name: "Ada Lovelace",
+	avatar_url: null,
+});

--- a/protocol/fixtures/backend-android/repository-lock.json
+++ b/protocol/fixtures/backend-android/repository-lock.json
@@ -1,0 +1,15 @@
+{
+	"schema_version": 1,
+	"repositories": {
+		"backend": {
+			"repository_url": "https://fixtures.agentrelay.dev/backend-profile.git",
+			"base_commit": "ce242c52841933788bc3b6a0a4e6c32ef38bf149",
+			"expected_commit": "fdbb25c9dec30e47dbfbdeed193005150f1c63d7"
+		},
+		"android": {
+			"repository_url": "https://fixtures.agentrelay.dev/android-profile.git",
+			"base_commit": "a976d7c7967b3ef8e89cbd1b9add606e08dbbbca",
+			"expected_commit": "6b5f8d29b22f4c4767fa7fd0ded01424f6457678"
+		}
+	}
+}

--- a/protocol/fixtures/backend-android/verification/hidden-user-scenario.mjs
+++ b/protocol/fixtures/backend-android/verification/hidden-user-scenario.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [backendRoot, androidRoot] = process.argv.slice(2);
+assert.ok(backendRoot, "backend workspace is required");
+assert.ok(androidRoot, "Android workspace is required");
+
+const { getProfile } = await import(pathToFileURL(join(backendRoot, "src/profile.mjs")).href);
+const { renderProfile } = await import(
+	pathToFileURL(join(androidRoot, "src/profile-client.mjs")).href
+);
+
+const rendered = renderProfile(
+	getProfile("hidden-user", { displayName: "  Grace   Brewster   Hopper  " }),
+);
+assert.deepEqual(rendered, {
+	title: "  Grace   Brewster   Hopper  ",
+	avatar: { kind: "initials", value: "GH" },
+});

--- a/protocol/fixtures/backend-android/verification/public-user-scenario.mjs
+++ b/protocol/fixtures/backend-android/verification/public-user-scenario.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const [backendRoot, androidRoot] = process.argv.slice(2);
+assert.ok(backendRoot, "backend workspace is required");
+assert.ok(androidRoot, "Android workspace is required");
+
+const { getProfile } = await import(pathToFileURL(join(backendRoot, "src/profile.mjs")).href);
+const { renderProfile } = await import(
+	pathToFileURL(join(androidRoot, "src/profile-client.mjs")).href
+);
+
+const rendered = renderProfile(getProfile("user-42"));
+assert.deepEqual(rendered, {
+	title: "Ada Lovelace",
+	avatar: { kind: "initials", value: "AL" },
+});

--- a/protocol/fixtures/backend-android/verification/verify-contract.mjs
+++ b/protocol/fixtures/backend-android/verification/verify-contract.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [contractPath] = process.argv.slice(2);
+assert.ok(contractPath, "contract path is required");
+
+const contract = JSON.parse(await readFile(contractPath, "utf8"));
+assert.deepEqual(contract.required, ["id", "display_name", "avatar_url"]);
+assert.deepEqual(contract.properties.avatar_url.oneOf, [
+	{ type: "string", format: "uri" },
+	{ type: "null" },
+]);
+assert.match(contract["x-avatar-fallback"], /first and last non-empty/u);

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -19,12 +19,12 @@
 			"import": "./dist/testing/index.js"
 		}
 	},
-	"files": ["dist"],
+	"files": ["dist", "fixtures"],
 	"scripts": {
 		"build": "tsc -p tsconfig.json",
 		"prepack": "pnpm run build",
 		"test": "vitest run",
-		"test:exports": "node --input-type=module -e \"const p = await import('@agentrelay/protocol'); const t = await import('@agentrelay/protocol/testing'); if (!p.missionManifestSchema || !p.transitionDeliveryState || !p.acceptHostEvent || !t.FakeAgentHostAdapter) throw new Error('protocol exports missing')\"",
+		"test:exports": "node --input-type=module -e \"const p = await import('@agentrelay/protocol'); const t = await import('@agentrelay/protocol/testing'); if (!p.missionManifestSchema || !p.transitionDeliveryState || !p.acceptHostEvent || !p.missionCoordinatorEventSchema || !t.FakeAgentHostAdapter || !t.runMissionFixture || !t.backendAndroidMissionFixture) throw new Error('protocol exports missing')\"",
 		"test:watch": "vitest",
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},

--- a/protocol/src/index.ts
+++ b/protocol/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./adapter.js";
+export * from "./mission-coordinator.js";
 export * from "./schemas.js";
 export * from "./state-machines.js";

--- a/protocol/src/mission-coordinator.test.ts
+++ b/protocol/src/mission-coordinator.test.ts
@@ -1,0 +1,607 @@
+import { describe, expect, it } from "vitest";
+import {
+	InvalidMissionCoordinatorEventError,
+	createMissionCoordinatorState,
+	missionCoordinatorEventSchema,
+	reduceMissionCoordinatorEvent,
+	replayMissionCoordinatorEvents,
+} from "./mission-coordinator.js";
+
+const IDS = {
+	mission: "00000000-0000-4000-8000-000000000001",
+	owner: "00000000-0000-4000-8000-000000000002",
+	backend: "00000000-0000-4000-8000-000000000003",
+	android: "00000000-0000-4000-8000-000000000004",
+	outsider: "00000000-0000-4000-8000-000000000005",
+	artifact: "00000000-0000-4000-8000-000000000006",
+	revision: "00000000-0000-4000-8000-000000000007",
+	message1: "00000000-0000-4000-8000-000000000008",
+	message2: "00000000-0000-4000-8000-000000000009",
+} as const;
+
+const CONTRACT_V1 = {
+	artifact_id: IDS.artifact,
+	type: "api_contract",
+	version: 1,
+	sha256: "a".repeat(64),
+	media_type: "application/json",
+	byte_size: 128,
+};
+
+const CONTRACT_V2 = {
+	...CONTRACT_V1,
+	version: 2,
+	sha256: "b".repeat(64),
+	byte_size: 144,
+};
+
+const CONFIG = {
+	mission_context: {
+		manifest: {
+			schema_version: 1,
+			mission_id: IDS.mission,
+			objective: "Ship compatible backend and Android changes.",
+			public_acceptance_criteria: ["Both repositories pass the shared contract fixture."],
+			participants: [
+				{
+					agent_id: IDS.backend,
+					role: "backend",
+					workspace_alias: "backend-api",
+					repository_url: "https://github.com/acme/backend.git",
+					expected_base_commit: "1".repeat(40),
+					initial_assignment: "Implement the backend contract.",
+					requested_local_policy_profile: "coding",
+				},
+				{
+					agent_id: IDS.android,
+					role: "android",
+					workspace_alias: "android-app",
+					repository_url: "https://github.com/acme/android.git",
+					expected_base_commit: "2".repeat(40),
+					initial_assignment: "Consume the backend contract.",
+					requested_local_policy_profile: "coding",
+				},
+			],
+			shared_contract: CONTRACT_V1,
+			max_turns: 12,
+			max_wall_time_seconds: 7_200,
+			token_budget: 200_000,
+			expires_at: "2026-08-03T10:00:00.000Z",
+			allowed_artifact_types: ["api_contract", "patch", "verification_report"],
+			created_at: "2026-08-02T10:00:00.000Z",
+		},
+		created_by: { principal_id: IDS.owner, kind: "owner" },
+	},
+	required_verification_commands: {
+		[IDS.backend]: ["backend-contract"],
+		[IDS.android]: ["android-contract"],
+	},
+};
+
+describe("Mission coordinator", () => {
+	it("starts only from exact participant and contract acceptance", () => {
+		const initial = createMissionCoordinatorState(CONFIG);
+		const event = acceptedEvent(1);
+		const active = reduceMissionCoordinatorEvent(initial, event);
+
+		expect(initial).toMatchObject({
+			status: "awaiting_acceptance",
+			sequence_no: 0,
+			turn_count: 0,
+			current_participant_agent_id: null,
+		});
+		expect(active).toMatchObject({
+			status: "active",
+			sequence_no: 1,
+			turn_count: 0,
+			contract_version: 1,
+			current_participant_agent_id: IDS.backend,
+		});
+		event.contract.sha256 = "f".repeat(64);
+		expect(active.applied_events[0]).toMatchObject({
+			type: "participants_accepted",
+			contract: { sha256: CONTRACT_V1.sha256 },
+		});
+
+		expect(() =>
+			reduceMissionCoordinatorEvent(initial, {
+				...acceptedEvent(1),
+				participant_agent_ids: [IDS.backend, IDS.outsider],
+			}),
+		).toThrow(InvalidMissionCoordinatorEventError);
+		expect(() =>
+			reduceMissionCoordinatorEvent(initial, {
+				...acceptedEvent(1),
+				contract: { ...CONTRACT_V1, sha256: "c".repeat(64) },
+			}),
+		).toThrow(InvalidMissionCoordinatorEventError);
+		expect(
+			missionCoordinatorEventSchema.safeParse({ ...acceptedEvent(1), remote_path: "/tmp/repo" })
+				.success,
+		).toBe(false);
+		expect(
+			missionCoordinatorEventSchema.safeParse({
+				...acceptedEvent(1),
+				event_id: "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects Mission mismatches, sequence gaps, and invalid turn companions", () => {
+		const initial = createMissionCoordinatorState(CONFIG);
+		expect(() =>
+			reduceMissionCoordinatorEvent(initial, {
+				...acceptedEvent(1),
+				mission_id: IDS.outsider,
+			}),
+		).toThrow(/mission_mismatch/);
+		expect(() => reduceMissionCoordinatorEvent(initial, acceptedEvent(2))).toThrow(/sequence/);
+
+		const reply = replyTurn(2, IDS.backend, 1, IDS.message1, null, "Reply.");
+		const proposal = proposalTurn(2);
+		const ready = readyTurn(2, IDS.backend, 1);
+		expect(missionCoordinatorEventSchema.safeParse({ ...reply, message: null }).success).toBe(
+			false,
+		);
+		expect(missionCoordinatorEventSchema.safeParse({ ...proposal, revision: null }).success).toBe(
+			false,
+		);
+		expect(
+			missionCoordinatorEventSchema.safeParse({ ...ready, message: reply.message }).success,
+		).toBe(false);
+		expect(
+			missionCoordinatorEventSchema.safeParse({
+				...ready,
+				disposition: { kind: "blocked", reason: "waiting", requested_input: "owner" },
+			}).success,
+		).toBe(false);
+		expect(
+			missionCoordinatorEventSchema.safeParse({
+				...ready,
+				disposition: { kind: "failed", class: "permanent" },
+			}).success,
+		).toBe(false);
+	});
+
+	it("pauses a proposal for two explicit acknowledgements and completes a fresh replay", () => {
+		const events: unknown[] = [acceptedEvent(1), proposalTurn(2)];
+		let state = replayMissionCoordinatorEvents(CONFIG, events);
+
+		expect(state).toMatchObject({
+			status: "active",
+			turn_count: 1,
+			current_participant_agent_id: null,
+			pending_revision: {
+				version: 2,
+				proposed_by_agent_id: IDS.backend,
+				acknowledged_by_agent_ids: [],
+			},
+		});
+		expect(() => reduceMissionCoordinatorEvent(state, readyTurn(3, IDS.android, 1))).toThrow(
+			InvalidMissionCoordinatorEventError,
+		);
+		expect(() => reduceMissionCoordinatorEvent(state, acknowledgement(3, IDS.outsider))).toThrow(
+			InvalidMissionCoordinatorEventError,
+		);
+		expect(() =>
+			reduceMissionCoordinatorEvent(state, {
+				...acknowledgement(3, IDS.backend),
+				artifact: { ...CONTRACT_V2, sha256: "c".repeat(64) },
+			}),
+		).toThrow(InvalidMissionCoordinatorEventError);
+
+		const backendAck = acknowledgement(3, IDS.backend);
+		state = reduceMissionCoordinatorEvent(state, backendAck);
+		events.push(backendAck);
+		expect(state.pending_revision?.acknowledged_by_agent_ids).toEqual([IDS.backend]);
+		expect(reduceMissionCoordinatorEvent(state, backendAck)).toBe(state);
+		expect(() => reduceMissionCoordinatorEvent(state, acknowledgement(4, IDS.backend))).toThrow(
+			InvalidMissionCoordinatorEventError,
+		);
+
+		const androidAck = acknowledgement(4, IDS.android);
+		state = reduceMissionCoordinatorEvent(state, androidAck);
+		events.push(androidAck);
+		expect(state).toMatchObject({
+			contract_version: 2,
+			active_contract: CONTRACT_V2,
+			pending_revision: null,
+			current_participant_agent_id: IDS.android,
+		});
+		expect(state.accepted_revisions[0]?.acknowledged_by_agent_ids).toEqual([
+			IDS.backend,
+			IDS.android,
+		]);
+		expect(() => reduceMissionCoordinatorEvent(state, readyTurn(5, IDS.android, 1))).toThrow(
+			InvalidMissionCoordinatorEventError,
+		);
+
+		const reply = replyTurn(5, IDS.android, 2, IDS.message1, null, "Use response field v2.");
+		const backendReady = readyTurn(6, IDS.backend, 2);
+		const androidReady = readyTurn(7, IDS.android, 2);
+		const backendVerified = verificationEvent(8, IDS.backend, 2, "backend-contract");
+		const androidVerified = verificationEvent(9, IDS.android, 2, "android-contract");
+		for (const event of [reply, backendReady, androidReady, backendVerified, androidVerified]) {
+			state = reduceMissionCoordinatorEvent(state, event);
+			events.push(event);
+		}
+
+		expect(state).toMatchObject({
+			status: "completed",
+			sequence_no: 9,
+			turn_count: 4,
+			current_participant_agent_id: null,
+			ready_agent_ids: [IDS.backend, IDS.android],
+		});
+		expect(state.verification_records).toHaveLength(2);
+		expect(replayMissionCoordinatorEvents(CONFIG, events)).toEqual(state);
+		expect(() =>
+			reduceMissionCoordinatorEvent(
+				state,
+				replyTurn(10, IDS.backend, 2, IDS.message2, IDS.message1, "Delayed output."),
+			),
+		).toThrow(InvalidMissionCoordinatorEventError);
+	});
+
+	it("rejects pre-acknowledged revisions and changed contract identity", () => {
+		const active = replayMissionCoordinatorEvents(CONFIG, [acceptedEvent(1)]);
+		const preAcknowledged = proposalTurn(2);
+		preAcknowledged.revision.acknowledged_by_agent_ids = [IDS.backend];
+		expect(() => reduceMissionCoordinatorEvent(active, preAcknowledged)).toThrow(
+			/revision_mismatch/,
+		);
+
+		const changedIdentity = proposalTurn(2);
+		changedIdentity.disposition.artifact.artifact_id = IDS.outsider;
+		changedIdentity.revision.artifact.artifact_id = IDS.outsider;
+		expect(() => reduceMissionCoordinatorEvent(active, changedIdentity)).toThrow(
+			/revision_contract_identity/,
+		);
+	});
+
+	it("validates reply Messages, current-participant routing, and delivery identity", () => {
+		const active = replayMissionCoordinatorEvents(CONFIG, [acceptedEvent(1)]);
+		const firstReply = replyTurn(2, IDS.backend, 1, IDS.message1, null, "Backend is ready.");
+
+		expect(() =>
+			reduceMissionCoordinatorEvent(
+				active,
+				replyTurn(2, IDS.android, 1, IDS.message1, null, "Wrong participant."),
+			),
+		).toThrow(InvalidMissionCoordinatorEventError);
+		expect(() =>
+			reduceMissionCoordinatorEvent(active, {
+				...firstReply,
+				message: { ...firstReply.message, body: "Does not match the disposition." },
+			}),
+		).toThrow(InvalidMissionCoordinatorEventError);
+
+		const replied = reduceMissionCoordinatorEvent(active, firstReply);
+		expect(replied.current_participant_agent_id).toBe(IDS.android);
+		expect(replied.turn_count).toBe(1);
+		expect(reduceMissionCoordinatorEvent(replied, firstReply)).toBe(replied);
+
+		const identityConflict = replyTurn(
+			3,
+			IDS.android,
+			1,
+			IDS.message2,
+			IDS.message1,
+			"Android is ready.",
+		);
+		identityConflict.event_id = firstReply.event_id;
+		expect(() => reduceMissionCoordinatorEvent(replied, identityConflict)).toThrow(
+			/event_identity_conflict/,
+		);
+		identityConflict.event_id = eventId(3);
+		identityConflict.idempotency_key = firstReply.idempotency_key;
+		expect(() => reduceMissionCoordinatorEvent(replied, identityConflict)).toThrow(
+			/event_identity_conflict/,
+		);
+
+		const deliveryConflict = replyTurn(
+			3,
+			IDS.android,
+			1,
+			IDS.message2,
+			IDS.message1,
+			"Android is ready.",
+		);
+		deliveryConflict.delivery_id = firstReply.delivery_id;
+		expect(() => reduceMissionCoordinatorEvent(replied, deliveryConflict)).toThrow(
+			/delivery_conflict/,
+		);
+	});
+
+	it("scopes readiness and locally registered verification to the active contract", () => {
+		let state = replayMissionCoordinatorEvents(CONFIG, [
+			acceptedEvent(1),
+			readyTurn(2, IDS.backend, 1),
+			readyTurn(3, IDS.android, 1),
+		]);
+		expect(state).toMatchObject({ status: "verifying", current_participant_agent_id: null });
+
+		expect(() =>
+			reduceMissionCoordinatorEvent(
+				state,
+				verificationEvent(4, IDS.backend, 2, "backend-contract"),
+			),
+		).toThrow(/contract_version/);
+		expect(() =>
+			reduceMissionCoordinatorEvent(state, verificationEvent(4, IDS.backend, 1, "unregistered")),
+		).toThrow(/verification_command/);
+
+		state = reduceMissionCoordinatorEvent(
+			state,
+			verificationEvent(4, IDS.backend, 1, "backend-contract", "failed"),
+		);
+		expect(state).toMatchObject({
+			status: "active",
+			current_participant_agent_id: IDS.backend,
+			ready_agent_ids: [],
+			verification_records: [],
+		});
+
+		state = reduceMissionCoordinatorEvent(state, readyTurn(5, IDS.backend, 1));
+		state = reduceMissionCoordinatorEvent(state, readyTurn(6, IDS.android, 1));
+		expect(state.verification_round).toBe(2);
+		expect(() =>
+			reduceMissionCoordinatorEvent(
+				state,
+				verificationEvent(7, IDS.backend, 1, "backend-contract", "passed", 1),
+			),
+		).toThrow(/verification_round/);
+
+		const reusedVerificationId = verificationEvent(
+			7,
+			IDS.backend,
+			1,
+			"backend-contract",
+			"passed",
+			2,
+		);
+		reusedVerificationId.evidence.verification_id = verificationId(4);
+		expect(() => reduceMissionCoordinatorEvent(state, reusedVerificationId)).toThrow(
+			/verification_conflict/,
+		);
+	});
+
+	it("clears stale readiness after peer work and rejects duplicate commands in one round", () => {
+		let state = replayMissionCoordinatorEvents(CONFIG, [
+			acceptedEvent(1),
+			readyTurn(2, IDS.backend, 1),
+		]);
+		state = reduceMissionCoordinatorEvent(
+			state,
+			replyTurn(3, IDS.android, 1, IDS.message1, null, "Android changed the contract consumer."),
+		);
+		expect(state).toMatchObject({
+			status: "active",
+			current_participant_agent_id: IDS.backend,
+			ready_agent_ids: [],
+		});
+
+		state = reduceMissionCoordinatorEvent(state, readyTurn(4, IDS.backend, 1));
+		state = reduceMissionCoordinatorEvent(state, readyTurn(5, IDS.android, 1));
+		state = reduceMissionCoordinatorEvent(
+			state,
+			verificationEvent(6, IDS.backend, 1, "backend-contract"),
+		);
+		expect(() =>
+			reduceMissionCoordinatorEvent(
+				state,
+				verificationEvent(7, IDS.backend, 1, "backend-contract"),
+			),
+		).toThrow(/verification_conflict/);
+	});
+
+	it.each([2, 3])(
+		"fails verification when a max-turn budget of %i cannot fund another readiness round",
+		(maxTurns) => {
+			const boundedConfig = structuredClone(CONFIG);
+			boundedConfig.mission_context.manifest.max_turns = maxTurns;
+			const verifying = replayMissionCoordinatorEvents(boundedConfig, [
+				acceptedEvent(1),
+				readyTurn(2, IDS.backend, 1),
+				readyTurn(3, IDS.android, 1),
+			]);
+
+			const failed = reduceMissionCoordinatorEvent(
+				verifying,
+				verificationEvent(4, IDS.backend, 1, "backend-contract", "failed"),
+			);
+
+			expect(failed).toMatchObject({
+				status: "failed",
+				turn_count: 2,
+				current_participant_agent_id: null,
+				ready_agent_ids: [],
+				verification_records: [],
+			});
+		},
+	);
+
+	it.each(["reply", "ready", "proposal"] as const)(
+		"fails after a final %s turn instead of leaving an unschedulable Mission",
+		(disposition) => {
+			const oneTurnConfig = structuredClone(CONFIG);
+			oneTurnConfig.mission_context.manifest.max_turns = 1;
+			const active = replayMissionCoordinatorEvents(oneTurnConfig, [acceptedEvent(1)]);
+			const finalTurn =
+				disposition === "reply"
+					? replyTurn(2, IDS.backend, 1, IDS.message1, null, "Final turn.")
+					: disposition === "ready"
+						? readyTurn(2, IDS.backend, 1)
+						: proposalTurn(2);
+
+			const failed = reduceMissionCoordinatorEvent(active, finalTurn);
+
+			expect(failed).toMatchObject({
+				status: "failed",
+				turn_count: 1,
+				pending_revision: null,
+				current_participant_agent_id: null,
+				ready_agent_ids: [],
+			});
+			expect(reduceMissionCoordinatorEvent(failed, finalTurn)).toBe(failed);
+		},
+	);
+
+	it("does not count exact replay against the turn budget", () => {
+		const twoTurnConfig = structuredClone(CONFIG);
+		twoTurnConfig.mission_context.manifest.max_turns = 2;
+		const active = replayMissionCoordinatorEvents(twoTurnConfig, [acceptedEvent(1)]);
+		const firstReply = replyTurn(2, IDS.backend, 1, IDS.message1, null, "First turn.");
+		const afterFirst = reduceMissionCoordinatorEvent(active, firstReply);
+
+		expect(reduceMissionCoordinatorEvent(afterFirst, firstReply)).toBe(afterFirst);
+		expect(afterFirst).toMatchObject({ status: "active", turn_count: 1 });
+	});
+});
+
+function acceptedEvent(sequence: number) {
+	return {
+		...envelope(sequence),
+		type: "participants_accepted" as const,
+		participant_agent_ids: [IDS.backend, IDS.android],
+		contract: structuredClone(CONTRACT_V1),
+	};
+}
+
+function proposalTurn(sequence: number) {
+	const revision = {
+		revision_id: IDS.revision,
+		mission_id: IDS.mission,
+		previous_version: 1,
+		version: 2,
+		artifact: structuredClone(CONTRACT_V2),
+		proposed_by_agent_id: IDS.backend,
+		acknowledged_by_agent_ids: [],
+		idempotency_key: "revision:2",
+		created_at: timestamp(sequence),
+	};
+	return {
+		...envelope(sequence),
+		type: "turn_completed" as const,
+		participant_agent_id: IDS.backend,
+		delivery_id: deliveryId(sequence),
+		contract_version: 1,
+		disposition: { kind: "propose_contract" as const, artifact: structuredClone(CONTRACT_V2) },
+		message: null,
+		revision,
+	};
+}
+
+function acknowledgement(sequence: number, participantAgentId: string) {
+	return {
+		...envelope(sequence),
+		type: "contract_acknowledged" as const,
+		participant_agent_id: participantAgentId,
+		revision_id: IDS.revision,
+		contract_version: 2,
+		artifact: structuredClone(CONTRACT_V2),
+	};
+}
+
+function replyTurn(
+	sequence: number,
+	participantAgentId: string,
+	contractVersion: number,
+	messageId: string,
+	parentMessageId: string | null,
+	body: string,
+) {
+	return {
+		...envelope(sequence),
+		type: "turn_completed" as const,
+		participant_agent_id: participantAgentId,
+		delivery_id: deliveryId(sequence),
+		contract_version: contractVersion,
+		disposition: { kind: "reply" as const, message_type: "progress" as const, message: body },
+		message: {
+			message_id: messageId,
+			mission_id: IDS.mission,
+			sequence_no: parentMessageId === null ? 1 : 2,
+			author_agent_id: participantAgentId,
+			type: "progress" as const,
+			body,
+			artifacts: [],
+			contract_version: contractVersion,
+			idempotency_key: `message:${sequence}`,
+			causal_parent_message_id: parentMessageId,
+			created_at: timestamp(sequence),
+		},
+		revision: null,
+	};
+}
+
+function readyTurn(sequence: number, participantAgentId: string, contractVersion: number) {
+	return {
+		...envelope(sequence),
+		type: "turn_completed" as const,
+		participant_agent_id: participantAgentId,
+		delivery_id: deliveryId(sequence),
+		contract_version: contractVersion,
+		disposition: { kind: "ready" as const, evidence: [] },
+		message: null,
+		revision: null,
+	};
+}
+
+function verificationEvent(
+	sequence: number,
+	participantAgentId: string,
+	contractVersion: number,
+	commandId: string,
+	outcome: "passed" | "failed" = "passed",
+	verificationRound = 1,
+) {
+	return {
+		...envelope(sequence),
+		type: "verification_recorded" as const,
+		participant_agent_id: participantAgentId,
+		contract_version: contractVersion,
+		verification_round: verificationRound,
+		evidence: {
+			verification_id: verificationId(sequence),
+			command_id: commandId,
+			outcome,
+			exit_code: outcome === "passed" ? 0 : 1,
+			duration_ms: 500,
+			summary: `${commandId} ${outcome}`,
+			output_sha256: "d".repeat(64),
+			artifacts: [],
+			recorded_at: timestamp(sequence),
+		},
+	};
+}
+
+function envelope(sequence: number) {
+	return {
+		event_id: eventId(sequence),
+		idempotency_key: `mission-event:${sequence}`,
+		mission_id: IDS.mission,
+		sequence_no: sequence,
+		created_at: timestamp(sequence),
+	};
+}
+
+function eventId(sequence: number): string {
+	return numberedUuid(100 + sequence);
+}
+
+function deliveryId(sequence: number): string {
+	return numberedUuid(200 + sequence);
+}
+
+function verificationId(sequence: number): string {
+	return numberedUuid(300 + sequence);
+}
+
+function numberedUuid(value: number): string {
+	return `00000000-0000-4000-8000-${String(value).padStart(12, "0")}`;
+}
+
+function timestamp(sequence: number): string {
+	return `2026-08-02T10:${String(sequence).padStart(2, "0")}:00.000Z`;
+}

--- a/protocol/src/mission-coordinator.ts
+++ b/protocol/src/mission-coordinator.ts
@@ -1,0 +1,684 @@
+import { isDeepStrictEqual } from "node:util";
+import { z } from "zod";
+import {
+	type ArtifactRef,
+	type ContractRevision,
+	type Message,
+	type MissionContext,
+	type MissionStatus,
+	type TurnDisposition,
+	type VerificationEvidence,
+	artifactRefSchema,
+	contractRevisionSchema,
+	contractVersionSchema,
+	isoTimestampSchema,
+	messageSchema,
+	missionContextSchema,
+	turnDispositionSchema,
+	uuidSchema,
+	verificationEvidenceSchema,
+} from "./schemas.js";
+import { transitionMissionStatus } from "./state-machines.js";
+
+const idempotencyKeySchema = z
+	.string()
+	.min(1)
+	.max(128)
+	.regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/);
+const commandIdSchema = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/);
+const requiredCommandsSchema = z.record(z.array(commandIdSchema).min(1).max(16));
+
+export const missionCoordinatorConfigSchema = z
+	.object({
+		mission_context: missionContextSchema,
+		required_verification_commands: requiredCommandsSchema,
+	})
+	.strict()
+	.superRefine((config, ctx) => {
+		const participantIds = config.mission_context.manifest.participants.map(
+			(participant) => participant.agent_id,
+		);
+		const configuredIds = Object.keys(config.required_verification_commands);
+		if (!sameStringSet(participantIds, configuredIds)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Verification plan must contain exactly the two Mission participants",
+				path: ["required_verification_commands"],
+			});
+		}
+		for (const participantId of configuredIds) {
+			const commands = config.required_verification_commands[participantId] ?? [];
+			if (new Set(commands).size !== commands.length) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Required verification command IDs must be unique per participant",
+					path: ["required_verification_commands", participantId],
+				});
+			}
+		}
+	});
+
+const eventEnvelopeShape = {
+	event_id: uuidSchema,
+	idempotency_key: idempotencyKeySchema,
+	mission_id: uuidSchema,
+	sequence_no: z.number().int().safe().positive(),
+	created_at: isoTimestampSchema,
+};
+
+const rawMissionCoordinatorEventSchema = z.discriminatedUnion("type", [
+	z
+		.object({
+			...eventEnvelopeShape,
+			type: z.literal("participants_accepted"),
+			participant_agent_ids: z.array(uuidSchema).length(2),
+			contract: artifactRefSchema,
+		})
+		.strict(),
+	z
+		.object({
+			...eventEnvelopeShape,
+			type: z.literal("turn_completed"),
+			participant_agent_id: uuidSchema,
+			delivery_id: uuidSchema,
+			contract_version: contractVersionSchema,
+			disposition: turnDispositionSchema,
+			message: messageSchema.nullable(),
+			revision: contractRevisionSchema.nullable(),
+		})
+		.strict(),
+	z
+		.object({
+			...eventEnvelopeShape,
+			type: z.literal("contract_acknowledged"),
+			participant_agent_id: uuidSchema,
+			revision_id: uuidSchema,
+			contract_version: contractVersionSchema,
+			artifact: artifactRefSchema,
+		})
+		.strict(),
+	z
+		.object({
+			...eventEnvelopeShape,
+			type: z.literal("verification_recorded"),
+			participant_agent_id: uuidSchema,
+			contract_version: contractVersionSchema,
+			verification_round: z.number().int().safe().positive(),
+			evidence: verificationEvidenceSchema,
+		})
+		.strict(),
+]);
+
+type RawMissionCoordinatorEvent = z.infer<typeof rawMissionCoordinatorEventSchema>;
+export type CoordinatorTurnDisposition = Extract<
+	TurnDisposition,
+	{ readonly kind: "reply" | "propose_contract" | "ready" }
+>;
+type RawTurnCompletedEvent = Extract<
+	RawMissionCoordinatorEvent,
+	{ readonly type: "turn_completed" }
+>;
+export type MissionCoordinatorEvent =
+	| Exclude<RawMissionCoordinatorEvent, { readonly type: "turn_completed" }>
+	| (Omit<RawTurnCompletedEvent, "disposition"> & {
+			readonly disposition: CoordinatorTurnDisposition;
+	  });
+
+export const missionCoordinatorEventSchema = rawMissionCoordinatorEventSchema
+	.superRefine((event, ctx) => {
+		if (event.type === "participants_accepted") {
+			if (new Set(event.participant_agent_ids).size !== event.participant_agent_ids.length) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Accepted Mission participants must be unique",
+					path: ["participant_agent_ids"],
+				});
+			}
+			return;
+		}
+		if (event.type !== "turn_completed") {
+			return;
+		}
+
+		const kind = event.disposition.kind;
+		if ((kind === "reply") !== (event.message !== null)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Reply dispositions require exactly one Message companion",
+				path: ["message"],
+			});
+		}
+		if ((kind === "propose_contract") !== (event.revision !== null)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Contract proposals require exactly one revision companion",
+				path: ["revision"],
+			});
+		}
+		if (kind !== "reply" && kind !== "propose_contract" && kind !== "ready") {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "This coordinator slice supports reply, propose_contract, and ready turns",
+				path: ["disposition", "kind"],
+			});
+		}
+	})
+	.transform((event): MissionCoordinatorEvent => event as MissionCoordinatorEvent);
+
+export type MissionCoordinatorConfig = z.infer<typeof missionCoordinatorConfigSchema>;
+
+export interface MissionVerificationRecord {
+	readonly event_id: string;
+	readonly participant_agent_id: string;
+	readonly contract_version: number;
+	readonly verification_round: number;
+	readonly evidence: VerificationEvidence;
+}
+
+export interface MissionCoordinatorState {
+	readonly mission_context: MissionContext;
+	readonly required_verification_commands: Readonly<Record<string, readonly string[]>>;
+	readonly status: MissionStatus;
+	readonly sequence_no: number;
+	readonly turn_count: number;
+	readonly contract_version: number;
+	readonly verification_round: number;
+	readonly active_contract: ArtifactRef;
+	readonly pending_revision: ContractRevision | null;
+	readonly accepted_revisions: readonly ContractRevision[];
+	readonly current_participant_agent_id: string | null;
+	readonly ready_agent_ids: readonly string[];
+	readonly verification_records: readonly MissionVerificationRecord[];
+	readonly messages: readonly Message[];
+	readonly applied_events: readonly MissionCoordinatorEvent[];
+}
+
+export class InvalidMissionCoordinatorEventError extends Error {
+	constructor(readonly reason: string) {
+		super(`Invalid Mission coordinator event: ${reason}`);
+		this.name = "InvalidMissionCoordinatorEventError";
+	}
+}
+
+export function createMissionCoordinatorState(configInput: unknown): MissionCoordinatorState {
+	const config = missionCoordinatorConfigSchema.parse(configInput);
+	const manifest = config.mission_context.manifest;
+	const required_verification_commands = Object.fromEntries(
+		manifest.participants.map((participant) => [
+			participant.agent_id,
+			[...config.required_verification_commands[participant.agent_id]!],
+		]),
+	);
+
+	return {
+		mission_context: structuredClone(config.mission_context),
+		required_verification_commands,
+		status: "awaiting_acceptance",
+		sequence_no: 0,
+		turn_count: 0,
+		contract_version: manifest.shared_contract.version,
+		verification_round: 0,
+		active_contract: structuredClone(manifest.shared_contract),
+		pending_revision: null,
+		accepted_revisions: [],
+		current_participant_agent_id: null,
+		ready_agent_ids: [],
+		verification_records: [],
+		messages: [],
+		applied_events: [],
+	};
+}
+
+export function reduceMissionCoordinatorEvent(
+	state: MissionCoordinatorState,
+	eventInput: unknown,
+): MissionCoordinatorState {
+	const event = missionCoordinatorEventSchema.parse(eventInput);
+	const replay = findReplay(state, event);
+	if (replay !== null) {
+		if (isDeepStrictEqual(replay, event)) {
+			return state;
+		}
+		throw new InvalidMissionCoordinatorEventError("event_identity_conflict");
+	}
+
+	if (event.mission_id !== state.mission_context.manifest.mission_id) {
+		throw new InvalidMissionCoordinatorEventError("mission_mismatch");
+	}
+	if (event.sequence_no !== state.sequence_no + 1) {
+		throw new InvalidMissionCoordinatorEventError("sequence");
+	}
+	if (isTerminal(state.status)) {
+		throw new InvalidMissionCoordinatorEventError("terminal");
+	}
+	if (
+		event.type === "turn_completed" &&
+		state.applied_events.some(
+			(applied) => applied.type === "turn_completed" && applied.delivery_id === event.delivery_id,
+		)
+	) {
+		throw new InvalidMissionCoordinatorEventError("delivery_conflict");
+	}
+
+	const current = structuredClone(state);
+	let reduced: MissionCoordinatorState;
+	if (event.type === "participants_accepted") {
+		reduced = applyParticipantsAccepted(current, event);
+	} else if (event.type === "turn_completed") {
+		reduced = applyTurnCompleted(current, event);
+	} else if (event.type === "contract_acknowledged") {
+		reduced = applyContractAcknowledged(current, event);
+	} else {
+		reduced = applyVerificationRecorded(current, event);
+	}
+
+	return {
+		...reduced,
+		sequence_no: event.sequence_no,
+		applied_events: [...reduced.applied_events, structuredClone(event)],
+	};
+}
+
+export function replayMissionCoordinatorEvents(
+	configInput: unknown,
+	eventInputs: readonly unknown[],
+): MissionCoordinatorState {
+	let state = createMissionCoordinatorState(configInput);
+	for (const event of eventInputs) {
+		state = reduceMissionCoordinatorEvent(state, event);
+	}
+	return state;
+}
+
+type ParticipantsAcceptedEvent = Extract<
+	MissionCoordinatorEvent,
+	{ readonly type: "participants_accepted" }
+>;
+type TurnCompletedEvent = Extract<MissionCoordinatorEvent, { readonly type: "turn_completed" }>;
+type ContractAcknowledgedEvent = Extract<
+	MissionCoordinatorEvent,
+	{ readonly type: "contract_acknowledged" }
+>;
+type VerificationRecordedEvent = Extract<
+	MissionCoordinatorEvent,
+	{ readonly type: "verification_recorded" }
+>;
+
+function applyParticipantsAccepted(
+	state: MissionCoordinatorState,
+	event: ParticipantsAcceptedEvent,
+): MissionCoordinatorState {
+	if (state.status !== "awaiting_acceptance" || state.applied_events.length !== 0) {
+		throw new InvalidMissionCoordinatorEventError("acceptance_state");
+	}
+	const manifest = state.mission_context.manifest;
+	const participantIds = manifest.participants.map((participant) => participant.agent_id);
+	if (!sameStringSet(event.participant_agent_ids, participantIds)) {
+		throw new InvalidMissionCoordinatorEventError("acceptance_participants");
+	}
+	if (!isDeepStrictEqual(event.contract, manifest.shared_contract)) {
+		throw new InvalidMissionCoordinatorEventError("acceptance_contract");
+	}
+
+	return {
+		...state,
+		status: transitionMissionStatus(state.status, { type: "participants_accepted" }),
+		current_participant_agent_id: participantIds[0]!,
+	};
+}
+
+function applyTurnCompleted(
+	state: MissionCoordinatorState,
+	event: TurnCompletedEvent,
+): MissionCoordinatorState {
+	if (
+		state.status !== "active" ||
+		state.pending_revision !== null ||
+		state.current_participant_agent_id === null
+	) {
+		throw new InvalidMissionCoordinatorEventError("turn_not_scheduled");
+	}
+	if (event.participant_agent_id !== state.current_participant_agent_id) {
+		throw new InvalidMissionCoordinatorEventError("turn_participant");
+	}
+	if (event.contract_version !== state.contract_version) {
+		throw new InvalidMissionCoordinatorEventError("contract_version");
+	}
+	if (state.turn_count >= state.mission_context.manifest.max_turns) {
+		throw new InvalidMissionCoordinatorEventError("turn_limit");
+	}
+
+	const withTurn = { ...state, turn_count: state.turn_count + 1 };
+	let reduced: MissionCoordinatorState;
+	if (event.disposition.kind === "reply") {
+		reduced = applyReply(withTurn, event);
+	} else if (event.disposition.kind === "propose_contract") {
+		reduced = applyContractProposal(withTurn, event);
+	} else if (event.disposition.kind === "ready") {
+		reduced = applyReady(withTurn, event);
+	} else {
+		throw new InvalidMissionCoordinatorEventError("unsupported_disposition");
+	}
+
+	if (
+		reduced.status === "active" &&
+		reduced.turn_count >= reduced.mission_context.manifest.max_turns
+	) {
+		return {
+			...reduced,
+			status: transitionMissionStatus(reduced.status, { type: "fail" }),
+			pending_revision: null,
+			current_participant_agent_id: null,
+			ready_agent_ids: [],
+			verification_records: [],
+		};
+	}
+	return reduced;
+}
+
+function applyReply(
+	state: MissionCoordinatorState,
+	event: TurnCompletedEvent,
+): MissionCoordinatorState {
+	const message = event.message;
+	if (event.disposition.kind !== "reply" || message === null) {
+		throw new InvalidMissionCoordinatorEventError("reply_message_missing");
+	}
+	const expectedArtifacts = event.disposition.artifacts ?? [];
+	const expectedParent = state.messages.at(-1)?.message_id ?? null;
+	if (
+		message.mission_id !== event.mission_id ||
+		message.author_agent_id !== event.participant_agent_id ||
+		message.contract_version !== state.contract_version ||
+		message.type !== event.disposition.message_type ||
+		message.body !== event.disposition.message ||
+		!isDeepStrictEqual(message.artifacts, expectedArtifacts) ||
+		message.sequence_no !== state.messages.length + 1 ||
+		message.causal_parent_message_id !== expectedParent
+	) {
+		throw new InvalidMissionCoordinatorEventError("reply_message_mismatch");
+	}
+	if (
+		state.messages.some(
+			(existing) =>
+				existing.message_id === message.message_id ||
+				existing.idempotency_key === message.idempotency_key,
+		)
+	) {
+		throw new InvalidMissionCoordinatorEventError("message_identity_conflict");
+	}
+	assertAllowedArtifacts(state, message.artifacts);
+
+	return {
+		...state,
+		current_participant_agent_id: otherParticipant(state, event.participant_agent_id),
+		ready_agent_ids: [],
+		verification_records: [],
+		messages: [...state.messages, structuredClone(message)],
+	};
+}
+
+function applyContractProposal(
+	state: MissionCoordinatorState,
+	event: TurnCompletedEvent,
+): MissionCoordinatorState {
+	const revision = event.revision;
+	if (event.disposition.kind !== "propose_contract" || revision === null) {
+		throw new InvalidMissionCoordinatorEventError("revision_missing");
+	}
+	if (
+		revision.mission_id !== event.mission_id ||
+		revision.proposed_by_agent_id !== event.participant_agent_id ||
+		revision.previous_version !== state.contract_version ||
+		revision.version !== state.contract_version + 1 ||
+		revision.acknowledged_by_agent_ids.length !== 0 ||
+		!isDeepStrictEqual(revision.artifact, event.disposition.artifact)
+	) {
+		throw new InvalidMissionCoordinatorEventError("revision_mismatch");
+	}
+	if (
+		revision.artifact.artifact_id !== state.active_contract.artifact_id ||
+		revision.artifact.type !== state.active_contract.type
+	) {
+		throw new InvalidMissionCoordinatorEventError("revision_contract_identity");
+	}
+	if (
+		state.accepted_revisions.some(
+			(existing) =>
+				existing.revision_id === revision.revision_id ||
+				existing.idempotency_key === revision.idempotency_key,
+		)
+	) {
+		throw new InvalidMissionCoordinatorEventError("revision_identity_conflict");
+	}
+	assertAllowedArtifacts(state, [revision.artifact]);
+
+	return {
+		...state,
+		pending_revision: structuredClone(revision),
+		current_participant_agent_id: null,
+		ready_agent_ids: [],
+		verification_records: [],
+	};
+}
+
+function applyReady(
+	state: MissionCoordinatorState,
+	event: TurnCompletedEvent,
+): MissionCoordinatorState {
+	if (event.disposition.kind !== "ready") {
+		throw new InvalidMissionCoordinatorEventError("ready_disposition");
+	}
+	assertAllowedArtifacts(
+		state,
+		event.disposition.evidence.flatMap((evidence) => evidence.artifacts),
+	);
+	const ready_agent_ids = [...state.ready_agent_ids, event.participant_agent_id];
+	const participantIds = missionParticipantIds(state);
+	if (sameStringSet(ready_agent_ids, participantIds)) {
+		return {
+			...state,
+			status: transitionMissionStatus(state.status, { type: "participants_ready" }),
+			verification_round: state.verification_round + 1,
+			current_participant_agent_id: null,
+			ready_agent_ids,
+			verification_records: [],
+		};
+	}
+
+	return {
+		...state,
+		current_participant_agent_id: otherParticipant(state, event.participant_agent_id),
+		ready_agent_ids,
+	};
+}
+
+function applyContractAcknowledged(
+	state: MissionCoordinatorState,
+	event: ContractAcknowledgedEvent,
+): MissionCoordinatorState {
+	const pending = state.pending_revision;
+	if (
+		state.status !== "active" ||
+		pending === null ||
+		state.current_participant_agent_id !== null
+	) {
+		throw new InvalidMissionCoordinatorEventError("no_pending_revision");
+	}
+	if (!missionParticipantIds(state).includes(event.participant_agent_id)) {
+		throw new InvalidMissionCoordinatorEventError("acknowledgement_participant");
+	}
+	if (
+		event.revision_id !== pending.revision_id ||
+		event.contract_version !== pending.version ||
+		!isDeepStrictEqual(event.artifact, pending.artifact)
+	) {
+		throw new InvalidMissionCoordinatorEventError("acknowledgement_revision");
+	}
+	if (pending.acknowledged_by_agent_ids.includes(event.participant_agent_id)) {
+		throw new InvalidMissionCoordinatorEventError("duplicate_acknowledgement");
+	}
+
+	const acknowledged = contractRevisionSchema.parse({
+		...pending,
+		acknowledged_by_agent_ids: [...pending.acknowledged_by_agent_ids, event.participant_agent_id],
+	});
+	if (!sameStringSet(acknowledged.acknowledged_by_agent_ids, missionParticipantIds(state))) {
+		return { ...state, pending_revision: acknowledged };
+	}
+
+	return {
+		...state,
+		contract_version: acknowledged.version,
+		active_contract: structuredClone(acknowledged.artifact),
+		pending_revision: null,
+		accepted_revisions: [...state.accepted_revisions, acknowledged],
+		current_participant_agent_id: otherParticipant(state, acknowledged.proposed_by_agent_id),
+		ready_agent_ids: [],
+		verification_records: [],
+	};
+}
+
+function applyVerificationRecorded(
+	state: MissionCoordinatorState,
+	event: VerificationRecordedEvent,
+): MissionCoordinatorState {
+	if (
+		state.status !== "verifying" ||
+		state.pending_revision !== null ||
+		state.current_participant_agent_id !== null
+	) {
+		throw new InvalidMissionCoordinatorEventError("not_verifying");
+	}
+	if (event.contract_version !== state.contract_version) {
+		throw new InvalidMissionCoordinatorEventError("contract_version");
+	}
+	if (event.verification_round !== state.verification_round) {
+		throw new InvalidMissionCoordinatorEventError("verification_round");
+	}
+	const required = state.required_verification_commands[event.participant_agent_id];
+	if (!required || !required.includes(event.evidence.command_id)) {
+		throw new InvalidMissionCoordinatorEventError("verification_command");
+	}
+	if (
+		state.applied_events.some(
+			(applied) =>
+				applied.type === "verification_recorded" &&
+				applied.evidence.verification_id === event.evidence.verification_id,
+		) ||
+		state.verification_records.some(
+			(record) =>
+				record.participant_agent_id === event.participant_agent_id &&
+				record.evidence.command_id === event.evidence.command_id,
+		)
+	) {
+		throw new InvalidMissionCoordinatorEventError("verification_conflict");
+	}
+	assertAllowedArtifacts(state, event.evidence.artifacts);
+
+	const record: MissionVerificationRecord = {
+		event_id: event.event_id,
+		participant_agent_id: event.participant_agent_id,
+		contract_version: event.contract_version,
+		verification_round: event.verification_round,
+		evidence: structuredClone(event.evidence),
+	};
+	if (event.evidence.outcome === "failed") {
+		const remainingTurns = state.mission_context.manifest.max_turns - state.turn_count;
+		const canRetry = remainingTurns >= missionParticipantIds(state).length;
+		return {
+			...state,
+			status: transitionMissionStatus(state.status, {
+				type: canRetry ? "verification_failed" : "fail",
+			}),
+			current_participant_agent_id: canRetry ? event.participant_agent_id : null,
+			ready_agent_ids: [],
+			verification_records: [],
+		};
+	}
+
+	const verification_records = [...state.verification_records, record];
+	if (!allRequiredCommandsPassed(state, verification_records)) {
+		return { ...state, verification_records };
+	}
+	return {
+		...state,
+		status: transitionMissionStatus(state.status, { type: "verification_passed" }),
+		verification_records,
+	};
+}
+
+function findReplay(
+	state: MissionCoordinatorState,
+	event: MissionCoordinatorEvent,
+): MissionCoordinatorEvent | null {
+	const matches = state.applied_events.filter(
+		(applied) =>
+			applied.event_id === event.event_id || applied.idempotency_key === event.idempotency_key,
+	);
+	if (matches.length === 0) {
+		return null;
+	}
+	if (matches.length !== 1) {
+		throw new InvalidMissionCoordinatorEventError("event_identity_conflict");
+	}
+	return matches[0]!;
+}
+
+function allRequiredCommandsPassed(
+	state: MissionCoordinatorState,
+	records: readonly MissionVerificationRecord[],
+): boolean {
+	return missionParticipantIds(state).every((participantId) =>
+		state.required_verification_commands[participantId]!.every((commandId) =>
+			records.some(
+				(record) =>
+					record.participant_agent_id === participantId &&
+					record.contract_version === state.contract_version &&
+					record.verification_round === state.verification_round &&
+					record.evidence.command_id === commandId &&
+					record.evidence.outcome === "passed",
+			),
+		),
+	);
+}
+
+function assertAllowedArtifacts(
+	state: MissionCoordinatorState,
+	artifacts: readonly ArtifactRef[],
+): void {
+	const allowed = state.mission_context.manifest.allowed_artifact_types;
+	if (artifacts.some((artifact) => !allowed.includes(artifact.type))) {
+		throw new InvalidMissionCoordinatorEventError("artifact_type");
+	}
+}
+
+function missionParticipantIds(state: MissionCoordinatorState): string[] {
+	return state.mission_context.manifest.participants.map((participant) => participant.agent_id);
+}
+
+function otherParticipant(state: MissionCoordinatorState, participantId: string): string {
+	const other = missionParticipantIds(state).find((candidate) => candidate !== participantId);
+	if (!other) {
+		throw new InvalidMissionCoordinatorEventError("participant");
+	}
+	return other;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+	return (
+		left.length === right.length &&
+		new Set(left).size === left.length &&
+		left.every((item) => right.includes(item))
+	);
+}
+
+function isTerminal(status: MissionStatus): boolean {
+	return (
+		status === "completed" || status === "cancelled" || status === "expired" || status === "failed"
+	);
+}

--- a/protocol/src/schemas.test.ts
+++ b/protocol/src/schemas.test.ts
@@ -116,6 +116,14 @@ describe("missionManifestSchema", () => {
 		expect(missionManifestSchema.safeParse(duplicate).success).toBe(false);
 	});
 
+	it("rejects non-canonical UUID casing before identity comparison", () => {
+		const mixedCaseDuplicate = clone(manifest);
+		mixedCaseDuplicate.participants[0].agent_id = "abcdefab-cdef-4abc-8def-abcdefabcdef";
+		mixedCaseDuplicate.participants[1].agent_id = "ABCDEFAB-CDEF-4ABC-8DEF-ABCDEFABCDEF";
+
+		expect(missionManifestSchema.safeParse(mixedCaseDuplicate).success).toBe(false);
+	});
+
 	it("rejects local repository paths and credential-bearing URLs", () => {
 		const localPath = clone(manifest);
 		localPath.participants[0].repository_url = "file:///Users/alice/backend";

--- a/protocol/src/schemas.ts
+++ b/protocol/src/schemas.ts
@@ -53,7 +53,10 @@ const fencingTokenSchema = z
 	.string()
 	.regex(/^(?:0|[1-9][0-9]*)$/)
 	.max(64);
-export const uuidSchema = z.string().uuid();
+export const uuidSchema = z
+	.string()
+	.uuid()
+	.refine((value) => value === value.toLowerCase(), "UUID must use lowercase canonical form");
 export const contractVersionSchema = z.number().int().positive().max(1_000_000);
 
 function hasUniqueValues(values: string[]): boolean {

--- a/protocol/src/testing/backend-android-transcript.test.ts
+++ b/protocol/src/testing/backend-android-transcript.test.ts
@@ -1,0 +1,328 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+	type InvalidMissionCoordinatorEventError,
+	type MissionCoordinatorEvent,
+	reduceMissionCoordinatorEvent,
+	replayMissionCoordinatorEvents,
+} from "../mission-coordinator.js";
+import {
+	type BackendAndroidFixtureEnvironment,
+	backendAndroidContracts,
+	backendAndroidCoordinatorConfig,
+	backendAndroidFixtureRoot,
+	backendAndroidIds,
+	backendAndroidMissionFixture,
+} from "./fixtures/backend-android.js";
+import { runFixedCommand } from "./frozen-repository.js";
+import { runMissionFixture } from "./mission-fixture-runner.js";
+
+describe("backend-Android deterministic Mission", () => {
+	it("completes one revised contract with no human action after kickoff", async () => {
+		const expectedTranscript = JSON.parse(
+			readFileSync(`${backendAndroidFixtureRoot}/expected-transcript.json`, "utf8"),
+		);
+		const result = await runMissionFixture(backendAndroidMissionFixture);
+		try {
+			expect(result.state.status).toBe("completed");
+			expect(result.state.sequence_no).toBe(14);
+			expect(result.state.turn_count).toBe(7);
+			expect(result.state.contract_version).toBe(2);
+			expect(result.state.pending_revision).toBeNull();
+			expect(result.state.current_participant_agent_id).toBeNull();
+			expect(result.state.ready_agent_ids).toEqual([
+				backendAndroidIds.androidAgent,
+				backendAndroidIds.backendAgent,
+			]);
+			expect(result.state.messages.map((message) => message.type)).toEqual([
+				"question",
+				"answer",
+				"progress",
+				"progress",
+			]);
+			expect(result.state.accepted_revisions).toHaveLength(1);
+			expect(result.state.accepted_revisions[0]).toMatchObject({
+				previous_version: 1,
+				version: 2,
+				proposed_by_agent_id: backendAndroidIds.backendAgent,
+				acknowledged_by_agent_ids: [backendAndroidIds.backendAgent, backendAndroidIds.androidAgent],
+			});
+			expect(result.duplicateDeliveriesSuppressed).toBe(1);
+			expect(result.duplicateAcknowledgementsSuppressed).toBe(1);
+			expect(result.recoveredHostTurns).toBe(1);
+			expect(result.humanInterventions).toBe(0);
+			expect(result.events.map(projectEvent)).toEqual(expectedTranscript.events);
+			expect(
+				result.hostTurns
+					.filter((turn) => turn.replayMode !== "none")
+					.map((turn) => ({
+						delivery_id: turn.input.deliveryId,
+						mode: turn.replayMode,
+					})),
+			).toEqual(expectedTranscript.delivery_replays);
+
+			const verificationCommandIds = result.state.verification_records.map(
+				(record) => record.evidence.command_id,
+			);
+			expect(verificationCommandIds).toEqual([
+				"backend-test",
+				"contract-test",
+				"android-test",
+				"public-user-scenario",
+			]);
+			expect(verificationCommandIds).not.toContain("hidden-user-scenario");
+
+			const secondAcknowledgement = result.events
+				.filter((event) => event.type === "contract_acknowledged")
+				.at(-1);
+			expect(secondAcknowledgement).toBeDefined();
+			const turnsAfterRevision = result.events.filter(
+				(event) =>
+					event.type === "turn_completed" &&
+					event.sequence_no > (secondAcknowledgement?.sequence_no ?? Number.MAX_SAFE_INTEGER),
+			);
+			expect(turnsAfterRevision).toHaveLength(4);
+			expect(turnsAfterRevision.every((event) => event.contract_version === 2)).toBe(true);
+
+			expect(result.hostTurns.map((turn) => turn.input.contractVersion)).toEqual([
+				1, 1, 1, 2, 2, 2, 2,
+			]);
+			for (const turn of result.hostTurns) {
+				expect(turn.input.objective).toMatchObject({
+					authorPrincipalId: backendAndroidIds.owner,
+					provenance: "mission_manifest",
+				});
+				expect(turn.input.artifacts).toHaveLength(1);
+				expect(turn.input.artifacts[0]).toEqual(
+					turn.input.contractVersion === 1
+						? backendAndroidContracts.v1
+						: backendAndroidContracts.v2,
+				);
+				expect(turn.events.map((event) => event.sequence)).toEqual(
+					turn.events.map((_, index) => index + 1),
+				);
+				expect(turn.events.at(-1)?.kind).toBe("completed");
+			}
+
+			expect(result.adapterCounters[backendAndroidIds.backendAgent]).toMatchObject({
+				ensureSessionCalls: 1,
+				startTurnCalls: 4,
+				turnsCreated: 4,
+				recoverTurnCalls: 0,
+			});
+			expect(result.adapterCounters[backendAndroidIds.androidAgent]).toMatchObject({
+				ensureSessionCalls: 1,
+				startTurnCalls: 4,
+				turnsCreated: 3,
+				recoverTurnCalls: 1,
+			});
+
+			const replayed = replayMissionCoordinatorEvents(
+				backendAndroidCoordinatorConfig,
+				result.events,
+			);
+			expect(replayed).toEqual(result.state);
+			let duplicateReplay = result.state;
+			for (const event of result.events) {
+				duplicateReplay = reduceMissionCoordinatorEvent(duplicateReplay, event);
+			}
+			expect(duplicateReplay).toEqual(result.state);
+
+			const lastTurn = result.events.findLast((event) => event.type === "turn_completed");
+			expect(lastTurn).toBeDefined();
+			if (lastTurn?.type === "turn_completed") {
+				expect(() =>
+					reduceMissionCoordinatorEvent(result.state, {
+						...lastTurn,
+						event_id: "90000000-0000-4000-8000-000000000001",
+						idempotency_key: "fixture:event:delayed",
+						sequence_no: result.state.sequence_no + 1,
+						created_at: "2026-08-02T10:01:00.000Z",
+						delivery_id: "90000000-0000-4000-8000-000000000002",
+					}),
+				).toThrowError(
+					expect.objectContaining<Partial<InvalidMissionCoordinatorEventError>>({
+						reason: "terminal",
+					}),
+				);
+			}
+
+			await expect(runFixedCommand(result.environment.hiddenUserScenario)).resolves.toBe("");
+			expect({
+				status: result.state.status,
+				contract_version: result.state.contract_version,
+				turn_count: result.state.turn_count,
+				message_count: result.state.messages.length,
+				accepted_revision_count: result.state.accepted_revisions.length,
+				human_interventions: result.humanInterventions,
+				hidden_user_scenario: "passed_after_completion",
+			}).toEqual(expectedTranscript.expected);
+		} finally {
+			await result.dispose();
+		}
+	}, 15_000);
+
+	it("delivers exact peer artifacts with teammate provenance", async () => {
+		const backendTurns =
+			backendAndroidMissionFixture.turnsByParticipant[backendAndroidIds.backendAgent] ?? [];
+		const [firstBackendTurn, ...remainingBackendTurns] = backendTurns;
+		if (firstBackendTurn?.disposition.kind !== "reply") {
+			throw new Error("Expected the backend fixture to begin with a reply");
+		}
+		const fixture = {
+			...backendAndroidMissionFixture,
+			turnsByParticipant: {
+				...backendAndroidMissionFixture.turnsByParticipant,
+				[backendAndroidIds.backendAgent]: [
+					{
+						...firstBackendTurn,
+						disposition: {
+							...firstBackendTurn.disposition,
+							artifacts: [backendAndroidContracts.v2.artifact],
+						},
+					},
+					...remainingBackendTurns,
+				],
+			},
+		};
+
+		const result = await runMissionFixture(fixture);
+		try {
+			const androidTurn = result.hostTurns.find(
+				(turn) => turn.input.deliveryId === backendAndroidIds.androidAnswerDelivery,
+			);
+			expect(androidTurn?.input.artifacts).toEqual([
+				backendAndroidContracts.v1,
+				backendAndroidContracts.v2,
+			]);
+		} finally {
+			await result.dispose();
+		}
+	}, 15_000);
+
+	it("disposes the prepared fixture when a registered verification command fails", async () => {
+		let disposed = false;
+		const fixture = {
+			...backendAndroidMissionFixture,
+			async prepareEnvironment() {
+				const environment = await backendAndroidMissionFixture.prepareEnvironment();
+				return {
+					...environment,
+					verificationCommands: {
+						...environment.verificationCommands,
+						[backendAndroidIds.backendAgent]: {
+							...environment.verificationCommands[backendAndroidIds.backendAgent],
+							"backend-test": {
+								command: {
+									executable: process.execPath,
+									args: ["-e", "process.exit(9)"],
+									cwd: environment.backend.expectedPath,
+								},
+								summary: "Intentional fixture failure.",
+								durationMs: 1,
+							},
+						},
+					},
+				};
+			},
+			async disposeEnvironment(environment: BackendAndroidFixtureEnvironment) {
+				disposed = true;
+				await backendAndroidMissionFixture.disposeEnvironment(environment);
+			},
+		};
+
+		await expect(runMissionFixture(fixture)).rejects.toThrow(
+			/Local verification command failed: backend-test/,
+		);
+		expect(disposed).toBe(true);
+	}, 15_000);
+
+	it("rejects a required verification command that local policy did not register", async () => {
+		let disposed = false;
+		const fixture = {
+			...backendAndroidMissionFixture,
+			coordinatorConfig: {
+				...backendAndroidCoordinatorConfig,
+				required_verification_commands: {
+					...backendAndroidCoordinatorConfig.required_verification_commands,
+					[backendAndroidIds.backendAgent]: [
+						...(backendAndroidCoordinatorConfig.required_verification_commands[
+							backendAndroidIds.backendAgent
+						] ?? []),
+						"missing-command",
+					],
+				},
+			},
+			async disposeEnvironment(environment: BackendAndroidFixtureEnvironment) {
+				disposed = true;
+				await backendAndroidMissionFixture.disposeEnvironment(environment);
+			},
+		};
+
+		await expect(runMissionFixture(fixture)).rejects.toThrow(
+			/No local verification command is registered for missing-command/,
+		);
+		expect(disposed).toBe(true);
+	}, 15_000);
+
+	it("rejects contract payload provenance that is not owned by the expected Mission actor", async () => {
+		const fixture = {
+			...backendAndroidMissionFixture,
+			artifacts: [
+				{
+					...backendAndroidContracts.v1,
+					source: {
+						principal_id: "90000000-0000-4000-8000-000000000001",
+						kind: "agent" as const,
+					},
+				},
+				backendAndroidContracts.v2,
+			],
+		};
+
+		await expect(runMissionFixture(fixture)).rejects.toThrow(/Fixture provenance mismatch/);
+	}, 15_000);
+});
+
+function projectEvent(event: MissionCoordinatorEvent): Record<string, unknown> {
+	if (event.type === "participants_accepted") {
+		return {
+			sequence_no: event.sequence_no,
+			type: event.type,
+			contract_version: event.contract.version,
+		};
+	}
+	if (event.type === "contract_acknowledged") {
+		return {
+			sequence_no: event.sequence_no,
+			type: event.type,
+			participant_agent_id: event.participant_agent_id,
+			contract_version: event.contract_version,
+		};
+	}
+	if (event.type === "verification_recorded") {
+		return {
+			sequence_no: event.sequence_no,
+			type: event.type,
+			participant_agent_id: event.participant_agent_id,
+			contract_version: event.contract_version,
+			verification_round: event.verification_round,
+			command_id: event.evidence.command_id,
+		};
+	}
+
+	const projected: Record<string, unknown> = {
+		sequence_no: event.sequence_no,
+		type: event.type,
+		participant_agent_id: event.participant_agent_id,
+		contract_version: event.contract_version,
+		disposition_kind: event.disposition.kind,
+	};
+	if (event.disposition.kind === "reply") {
+		projected.message_type = event.disposition.message_type;
+	}
+	if (event.disposition.kind === "propose_contract") {
+		projected.proposed_contract_version = event.disposition.artifact.version;
+	}
+	return projected;
+}

--- a/protocol/src/testing/fixtures/backend-android.ts
+++ b/protocol/src/testing/fixtures/backend-android.ts
@@ -1,0 +1,384 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { z } from "zod";
+import { type HostInputArtifact, hostInputArtifactSchema } from "../../adapter.js";
+import type { MissionCoordinatorConfig } from "../../mission-coordinator.js";
+import {
+	type ArtifactRef,
+	type MissionContext,
+	artifactRefSchema,
+	missionContextSchema,
+} from "../../schemas.js";
+import {
+	type FixedCommand,
+	type FrozenRepositoryDefinition,
+	type MaterializedFrozenRepository,
+	materializeFrozenRepository,
+} from "../frozen-repository.js";
+import type {
+	MissionFixtureEnvironment,
+	ScriptedMissionFixture,
+} from "../mission-fixture-runner.js";
+
+export const backendAndroidIds = {
+	mission: "10000000-0000-4000-8000-000000000001",
+	owner: "10000000-0000-4000-8000-000000000002",
+	backendAgent: "10000000-0000-4000-8000-000000000003",
+	androidAgent: "10000000-0000-4000-8000-000000000004",
+	contractArtifact: "10000000-0000-4000-8000-000000000005",
+	revision: "10000000-0000-4000-8000-000000000006",
+	backendQuestionDelivery: "30000000-0000-4000-8000-000000000001",
+	androidAnswerDelivery: "30000000-0000-4000-8000-000000000002",
+	backendProposalDelivery: "30000000-0000-4000-8000-000000000003",
+	androidProgressDelivery: "30000000-0000-4000-8000-000000000004",
+	backendProgressDelivery: "30000000-0000-4000-8000-000000000005",
+	androidReadyDelivery: "30000000-0000-4000-8000-000000000006",
+	backendReadyDelivery: "30000000-0000-4000-8000-000000000007",
+} as const;
+
+export const backendAndroidFixtureRoot = fileURLToPath(
+	new URL("../../../fixtures/backend-android/", import.meta.url),
+);
+
+const repositoryLockSchema = z
+	.object({
+		schema_version: z.literal(1),
+		repositories: z
+			.object({
+				backend: repositoryEntrySchema(),
+				android: repositoryEntrySchema(),
+			})
+			.strict(),
+	})
+	.strict();
+
+function repositoryEntrySchema() {
+	return z
+		.object({
+			repository_url: z.string().url(),
+			base_commit: z.string().regex(/^[a-f0-9]{40}$/),
+			expected_commit: z.string().regex(/^[a-f0-9]{40}$/),
+		})
+		.strict();
+}
+
+const repositoryLock = repositoryLockSchema.parse(
+	JSON.parse(readFileSync(`${backendAndroidFixtureRoot}/repository-lock.json`, "utf8")),
+);
+
+const contractLockSchema = z
+	.object({
+		schema_version: z.literal(1),
+		contracts: z
+			.object({
+				v1: artifactRefSchema,
+				v2: artifactRefSchema,
+			})
+			.strict(),
+	})
+	.strict()
+	.superRefine((lock, ctx) => {
+		const { v1, v2 } = lock.contracts;
+		if (v1.version !== 1 || v2.version !== 2) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Backend-Android contract locks must contain versions 1 and 2",
+				path: ["contracts"],
+			});
+		}
+		if (v1.artifact_id !== v2.artifact_id || v1.type !== v2.type) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Backend-Android contract revisions must preserve artifact identity",
+				path: ["contracts", "v2"],
+			});
+		}
+	});
+
+const contractLock = contractLockSchema.parse(
+	JSON.parse(readFileSync(`${backendAndroidFixtureRoot}/contract-lock.json`, "utf8")),
+);
+
+export const backendAndroidRepositories = {
+	backend: repositoryDefinition("backend"),
+	android: repositoryDefinition("android"),
+} as const satisfies Readonly<Record<string, FrozenRepositoryDefinition>>;
+
+function repositoryDefinition(
+	name: keyof typeof repositoryLock.repositories,
+): FrozenRepositoryDefinition {
+	const entry = repositoryLock.repositories[name];
+	return {
+		name,
+		baseDirectory: `${backendAndroidFixtureRoot}/repositories/${name}/base`,
+		expectedDirectory: `${backendAndroidFixtureRoot}/repositories/${name}/expected`,
+		baseCommit: entry.base_commit,
+		expectedCommit: entry.expected_commit,
+	};
+}
+
+const contractV1 = inputArtifact(
+	contractLock.contracts.v1,
+	`${backendAndroidFixtureRoot}/contracts/v1.json`,
+	backendAndroidIds.owner,
+	"owner",
+);
+const contractV2 = inputArtifact(
+	contractLock.contracts.v2,
+	`${backendAndroidFixtureRoot}/contracts/v2.json`,
+	backendAndroidIds.backendAgent,
+	"agent",
+);
+
+export const backendAndroidContracts = {
+	v1: contractV1,
+	v2: contractV2,
+} as const satisfies Readonly<Record<string, HostInputArtifact>>;
+
+export const backendAndroidMissionContext: MissionContext = missionContextSchema.parse({
+	manifest: JSON.parse(readFileSync(`${backendAndroidFixtureRoot}/manifest.json`, "utf8")),
+	created_by: {
+		principal_id: backendAndroidIds.owner,
+		kind: "owner",
+	},
+});
+
+if (
+	JSON.stringify(backendAndroidMissionContext.manifest.shared_contract) !==
+	JSON.stringify(contractV1.artifact)
+) {
+	throw new Error("Backend-Android manifest does not match the exact v1 contract payload");
+}
+
+for (const participant of backendAndroidMissionContext.manifest.participants) {
+	const name = participant.role === "backend" ? "backend" : "android";
+	const locked = repositoryLock.repositories[name];
+	if (
+		participant.repository_url !== locked.repository_url ||
+		participant.expected_base_commit !== locked.base_commit
+	) {
+		throw new Error(`Backend-Android ${name} participant does not match its repository lock`);
+	}
+}
+
+export const backendAndroidCoordinatorConfig: MissionCoordinatorConfig = {
+	mission_context: backendAndroidMissionContext,
+	required_verification_commands: {
+		[backendAndroidIds.backendAgent]: ["backend-test", "contract-test"],
+		[backendAndroidIds.androidAgent]: ["android-test", "public-user-scenario"],
+	},
+};
+
+export interface BackendAndroidFixtureEnvironment extends MissionFixtureEnvironment {
+	readonly temporaryRoot: string;
+	readonly backend: MaterializedFrozenRepository;
+	readonly android: MaterializedFrozenRepository;
+	readonly hiddenUserScenario: FixedCommand;
+}
+
+export const backendAndroidMissionFixture: ScriptedMissionFixture<BackendAndroidFixtureEnvironment> =
+	{
+		coordinatorConfig: backendAndroidCoordinatorConfig,
+		artifacts: [contractV1, contractV2],
+		turnsByParticipant: {
+			[backendAndroidIds.backendAgent]: [
+				{
+					deliveryId: backendAndroidIds.backendQuestionDelivery,
+					disposition: {
+						kind: "reply",
+						message_type: "question",
+						message:
+							"Can avatar_url become nullable, and what deterministic fallback should Android render?",
+					},
+					progress: [{ kind: "output", text: "Comparing the v1 response to Android needs." }],
+				},
+				{
+					deliveryId: backendAndroidIds.backendProposalDelivery,
+					disposition: {
+						kind: "propose_contract",
+						artifact: contractV2.artifact,
+					},
+					revision: {
+						revision_id: backendAndroidIds.revision,
+						mission_id: backendAndroidIds.mission,
+						previous_version: 1,
+						version: 2,
+						artifact: contractV2.artifact,
+						proposed_by_agent_id: backendAndroidIds.backendAgent,
+						acknowledged_by_agent_ids: [],
+						idempotency_key: "fixture:revision:2",
+						created_at: "2026-08-02T10:00:04.000Z",
+					},
+					progress: [{ kind: "artifact", artifact: contractV2.artifact }],
+				},
+				{
+					deliveryId: backendAndroidIds.backendProgressDelivery,
+					disposition: {
+						kind: "reply",
+						message_type: "progress",
+						message: "Backend now emits the accepted nullable avatar response.",
+					},
+					progress: [
+						{
+							kind: "tool",
+							activity: {
+								toolCallId: "backend-edit-1",
+								name: "fixture-edit",
+								phase: "completed",
+							},
+						},
+					],
+				},
+				{
+					deliveryId: backendAndroidIds.backendReadyDelivery,
+					disposition: { kind: "ready", evidence: [] },
+				},
+			],
+			[backendAndroidIds.androidAgent]: [
+				{
+					deliveryId: backendAndroidIds.androidAnswerDelivery,
+					disposition: {
+						kind: "reply",
+						message_type: "answer",
+						message:
+							"Yes. Use null and render uppercase initials from the first and last non-empty display-name segments.",
+					},
+					progress: [{ kind: "output", text: "Checking decoder and UI fallback constraints." }],
+					replayMode: "duplicate_start",
+				},
+				{
+					deliveryId: backendAndroidIds.androidProgressDelivery,
+					disposition: {
+						kind: "reply",
+						message_type: "progress",
+						message: "Android now accepts null and renders the agreed initials fallback.",
+					},
+					progress: [
+						{ kind: "output", text: "Updating the profile decoder." },
+						{
+							kind: "usage",
+							usage: {
+								available: true,
+								scope: "turn_cumulative",
+								inputTokens: 320,
+								outputTokens: 90,
+							},
+						},
+					],
+					replayMode: "recover_after_partial",
+				},
+				{
+					deliveryId: backendAndroidIds.androidReadyDelivery,
+					disposition: { kind: "ready", evidence: [] },
+				},
+			],
+		},
+		contractAcknowledgements: [
+			{
+				participantAgentId: backendAndroidIds.backendAgent,
+				revisionId: backendAndroidIds.revision,
+				contractVersion: 2,
+				artifact: contractV2.artifact,
+			},
+			{
+				participantAgentId: backendAndroidIds.androidAgent,
+				revisionId: backendAndroidIds.revision,
+				contractVersion: 2,
+				artifact: contractV2.artifact,
+			},
+		],
+		async prepareEnvironment() {
+			const temporaryRoot = await mkdtemp(join(tmpdir(), "agentrelay-backend-android-"));
+			try {
+				const [backend, android] = await Promise.all([
+					materializeFrozenRepository(backendAndroidRepositories.backend, temporaryRoot),
+					materializeFrozenRepository(backendAndroidRepositories.android, temporaryRoot),
+				]);
+				const verificationRoot = `${backendAndroidFixtureRoot}/verification`;
+				const contractPath = `${backendAndroidFixtureRoot}/contracts/v2.json`;
+				return {
+					temporaryRoot,
+					backend,
+					android,
+					verificationCommands: {
+						[backendAndroidIds.backendAgent]: {
+							"backend-test": verificationCommand(
+								backend.expectedPath,
+								["verify.mjs"],
+								"Backend profile response matches contract v2.",
+							),
+							"contract-test": verificationCommand(
+								verificationRoot,
+								["verify-contract.mjs", contractPath],
+								"Shared profile contract v2 is executable and valid.",
+							),
+						},
+						[backendAndroidIds.androidAgent]: {
+							"android-test": verificationCommand(
+								android.expectedPath,
+								["verify.mjs"],
+								"Android profile fallback matches contract v2.",
+							),
+							"public-user-scenario": verificationCommand(
+								verificationRoot,
+								["public-user-scenario.mjs", backend.expectedPath, android.expectedPath],
+								"Public cross-repository profile scenario passes.",
+							),
+						},
+					},
+					hiddenUserScenario: {
+						executable: process.execPath,
+						args: ["hidden-user-scenario.mjs", backend.expectedPath, android.expectedPath],
+						cwd: verificationRoot,
+					},
+				};
+			} catch (error) {
+				await rm(temporaryRoot, { recursive: true, force: true });
+				throw error;
+			}
+		},
+		async disposeEnvironment(environment) {
+			await rm(environment.temporaryRoot, { recursive: true, force: true });
+		},
+	};
+
+function verificationCommand(cwd: string, args: readonly string[], summary: string) {
+	return {
+		command: {
+			executable: process.execPath,
+			args,
+			cwd,
+		},
+		summary,
+		durationMs: 1,
+	};
+}
+
+function inputArtifact(
+	lockedArtifact: ArtifactRef,
+	path: string,
+	principalId: string,
+	kind: "owner" | "agent",
+): HostInputArtifact {
+	const rawText = readFileSync(path, "utf8");
+	const sha256 = createHash("sha256").update(rawText, "utf8").digest("hex");
+	const byteSize = Buffer.byteLength(rawText, "utf8");
+	if (sha256 !== lockedArtifact.sha256 || byteSize !== lockedArtifact.byte_size) {
+		throw new Error(`Backend-Android contract v${lockedArtifact.version} does not match its lock`);
+	}
+	return hostInputArtifactSchema.parse({
+		artifact: lockedArtifact,
+		source: {
+			principal_id: principalId,
+			kind,
+		},
+		payload: {
+			kind: "json",
+			rawText,
+		},
+	});
+}

--- a/protocol/src/testing/frozen-repository.test.ts
+++ b/protocol/src/testing/frozen-repository.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { backendAndroidRepositories } from "./fixtures/backend-android.js";
+import { materializeFrozenRepository, runFixedCommand } from "./frozen-repository.js";
+
+let temporaryRoot: string | undefined;
+
+afterEach(async () => {
+	if (temporaryRoot !== undefined) {
+		await rm(temporaryRoot, { recursive: true, force: true });
+		temporaryRoot = undefined;
+	}
+});
+
+describe("materializeFrozenRepository", () => {
+	it("reproduces the locked commits independently of ambient Git configuration", async () => {
+		temporaryRoot = await mkdtemp(join(tmpdir(), "agentrelay-frozen-repositories-"));
+		const [backend, android] = await withAmbientCommitEncoding(async () =>
+			Promise.all([
+				materializeFrozenRepository(backendAndroidRepositories.backend, temporaryRoot),
+				materializeFrozenRepository(backendAndroidRepositories.android, temporaryRoot),
+			]),
+		);
+
+		expect(backend.baseCommit).toBe(backendAndroidRepositories.backend.baseCommit);
+		expect(backend.expectedCommit).toBe(backendAndroidRepositories.backend.expectedCommit);
+		expect(android.baseCommit).toBe(backendAndroidRepositories.android.baseCommit);
+		expect(android.expectedCommit).toBe(backendAndroidRepositories.android.expectedCommit);
+		expect(
+			await runFixedCommand({
+				executable: "git",
+				args: ["status", "--porcelain"],
+				cwd: backend.basePath,
+			}),
+		).toBe("");
+		expect(
+			await runFixedCommand({
+				executable: "git",
+				args: ["status", "--porcelain"],
+				cwd: android.basePath,
+			}),
+		).toBe("");
+	});
+
+	it("runs the locally registered repository checks on the expected workspaces", async () => {
+		temporaryRoot = await mkdtemp(join(tmpdir(), "agentrelay-frozen-repositories-"));
+		const [backend, android] = await Promise.all([
+			materializeFrozenRepository(backendAndroidRepositories.backend, temporaryRoot),
+			materializeFrozenRepository(backendAndroidRepositories.android, temporaryRoot),
+		]);
+
+		await expect(
+			runFixedCommand({
+				executable: process.execPath,
+				args: ["verify.mjs"],
+				cwd: backend.expectedPath,
+			}),
+		).resolves.toBe("");
+		await expect(
+			runFixedCommand({
+				executable: process.execPath,
+				args: ["verify.mjs"],
+				cwd: android.expectedPath,
+			}),
+		).resolves.toBe("");
+	});
+
+	it("preserves exact verification stdout and rejects nonzero commands", async () => {
+		await expect(
+			runFixedCommand({
+				executable: process.execPath,
+				args: ["-e", 'process.stdout.write("result\\n")'],
+				cwd: tmpdir(),
+			}),
+		).resolves.toBe("result\n");
+		await expect(
+			runFixedCommand({
+				executable: process.execPath,
+				args: ["-e", 'process.stderr.write("failed\\n"); process.exit(7)'],
+				cwd: tmpdir(),
+			}),
+		).rejects.toThrow(/exited 7: failed/);
+	});
+
+	it("rejects unsafe fixture names and stale commit locks", async () => {
+		temporaryRoot = await mkdtemp(join(tmpdir(), "agentrelay-frozen-repositories-"));
+		await expect(
+			materializeFrozenRepository(
+				{ ...backendAndroidRepositories.backend, name: "../backend" },
+				temporaryRoot,
+			),
+		).rejects.toThrow(/Invalid frozen repository name/);
+		await expect(
+			materializeFrozenRepository(
+				{ ...backendAndroidRepositories.backend, baseCommit: "0".repeat(40) },
+				temporaryRoot,
+			),
+		).rejects.toThrow(/Frozen backend base commit mismatch/);
+	});
+});
+
+async function withAmbientCommitEncoding<T>(callback: () => Promise<T>): Promise<T> {
+	const previousGitConfig = {
+		count: process.env.GIT_CONFIG_COUNT,
+		key: process.env.GIT_CONFIG_KEY_0,
+		value: process.env.GIT_CONFIG_VALUE_0,
+	};
+	process.env.GIT_CONFIG_COUNT = "1";
+	process.env.GIT_CONFIG_KEY_0 = "i18n.commitEncoding";
+	process.env.GIT_CONFIG_VALUE_0 = "ISO-8859-1";
+	try {
+		return await callback();
+	} finally {
+		restoreEnvironment("GIT_CONFIG_COUNT", previousGitConfig.count);
+		restoreEnvironment("GIT_CONFIG_KEY_0", previousGitConfig.key);
+		restoreEnvironment("GIT_CONFIG_VALUE_0", previousGitConfig.value);
+	}
+}
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+		return;
+	}
+	process.env[name] = value;
+}

--- a/protocol/src/testing/frozen-repository.ts
+++ b/protocol/src/testing/frozen-repository.ts
@@ -1,0 +1,205 @@
+import { spawn } from "node:child_process";
+import { cp, mkdir } from "node:fs/promises";
+import { devNull } from "node:os";
+import { join } from "node:path";
+
+const FIXTURE_NAME = /^[a-z][a-z0-9-]*$/;
+const GIT_COMMIT = /^[a-f0-9]{40}$/;
+const GIT_IDENTITY = {
+	GIT_AUTHOR_NAME: "AgentRelay Fixture",
+	GIT_AUTHOR_EMAIL: "fixture@agentrelay.dev",
+	GIT_COMMITTER_NAME: "AgentRelay Fixture",
+	GIT_COMMITTER_EMAIL: "fixture@agentrelay.dev",
+} as const;
+
+export interface FrozenRepositoryDefinition {
+	readonly name: string;
+	readonly baseDirectory: string;
+	readonly expectedDirectory: string;
+	readonly baseCommit: string;
+	readonly expectedCommit: string;
+}
+
+export interface MaterializedFrozenRepository {
+	readonly name: string;
+	readonly basePath: string;
+	readonly expectedPath: string;
+	readonly baseCommit: string;
+	readonly expectedCommit: string;
+}
+
+/** Materializes and verifies the two fixed commits used by a local test fixture. */
+export async function materializeFrozenRepository(
+	definition: FrozenRepositoryDefinition,
+	parentDirectory: string,
+): Promise<MaterializedFrozenRepository> {
+	assertDefinition(definition);
+	const basePath = join(parentDirectory, `${definition.name}-base`);
+	const expectedPath = join(parentDirectory, `${definition.name}-expected`);
+	const expectedIndex = join(parentDirectory, `${definition.name}-expected.index`);
+
+	await mkdir(basePath, { recursive: false });
+	await runGit(["init", "--quiet", "--initial-branch=main", "--object-format=sha1"], {
+		cwd: basePath,
+	});
+	await runGit(["config", "core.autocrlf", "false"], { cwd: basePath });
+	await cp(definition.baseDirectory, basePath, { recursive: true });
+	await runGit(["add", "--all"], { cwd: basePath });
+	await runGit(
+		[
+			"-c",
+			"commit.gpgsign=false",
+			"commit",
+			"--quiet",
+			"-m",
+			`fixture: freeze ${definition.name} base`,
+		],
+		{
+			cwd: basePath,
+			env: {
+				...GIT_IDENTITY,
+				GIT_AUTHOR_DATE: "2026-08-02T00:00:00Z",
+				GIT_COMMITTER_DATE: "2026-08-02T00:00:00Z",
+			},
+		},
+	);
+	const baseCommit = await runGit(["rev-parse", "HEAD"], { cwd: basePath });
+	assertLockedCommit(definition.name, "base", definition.baseCommit, baseCommit);
+
+	const gitDirectory = join(basePath, ".git");
+	await runGit(
+		[
+			`--git-dir=${gitDirectory}`,
+			`--work-tree=${definition.expectedDirectory}`,
+			"-c",
+			"core.autocrlf=false",
+			"add",
+			"--all",
+		],
+		{ env: { GIT_INDEX_FILE: expectedIndex } },
+	);
+	const expectedTree = await runGit([`--git-dir=${gitDirectory}`, "write-tree"], {
+		env: { GIT_INDEX_FILE: expectedIndex },
+	});
+	const expectedCommit = await runGit(
+		[
+			`--git-dir=${gitDirectory}`,
+			"-c",
+			"commit.gpgsign=false",
+			"commit-tree",
+			expectedTree,
+			"-p",
+			baseCommit,
+			"-m",
+			`fixture: apply ${definition.name} expected result`,
+		],
+		{
+			env: {
+				...GIT_IDENTITY,
+				GIT_AUTHOR_DATE: "2026-08-02T00:01:00Z",
+				GIT_COMMITTER_DATE: "2026-08-02T00:01:00Z",
+			},
+		},
+	);
+	assertLockedCommit(definition.name, "expected", definition.expectedCommit, expectedCommit);
+
+	await runGit(["worktree", "add", "--quiet", "--detach", expectedPath, expectedCommit], {
+		cwd: basePath,
+	});
+	return {
+		name: definition.name,
+		basePath,
+		expectedPath,
+		baseCommit,
+		expectedCommit,
+	};
+}
+
+export interface FixedCommand {
+	readonly executable: string;
+	readonly args: readonly string[];
+	readonly cwd: string;
+}
+
+export async function runFixedCommand(command: FixedCommand): Promise<string> {
+	return run(command.executable, command.args, { cwd: command.cwd, preserveStdout: true });
+}
+
+function assertDefinition(definition: FrozenRepositoryDefinition): void {
+	if (!FIXTURE_NAME.test(definition.name)) {
+		throw new Error(`Invalid frozen repository name: ${definition.name}`);
+	}
+	if (!GIT_COMMIT.test(definition.baseCommit) || !GIT_COMMIT.test(definition.expectedCommit)) {
+		throw new Error(`Invalid frozen repository commit lock: ${definition.name}`);
+	}
+}
+
+function assertLockedCommit(
+	name: string,
+	kind: "base" | "expected",
+	expected: string,
+	received: string,
+): void {
+	if (received !== expected) {
+		throw new Error(
+			`Frozen ${name} ${kind} commit mismatch: expected ${expected}, received ${received}`,
+		);
+	}
+}
+
+interface RunOptions {
+	readonly cwd?: string;
+	readonly env?: Readonly<Record<string, string>>;
+	readonly preserveStdout?: boolean;
+}
+
+function runGit(args: readonly string[], options: RunOptions = {}): Promise<string> {
+	const inherited = Object.fromEntries(
+		Object.entries(process.env).filter(([name]) => !name.startsWith("GIT_")),
+	);
+	return run("git", args, {
+		...options,
+		env: {
+			...inherited,
+			GIT_CONFIG_NOSYSTEM: "1",
+			GIT_CONFIG_SYSTEM: devNull,
+			GIT_CONFIG_GLOBAL: devNull,
+			GIT_ATTR_NOSYSTEM: "1",
+			...options.env,
+		},
+	});
+}
+
+async function run(
+	executable: string,
+	args: readonly string[],
+	options: RunOptions = {},
+): Promise<string> {
+	return await new Promise((resolve, reject) => {
+		const child = spawn(executable, args, {
+			cwd: options.cwd,
+			env: options.env ?? process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const stdout: Buffer[] = [];
+		const stderr: Buffer[] = [];
+		child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+		child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+		child.once("error", reject);
+		child.once("close", (code) => {
+			const rawOutput = Buffer.concat(stdout).toString("utf8");
+			const output = options.preserveStdout ? rawOutput : rawOutput.trim();
+			if (code === 0) {
+				resolve(output);
+				return;
+			}
+			reject(
+				new Error(
+					`${executable} exited ${code ?? "without a status"}: ${Buffer.concat(stderr)
+						.toString("utf8")
+						.trim()}`,
+				),
+			);
+		});
+	});
+}

--- a/protocol/src/testing/index.ts
+++ b/protocol/src/testing/index.ts
@@ -4,3 +4,31 @@ export {
 	type FakeTurnOutcome,
 	type FakeTurnProgress,
 } from "./fake-adapter.js";
+export {
+	type FixedCommand,
+	type FrozenRepositoryDefinition,
+	type MaterializedFrozenRepository,
+	materializeFrozenRepository,
+	runFixedCommand,
+} from "./frozen-repository.js";
+export {
+	type FixtureHostTurnTrace,
+	type FixtureReplayMode,
+	type FixtureVerificationCommand,
+	type MissionFixtureEnvironment,
+	type MissionFixtureRunResult,
+	type ScriptedContractAcknowledgement,
+	type ScriptedMissionFixture,
+	type ScriptedMissionTurn,
+	runMissionFixture,
+} from "./mission-fixture-runner.js";
+export {
+	type BackendAndroidFixtureEnvironment,
+	backendAndroidContracts,
+	backendAndroidCoordinatorConfig,
+	backendAndroidFixtureRoot,
+	backendAndroidIds,
+	backendAndroidMissionContext,
+	backendAndroidMissionFixture,
+	backendAndroidRepositories,
+} from "./fixtures/backend-android.js";

--- a/protocol/src/testing/mission-fixture-runner.ts
+++ b/protocol/src/testing/mission-fixture-runner.ts
@@ -1,0 +1,536 @@
+import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import {
+	type HostEvent,
+	type HostInputArtifact,
+	type HostSessionRef,
+	type StartTurnInput,
+	acceptHostEvent,
+	createHostEventStreamState,
+	deriveHostMissionInputs,
+} from "../adapter.js";
+import {
+	type CoordinatorTurnDisposition,
+	type MissionCoordinatorConfig,
+	type MissionCoordinatorEvent,
+	type MissionCoordinatorState,
+	createMissionCoordinatorState,
+	reduceMissionCoordinatorEvent,
+} from "../mission-coordinator.js";
+import type { ActorRef, ArtifactRef, ContractRevision, Message } from "../schemas.js";
+import {
+	type FakeAdapterCounters,
+	FakeAgentHostAdapter,
+	type FakeTurnProgress,
+} from "./fake-adapter.js";
+import type { FixedCommand } from "./frozen-repository.js";
+import { runFixedCommand } from "./frozen-repository.js";
+
+export type FixtureReplayMode = "none" | "duplicate_start" | "recover_after_partial";
+
+interface ScriptedMissionTurnBase {
+	readonly deliveryId: string;
+	readonly progress?: readonly FakeTurnProgress[];
+	readonly replayMode?: FixtureReplayMode;
+}
+
+export type ScriptedMissionTurn =
+	| (ScriptedMissionTurnBase & {
+			readonly disposition: Exclude<
+				CoordinatorTurnDisposition,
+				{ readonly kind: "propose_contract" }
+			>;
+			readonly revision?: never;
+	  })
+	| (ScriptedMissionTurnBase & {
+			readonly disposition: Extract<
+				CoordinatorTurnDisposition,
+				{ readonly kind: "propose_contract" }
+			>;
+			readonly revision: ContractRevision;
+	  });
+
+export interface ScriptedContractAcknowledgement {
+	readonly participantAgentId: string;
+	readonly revisionId: string;
+	readonly contractVersion: number;
+	readonly artifact: ArtifactRef;
+}
+
+export interface FixtureVerificationCommand {
+	readonly command: FixedCommand;
+	readonly summary: string;
+	readonly durationMs: number;
+}
+
+export interface MissionFixtureEnvironment {
+	readonly verificationCommands: Readonly<
+		Record<string, Readonly<Record<string, FixtureVerificationCommand>>>
+	>;
+}
+
+export interface ScriptedMissionFixture<TEnvironment extends MissionFixtureEnvironment> {
+	readonly coordinatorConfig: MissionCoordinatorConfig;
+	readonly artifacts: readonly HostInputArtifact[];
+	readonly turnsByParticipant: Readonly<Record<string, readonly ScriptedMissionTurn[]>>;
+	readonly contractAcknowledgements: readonly ScriptedContractAcknowledgement[];
+	prepareEnvironment(): Promise<TEnvironment>;
+	disposeEnvironment(environment: TEnvironment): Promise<void>;
+}
+
+export interface FixtureHostTurnTrace {
+	readonly participantAgentId: string;
+	readonly input: StartTurnInput;
+	readonly events: readonly HostEvent[];
+	readonly replayMode: FixtureReplayMode;
+}
+
+export interface MissionFixtureRunResult<TEnvironment extends MissionFixtureEnvironment> {
+	readonly state: MissionCoordinatorState;
+	readonly events: readonly MissionCoordinatorEvent[];
+	readonly hostTurns: readonly FixtureHostTurnTrace[];
+	readonly adapterCounters: Readonly<Record<string, FakeAdapterCounters>>;
+	readonly duplicateDeliveriesSuppressed: number;
+	readonly duplicateAcknowledgementsSuppressed: number;
+	readonly recoveredHostTurns: number;
+	readonly humanInterventions: 0;
+	readonly environment: TEnvironment;
+	dispose(): Promise<void>;
+}
+
+/** Runs one fully pre-scripted Mission after the initial owner-controlled kickoff. */
+export async function runMissionFixture<TEnvironment extends MissionFixtureEnvironment>(
+	fixture: ScriptedMissionFixture<TEnvironment>,
+): Promise<MissionFixtureRunResult<TEnvironment>> {
+	const environment = await fixture.prepareEnvironment();
+	try {
+		return await runPreparedMissionFixture(fixture, environment);
+	} catch (error) {
+		await fixture.disposeEnvironment(environment);
+		throw error;
+	}
+}
+
+async function runPreparedMissionFixture<TEnvironment extends MissionFixtureEnvironment>(
+	fixture: ScriptedMissionFixture<TEnvironment>,
+	environment: TEnvironment,
+): Promise<MissionFixtureRunResult<TEnvironment>> {
+	const context = fixture.coordinatorConfig.mission_context;
+	const participants = context.manifest.participants;
+	const adapters: Record<string, FakeAgentHostAdapter> = {};
+	const sessions: Record<string, HostSessionRef> = {};
+	const turnQueues: Record<string, ScriptedMissionTurn[]> = {};
+	const acknowledgementQueue = [...fixture.contractAcknowledgements];
+
+	for (const participant of participants) {
+		const turns = [...(fixture.turnsByParticipant[participant.agent_id] ?? [])];
+		const adapter = new FakeAgentHostAdapter();
+		for (const turn of turns) {
+			adapter.queueOutcome({
+				kind: "completed",
+				events: turn.progress,
+				disposition: turn.disposition,
+			});
+		}
+		adapters[participant.agent_id] = adapter;
+		turnQueues[participant.agent_id] = turns;
+		sessions[participant.agent_id] = await adapter.ensureSession({
+			missionId: context.manifest.mission_id,
+			participantId: participant.agent_id,
+			workspaceAlias: participant.workspace_alias,
+		});
+	}
+
+	let state = createMissionCoordinatorState(fixture.coordinatorConfig);
+	state = reduceMissionCoordinatorEvent(state, {
+		...eventEnvelope(state.sequence_no + 1, context.manifest.mission_id),
+		type: "participants_accepted",
+		participant_agent_ids: participants.map((participant) => participant.agent_id),
+		contract: context.manifest.shared_contract,
+	});
+
+	const hostTurns: FixtureHostTurnTrace[] = [];
+	let duplicateDeliveriesSuppressed = 0;
+	let duplicateAcknowledgementsSuppressed = 0;
+	let recoveredHostTurns = 0;
+	let steps = 0;
+
+	while (state.status === "active") {
+		steps += 1;
+		if (steps > context.manifest.max_turns * 3) {
+			throw new Error("Scripted Mission exceeded its deterministic runner step limit");
+		}
+
+		if (state.pending_revision !== null) {
+			const scripted = acknowledgementQueue.shift();
+			if (scripted === undefined) {
+				throw new Error(
+					`No scripted acknowledgement remains for revision ${state.pending_revision.revision_id}`,
+				);
+			}
+			const acknowledgement = {
+				...eventEnvelope(state.sequence_no + 1, context.manifest.mission_id),
+				type: "contract_acknowledged" as const,
+				participant_agent_id: scripted.participantAgentId,
+				revision_id: scripted.revisionId,
+				contract_version: scripted.contractVersion,
+				artifact: scripted.artifact,
+			};
+			state = reduceMissionCoordinatorEvent(state, acknowledgement);
+			if (duplicateAcknowledgementsSuppressed === 0) {
+				const beforeReplay = state;
+				state = reduceMissionCoordinatorEvent(state, acknowledgement);
+				assertDeepEqual(state, beforeReplay, "duplicate contract acknowledgement changed state");
+				duplicateAcknowledgementsSuppressed += 1;
+			}
+			continue;
+		}
+
+		const participantAgentId = state.current_participant_agent_id;
+		if (participantAgentId === null) {
+			break;
+		}
+		const turn = turnQueues[participantAgentId]?.shift();
+		if (turn === undefined) {
+			throw new Error(`No scripted turn remains for current participant ${participantAgentId}`);
+		}
+		const adapter = requireValue(adapters[participantAgentId], "fake adapter");
+		const session = requireValue(sessions[participantAgentId], "host session");
+		const missionInputs = deriveHostMissionInputs(context, participantAgentId);
+		const peerMessages = state.messages.filter(
+			(message) => message.author_agent_id !== participantAgentId,
+		);
+		const input: StartTurnInput = {
+			session,
+			missionId: context.manifest.mission_id,
+			deliveryId: turn.deliveryId,
+			contractVersion: state.contract_version,
+			missionSequence: state.sequence_no + 1,
+			objective: missionInputs.objective,
+			assignment: missionInputs.assignment,
+			acceptanceCriteria: [...missionInputs.acceptanceCriteria],
+			peerMessages: peerMessages.map((message) => ({
+				messageId: message.message_id,
+				authorAgentId: message.author_agent_id,
+				kind: message.type,
+				body: message.body,
+			})),
+			artifacts: collectTurnArtifacts(fixture.artifacts, state, peerMessages),
+		};
+		const replayMode = turn.replayMode ?? "none";
+		const events = await executeHostTurn(adapter, input, replayMode);
+		const terminal = events.at(-1);
+		if (terminal?.kind !== "completed") {
+			throw new Error(`Scripted host turn did not complete: ${turn.deliveryId}`);
+		}
+		assertDeepEqual(terminal.disposition, turn.disposition, "host disposition changed");
+
+		const sequence = state.sequence_no + 1;
+		const envelope = eventEnvelope(sequence, context.manifest.mission_id);
+		const message = createMessage(turn.disposition, state, participantAgentId, envelope);
+		const revision = createRevision(turn);
+		const completedEvent = {
+			...envelope,
+			type: "turn_completed" as const,
+			participant_agent_id: participantAgentId,
+			delivery_id: turn.deliveryId,
+			contract_version: input.contractVersion,
+			disposition: terminal.disposition,
+			message,
+			revision,
+		};
+		state = reduceMissionCoordinatorEvent(state, completedEvent);
+		if (replayMode === "duplicate_start") {
+			const beforeReplay = state;
+			state = reduceMissionCoordinatorEvent(state, completedEvent);
+			assertDeepEqual(state, beforeReplay, "duplicate delivery changed coordinator state");
+			duplicateDeliveriesSuppressed += 1;
+		}
+		if (replayMode === "recover_after_partial") {
+			recoveredHostTurns += 1;
+		}
+		hostTurns.push({ participantAgentId, input, events, replayMode });
+	}
+
+	if (state.status !== "verifying") {
+		throw new Error(`Scripted Mission did not reach verification: ${state.status}`);
+	}
+
+	for (const participant of participants) {
+		const required = fixture.coordinatorConfig.required_verification_commands[participant.agent_id];
+		for (const commandId of required ?? []) {
+			const registered = environment.verificationCommands[participant.agent_id]?.[commandId];
+			if (registered === undefined) {
+				throw new Error(`No local verification command is registered for ${commandId}`);
+			}
+			const sequence = state.sequence_no + 1;
+			const createdAt = timestampFor(sequence);
+			let output = "";
+			let passed = true;
+			try {
+				output = await runFixedCommand(registered.command);
+			} catch {
+				passed = false;
+			}
+			state = reduceMissionCoordinatorEvent(state, {
+				...eventEnvelope(sequence, context.manifest.mission_id),
+				type: "verification_recorded",
+				participant_agent_id: participant.agent_id,
+				contract_version: state.contract_version,
+				verification_round: state.verification_round,
+				evidence: {
+					verification_id: fixtureUuid("22000000", sequence),
+					command_id: commandId,
+					outcome: passed ? "passed" : "failed",
+					exit_code: passed ? 0 : 1,
+					duration_ms: registered.durationMs,
+					summary: registered.summary,
+					output_sha256: createHash("sha256").update(output, "utf8").digest("hex"),
+					artifacts: [],
+					recorded_at: createdAt,
+				},
+			});
+			if (!passed) {
+				throw new Error(`Local verification command failed: ${commandId}`);
+			}
+		}
+	}
+
+	if (state.status !== "completed") {
+		throw new Error(`Scripted Mission did not complete: ${state.status}`);
+	}
+	for (const [participantAgentId, turns] of Object.entries(turnQueues)) {
+		if (turns.length > 0) {
+			throw new Error(`Unused scripted turns remain for ${participantAgentId}`);
+		}
+	}
+	if (acknowledgementQueue.length > 0) {
+		throw new Error("Unused scripted contract acknowledgements remain");
+	}
+
+	let disposed = false;
+	return {
+		state,
+		events: state.applied_events,
+		hostTurns,
+		adapterCounters: Object.fromEntries(
+			Object.entries(adapters).map(([agentId, adapter]) => [agentId, adapter.counters]),
+		),
+		duplicateDeliveriesSuppressed,
+		duplicateAcknowledgementsSuppressed,
+		recoveredHostTurns,
+		humanInterventions: 0,
+		environment,
+		async dispose() {
+			if (!disposed) {
+				disposed = true;
+				await fixture.disposeEnvironment(environment);
+			}
+		},
+	};
+}
+
+async function executeHostTurn(
+	adapter: FakeAgentHostAdapter,
+	input: StartTurnInput,
+	mode: FixtureReplayMode,
+): Promise<readonly HostEvent[]> {
+	let events: readonly HostEvent[];
+	if (mode === "recover_after_partial") {
+		const iterator = adapter.startTurn(input)[Symbol.asyncIterator]();
+		const partial: HostEvent[] = [];
+		for (let index = 0; index < 2; index += 1) {
+			const next = await iterator.next();
+			if (next.done) {
+				break;
+			}
+			partial.push(next.value);
+		}
+		await iterator.return?.();
+		const ref = await adapter.lookupTurn(input.deliveryId);
+		if (ref === null) {
+			throw new Error(`Accepted host turn was not recoverable: ${input.deliveryId}`);
+		}
+		const recovered = await collect(adapter.recoverTurn(ref));
+		events = mergeReplay(partial, recovered);
+	} else {
+		events = await collect(adapter.startTurn(input));
+	}
+
+	validateHostEvents(input, events);
+	if (mode === "duplicate_start") {
+		const replayed = await collect(adapter.startTurn(input));
+		assertDeepEqual(replayed, events, "duplicate host start returned a different replay");
+	}
+	return events;
+}
+
+function validateHostEvents(input: StartTurnInput, events: readonly HostEvent[]): void {
+	let state = createHostEventStreamState({
+		sessionId: input.session.sessionId,
+		missionId: input.missionId,
+		deliveryId: input.deliveryId,
+		contractVersion: input.contractVersion,
+	});
+	for (const event of events) {
+		state = acceptHostEvent(state, event).state;
+	}
+	if (state.phase !== "terminal") {
+		throw new Error(`Host event replay is not terminal: ${input.deliveryId}`);
+	}
+}
+
+function mergeReplay(
+	partial: readonly HostEvent[],
+	recovered: readonly HostEvent[],
+): readonly HostEvent[] {
+	const bySequence = new Map<number, HostEvent>();
+	for (const event of [...partial, ...recovered]) {
+		const existing = bySequence.get(event.sequence);
+		if (existing !== undefined && !isDeepStrictEqual(existing, event)) {
+			throw new Error(`Host replay changed sequence ${event.sequence}`);
+		}
+		bySequence.set(event.sequence, structuredClone(event));
+	}
+	return [...bySequence.values()].sort((left, right) => left.sequence - right.sequence);
+}
+
+function createMessage(
+	disposition: CoordinatorTurnDisposition,
+	state: MissionCoordinatorState,
+	participantAgentId: string,
+	envelope: ReturnType<typeof eventEnvelope>,
+): Message | null {
+	if (disposition.kind !== "reply") {
+		return null;
+	}
+	return {
+		message_id: fixtureUuid("21000000", envelope.sequence_no),
+		mission_id: envelope.mission_id,
+		sequence_no: state.messages.length + 1,
+		author_agent_id: participantAgentId,
+		type: disposition.message_type,
+		body: disposition.message,
+		artifacts: disposition.artifacts ?? [],
+		contract_version: state.contract_version,
+		idempotency_key: `fixture:message:${envelope.sequence_no}`,
+		causal_parent_message_id: state.messages.at(-1)?.message_id ?? null,
+		created_at: envelope.created_at,
+	};
+}
+
+function createRevision(turn: ScriptedMissionTurn): ContractRevision | null {
+	if (turn.disposition.kind !== "propose_contract" || turn.revision === undefined) {
+		return null;
+	}
+	return structuredClone(turn.revision);
+}
+
+function collectTurnArtifacts(
+	artifacts: readonly HostInputArtifact[],
+	state: MissionCoordinatorState,
+	peerMessages: readonly Message[],
+): HostInputArtifact[] {
+	const required: Array<{ ref: ArtifactRef; expectedSource: ActorRef | null }> = [
+		{ ref: state.active_contract, expectedSource: activeContractSource(state) },
+	];
+	for (const message of peerMessages) {
+		for (const ref of message.artifacts) {
+			const existing = required.find(
+				(candidate) =>
+					candidate.ref.artifact_id === ref.artifact_id && candidate.ref.version === ref.version,
+			);
+			if (existing !== undefined) {
+				if (!isDeepStrictEqual(existing.ref, ref)) {
+					throw new Error(`Conflicting fixture metadata for artifact ${ref.artifact_id}`);
+				}
+				continue;
+			}
+			required.push({ ref, expectedSource: null });
+		}
+	}
+	const allowedSources: ActorRef[] = [
+		state.mission_context.created_by,
+		...state.mission_context.manifest.participants.map((participant) => ({
+			principal_id: participant.agent_id,
+			kind: "agent" as const,
+		})),
+	];
+	return required.map(({ ref, expectedSource }) =>
+		findArtifact(artifacts, ref, expectedSource, allowedSources),
+	);
+}
+
+function activeContractSource(state: MissionCoordinatorState): ActorRef {
+	if (isDeepStrictEqual(state.active_contract, state.mission_context.manifest.shared_contract)) {
+		return structuredClone(state.mission_context.created_by);
+	}
+	const revision = state.accepted_revisions.find((candidate) =>
+		isDeepStrictEqual(candidate.artifact, state.active_contract),
+	);
+	if (revision === undefined) {
+		throw new Error(`No accepted revision owns contract version ${state.contract_version}`);
+	}
+	return { principal_id: revision.proposed_by_agent_id, kind: "agent" };
+}
+
+function findArtifact(
+	artifacts: readonly HostInputArtifact[],
+	ref: ArtifactRef,
+	expectedSource: ActorRef | null,
+	allowedSources: readonly ActorRef[],
+): HostInputArtifact {
+	const matches = artifacts.filter((candidate) => isDeepStrictEqual(candidate.artifact, ref));
+	if (matches.length !== 1) {
+		throw new Error(
+			`Expected one exact fixture payload for artifact ${ref.artifact_id} v${ref.version}, found ${matches.length}`,
+		);
+	}
+	const found = matches[0]!;
+	if (expectedSource !== null && !isDeepStrictEqual(found.source, expectedSource)) {
+		throw new Error(`Fixture provenance mismatch for artifact ${ref.artifact_id} v${ref.version}`);
+	}
+	if (!allowedSources.some((source) => isDeepStrictEqual(found.source, source))) {
+		throw new Error(`Fixture artifact source is not a Mission actor: ${ref.artifact_id}`);
+	}
+	return structuredClone(found);
+}
+
+function eventEnvelope(sequence: number, missionId: string) {
+	return {
+		event_id: fixtureUuid("20000000", sequence),
+		idempotency_key: `fixture:event:${sequence}`,
+		mission_id: missionId,
+		sequence_no: sequence,
+		created_at: timestampFor(sequence),
+	};
+}
+
+function fixtureUuid(prefix: string, sequence: number): string {
+	return `${prefix}-0000-4000-8000-${sequence.toString().padStart(12, "0")}`;
+}
+
+function timestampFor(sequence: number): string {
+	return new Date(Date.parse("2026-08-02T10:00:00.000Z") + sequence * 1_000).toISOString();
+}
+
+async function collect(events: AsyncIterable<HostEvent>): Promise<readonly HostEvent[]> {
+	const collected: HostEvent[] = [];
+	for await (const event of events) {
+		collected.push(event);
+	}
+	return collected;
+}
+
+function assertDeepEqual(left: unknown, right: unknown, message: string): void {
+	if (!isDeepStrictEqual(left, right)) {
+		throw new Error(message);
+	}
+}
+
+function requireValue<T>(value: T | undefined, name: string): T {
+	if (value === undefined) {
+		throw new Error(`Missing ${name}`);
+	}
+	return value;
+}


### PR DESCRIPTION
## Summary

- add a pure, replayable two-participant Mission coordinator with explicit exact contract acknowledgements, deterministic turn ownership, turn-budget liveness, idempotent replay, and verification-round fencing
- package a frozen backend/Android proof with locked Git commits and contract bytes, a golden 14-event transcript, duplicate-start suppression, partial recovery, local command verification, and a separate hidden evaluator
- record the Stage 1 result and its nonclaims; durable relay delivery, foreground Nodes, real model runtimes, cross-device execution, and A2A transport remain subsequent evidence gates

## Compatibility

Protocol UUID inputs now require canonical lowercase text. This prevents the same UUID from being treated as two actor identities under mixed casing.

## Validation

- `pnpm lint` (passes with 6 pre-existing unused-suppression warnings under `relay/`)
- `pnpm -r typecheck`
- `pnpm -r build`
- protocol: 81/81 tests
- MCP server: 152/152 tests
- relay DB-free: 39/39 tests; 68 database tests self-skipped because `RELAY_TEST_DATABASE_URL` is unset
- hostile ambient Git-config reproduction: 4/4 tests
- workspace export smoke
- packed tarball install and full 14-event fixture execution
- `git diff --check`

The two database E2E suites could not run locally because Docker Desktop is not running. GitHub CI remains the authoritative database-backed gate.

## Scope

This is a deterministic in-memory proof, not a claim of durable receipts, restart/offline recovery, production policy enforcement, real agent coding, cross-device communication, or full A2A conformance. JSON Schema/OpenAPI publication is deliberately deferred until a non-TypeScript Node or public gateway consumes this contract.

## Dependency

Stacked on #52 and intentionally targeted at `feat/node-protocol-foundation`.
