### PR TITLE
feat(relay): add durable Mission ledger kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,25 @@ jobs:
       # relay subprocess and is covered by the dedicated `e2e` job.
       - run: pnpm --filter @agentrelay/protocol --filter relay --filter agentrelay-mcp test
 
+  relay-image:
+    needs: lint-typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build relay image
+        run: docker build --tag agentrelay-relay:ci --file relay/Dockerfile .
+
+      - name: Smoke-test protocol workspace dependency
+        run: >-
+          docker run --rm
+          --entrypoint node
+          --workdir /app/relay
+          agentrelay-relay:ci
+          --input-type=module
+          --eval "await import('@agentrelay/protocol')"
+
   relay-integration:
     needs: lint-typecheck
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ repositories is the first proof, not the final product boundary.
 
 ## Honest status
 
-The repository currently ships an **authenticated asynchronous mailbox**, not the
-full autonomous runtime described above.
+The repository currently ships an **authenticated asynchronous mailbox plus an
+internal durable Mission-ledger kernel**, not the full autonomous runtime described
+above. The ledger has no public Node API or runtime activation path yet.
 
 ### Implemented today
 
@@ -32,6 +33,11 @@ full autonomous runtime described above.
 - An executable `@agentrelay/protocol` workspace with bounded Mission contracts,
   strict lifecycle and coordinator reducers, a deterministic fake runtime adapter,
   and a reproducible backend-Android transcript fixture.
+- Relay-visible Node/workspace contracts and Postgres persistence for Nodes,
+  workspace bindings, Missions, append-only Mission events, and stored per-Node
+  deliveries. The internal ledger service records one exact acceptance receipt per
+  participant, derives activation only after both receipts exist, binds every result
+  to its source work, and supports provenance-preserving cursor replay.
 - CLI setup, invite/join, install, doctor/fix, key rotation, audit, relay-synchronized
   block/unblock, and local trust management.
 - An in-process Slack dispatcher with encrypted-at-rest webhook configuration.
@@ -39,11 +45,15 @@ full autonomous runtime described above.
 ### Next architecture, not shipped yet
 
 - A persistent AgentRelay Node on every participating machine.
-- Durable delivery events, replay cursors, claims, acknowledgements, and duplicate
-  suppression.
-- Device and workspace identities, isolated worktrees, and runtime sessions.
+- Node-scoped credentials plus public enrollment and cursor-polling routes.
+- Fenced delivery claims, lease renewal/expiry, acknowledgements, retries,
+  dead-letter handling, and durable transport-operation receipts. The current kernel
+  can settle logical work, but it does not pretend that unclaimed work was executed.
+- Isolated worktrees and runtime sessions attached to the persisted device and
+  workspace identities.
 - Local policy enforcement outside the model.
-- Bounded, versioned Missions with acceptance criteria and executable verification.
+- A live Mission creation/acceptance/result API around the executable Mission
+  contracts and internal ledger.
 - Codex and Claude runtime adapters that start or resume real agent turns.
 
 The design is in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **Status:** Canonical system overview as of 2026-08-01.
+> **Status:** Canonical system overview as of 2026-08-02.
 > Current implementation details live in [`hld.md`](hld.md) and
 > [`lld.md`](lld.md). The accepted next target lives in
 > [`RFC 001: AgentRelay Node and Missions`](rfcs/001-agentrelay-node-and-missions.md).
@@ -27,6 +27,11 @@ The repository currently ships an authenticated asynchronous mailbox:
   completing handoff threads.
 - An executable protocol workspace with Mission/delivery/runtime contracts and an
   in-memory deterministic backend-Android coordination proof.
+- An internal Postgres Mission-ledger kernel with relay-visible Node and workspace
+  identity, immutable Mission context, current reducer projection, append-only
+  coordinator events, independent participant acceptance receipts, transactionally
+  derived stored deliveries, and per-Node cursor replay. It is not exposed as a Node
+  API yet.
 - Typed engineering artifacts plus provenance wrapping or structural markers on all
   teammate-originated mailbox content.
 - An in-process Slack notification dispatcher with encrypted-at-rest webhook setup.
@@ -36,8 +41,10 @@ This is useful groundwork, but it is not yet an autonomous agent network. The cu
 system does not contain:
 
 - A persistent local daemon that consumes work and starts or resumes agent turns.
-- Durable delivery events, replay cursors, processing claims, or acknowledgements.
-- Distinct device, workspace, runtime-session, or mission-lease identity.
+- Node-scoped credentials, enrollment/polling routes, processing claims, leases,
+  acknowledgements, retry, or dead-letter operations.
+- Runtime-session or Mission-lease identity; persisted Node/workspace records are an
+  internal routing foundation only.
 - Enforcement of the returned per-teammate trust overlay inside a runtime.
 - A current A2A v1 Agent Card endpoint or verified A2A compatibility.
 - End-to-end traces of local commands, edits, policy decisions, and tests.

--- a/docs/hld.md
+++ b/docs/hld.md
@@ -1,7 +1,8 @@
-# High-level design: current mailbox implementation
+# High-level design: current relay implementation
 
 > **Scope:** Current repository implementation as of 2026-08-02.
-> This document describes the existing handoff plane, not the autonomous Node target.
+> This document describes the existing handoff plane and internal durable-ledger
+> kernel, not the autonomous Node target.
 > See [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md) for the next system.
 
 ## Purpose
@@ -12,7 +13,8 @@ the conversation and enforces participant access. A local stdio MCP server expos
 the mailbox as tools to Claude Code or Codex.
 
 Humans or active agent sessions still initiate inbox checks and every subsequent
-tool call. There is no daemon, durable processing claim, or runtime activation loop.
+tool call. There is no daemon, Node credential/API, durable processing claim, or
+runtime activation loop.
 
 ## Components
 
@@ -42,6 +44,9 @@ The relay is a Node/TypeScript Hono service backed by Postgres and Drizzle. It o
 - Participant authorization and lifecycle transitions.
 - Audit records for invite, handoff/message, and block mutations.
 - An in-process Slack dispatcher with encrypted-at-rest webhook configuration.
+- An internal Mission-ledger service that persists Mission projections and append-only
+  events, derives stored per-Node deliveries in the same transaction, and reads them
+  through an opaque cursor. No HTTP route invokes this service yet.
 
 The HTTP application is stateless with respect to durable domain rows, but the
 notification queue is process-local and not durable.
@@ -78,6 +83,11 @@ Agent 1---1 AgentCard
   +---N Handoff ---N Message
              |
              +----- mutation AuditLog rows
+
+Agent 1---N Node ---N WorkspaceBinding
+                 \---N MissionParticipant ---1 Mission ---N MissionEvent
+                                                    |
+                                                    +---N NodeDelivery
 ```
 
 - `Agent` is the current logical developer identity.
@@ -93,6 +103,14 @@ Agent 1---1 AgentCard
 - `AgentBlock` prevents a blocked sender from creating a new handoff for the blocker
   or appending another message to an existing thread whose receiver blocked them.
 - `Invite` records signed-token identity, expiry, and one-time redemption.
+- `Node` and `WorkspaceBinding` are relay-visible routing identities without a local
+  checkout path or executable command authority.
+- `Mission` stores the immutable coordinator config plus a reducer projection;
+  `MissionEvent` is append-only and ordered within that Mission.
+- `NodeDelivery` points one Node cursor to work derived from a committed Mission
+  event. Verification work is bound to one coordinator round. This checkpoint can
+  logically settle consumed or invalidated work, but transport state remains
+  `stored`; it cannot claim or run deliveries.
 
 Exact tables and current route names are summarized in [`lld.md`](lld.md). Source
 under `relay/src/db/schema.ts` remains authoritative for column-level behavior.
@@ -159,6 +177,11 @@ and the relay-owned idempotency key is not exposed to the model.
   rows for invite, handoff/message, and block mutations.
 - Participant access checks and most state transitions.
 - Idempotent replay for handoff creation and message append.
+- Through the internal ledger service: Mission creation, ordered event append,
+  independent exact participant-acceptance receipts, reducer-projection updates,
+  source-delivery and causal links, derived stored deliveries, logical settlement,
+  audit, stable event/delivery-ID replay, and joined cursor replay. Each mutation and
+  its consequences share one Postgres transaction.
 
 ### Best effort today
 
@@ -168,10 +191,11 @@ and the relay-owned idempotency key is not exposed to the model.
 
 ### Not implemented today
 
-- A durable event/outbox ledger and replay cursor.
-- Delivery claim, acknowledgement, retry lease, or duplicate processing receipt.
+- Node enrollment/credentials or an authenticated polling route over the internal
+  Node/workspace and delivery records.
+- Delivery claim, transport acknowledgement, retry lease, dead-letter transition, or
+  general transport-operation receipt.
 - Runtime-session start/resume/cancel.
-- Device and workspace identity.
 - Local worktree isolation and per-Mission policy enforcement.
 - Local command, edit, test, and permission-decision audit.
 - A current A2A compatibility proof.
@@ -212,10 +236,17 @@ model. See the security section of [`architecture.md`](architecture.md).
 - Block/unblock and content-bearing mutations use the same directed-pair transaction
   lock, so no new content mutation can commit after a successful block response.
 - A terminal handoff rejects new messages and transitions.
+- Mission-event append takes a Mission-scoped transaction lock, reconstructs the
+  current projection from stored events, then commits the new event, projection,
+  source-work settlement, derived deliveries, and audit together. Each participant
+  acceptance is its own exact receipt; the second receipt atomically derives the
+  aggregate activation event and first turn. A failed delivery insert rolls back that
+  entire mutation. Cursor reads do not imply claim, execution, or acknowledgement.
 
 ## Relationship to the next design
 
 The current APIs remain a compatibility and inspection surface while Missions are
-proved. The next design adds Nodes, workspace bindings, durable events, deliveries,
-claims, runs, and Mission revisions rather than stretching the handoff row into a
-runtime scheduler.
+proved. The internal kernel now stores Nodes, workspace bindings, Missions, events,
+and unclaimed deliveries without stretching the handoff row into a scheduler. The
+next checkpoint adds separately revocable Node credentials and fenced lease/claim/
+completion APIs before any local runtime is allowed to consume that work.

--- a/docs/lld.md
+++ b/docs/lld.md
@@ -1,6 +1,6 @@
-# Low-level design: current mailbox contracts
+# Low-level design: current relay contracts
 
-> **Scope:** Implemented code on `main` as of 2026-08-02.
+> **Scope:** Current repository implementation as of 2026-08-02.
 > This is a compact source-oriented reference, not a promise that planned fields or
 > routes exist. Future Node and Mission contracts belong to
 > [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md) until implemented.
@@ -19,15 +19,19 @@
 └── package.json         pnpm workspace scripts
 ```
 
-There is currently no `node/` daemon, persistent event consumer, or real runtime
-adapter. The executable Mission contracts, deterministic coordinator, fake adapter,
-and backend-Android proof fixture live in `protocol/`.
+There is currently no `node/` daemon, persistent event consumer, Node HTTP surface,
+or real runtime adapter. The executable Mission contracts, deterministic coordinator,
+fake adapter, and backend-Android proof fixture live in `protocol/`; the relay now
+contains an internal durable-ledger service that no route calls yet.
 
 ## Protocol workspace
 
 `@agentrelay/protocol` currently implements:
 
 - strict Mission, contract, message, artifact, delivery, run, and evidence schemas;
+- relay-visible Node/workspace descriptors, a trusted Mission-event envelope, a
+  client append-input contract that excludes relay-owned identity/order fields, and
+  stored-delivery cursor-page contracts;
 - pure Mission lifecycle and fenced-delivery reducers;
 - a replayable four-event coordinator boundary for participant acceptance, completed
   turns, explicit contract acknowledgement, and local verification evidence;
@@ -39,11 +43,12 @@ and backend-Android proof fixture live in `protocol/`.
 - reproducible backend and Android fixture repositories, a golden 14-event transcript,
   executable backend/Android/contract/public checks, and a separate hidden evaluator.
 
-The coordinator is pure and in memory. `applied_events` is test evidence, not a
-durable ledger or receipt store. The fixture uses pre-scripted fake outcomes, an
-explicit pre-kickoff acknowledgement queue, and pre-authored expected repository
-snapshots; it does not show a model writing code, a relay surviving restart, or two
-Nodes collaborating across machines. Exact evidence and nonclaims are recorded in
+The coordinator remains a pure reducer. Its `applied_events` projection is test and
+replay state, while the relay ledger persists validated event envelopes and reducer
+snapshots. The fixture still uses pre-scripted fake outcomes, an explicit pre-kickoff
+acknowledgement queue, and pre-authored expected repository snapshots; it does not
+show a model writing code, an authenticated Node consuming work, or two Nodes
+collaborating across machines. Exact evidence and nonclaims are recorded in
 [`experiment 001`](experiments/001-backend-android-deterministic-proof.md).
 
 ## Relay tables
@@ -58,12 +63,19 @@ the committed Drizzle migrations.
 | `api_keys` | Hashed bearer keys with label, last-used timestamp, and revocation timestamp. |
 | `handoffs` | Sender, recipient, summary, intent, four-state lifecycle, initial and completion artifacts, proposed action, metadata, timestamps, idempotency key. |
 | `messages` | Append-only handoff messages with separate generic payload and typed artifacts, per-thread sequence, and idempotency key. |
-| `audit_log` | Invite, handoff/message, and block mutation records: actor, action, resource, metadata, request ID, timestamp. |
+| `audit_log` | Invite, handoff/message, block, and internal Mission create/participant-accept/event mutation records: actor, action, resource, metadata, request ID, timestamp. |
 | `agent_blocks` | Blocker/blocked pairs enforced for new handoffs and each existing-thread append. |
 | `invites` | Signed-token hash, target handle/role, inviter, expiry, use timestamp, and redeemed agent. |
+| `nodes` | Internal device identity owned by one agent, with relay-visible capabilities, presence timestamp, and revocation state. No credential is issued yet. |
+| `workspace_bindings` | A Node-local logical alias represented at the relay by repository URL and allowed base refs. It deliberately has no checkout path. |
+| `missions` | Immutable coordinator config, current reducer projection/status/contract version, sequence, creator, and expiry. |
+| `mission_participants` | The exact agent, Node, and workspace binding selected for each two-party Mission, plus that participant's idempotent contract and opaque local-policy-grant acceptance receipt. |
+| `mission_events` | Append-only type-specific coordinator payload with relay-generated event ID, Mission sequence/time, service-supplied actor, source delivery, idempotency key, and causal parent. |
+| `node_deliveries` | Per-Node opaque cursor pointing to one Mission event, with contract/verification generation, logical settlement, and future lease/fencing state. |
 
-The current identity represents a logical developer/agent. It does not distinguish
-device, workspace, repository checkout, runtime, or Mission lease.
+Public mailbox authentication still represents a logical developer/agent. Internal
+Node and workspace identities now exist for deterministic Mission routing, but there
+is no Node credential, local checkout identity, runtime session, or Mission lease.
 
 ## Authentication
 
@@ -76,6 +88,47 @@ device, workspace, repository checkout, runtime, or Mission lease.
   updates local config after the response.
 
 Node-scoped credentials do not exist yet.
+
+## Internal Mission ledger
+
+`relay/src/services/mission-ledger.ts` is a service boundary, not a public route.
+
+- Mission creation validates the shared protocol config, requires each participant
+  to resolve to exactly one active `agent + Node + workspace alias + repository URL`,
+  stores that routing choice, and treats the manifest Mission ID as the exact
+  creation-replay identity.
+- Participant acceptance stores one strict receipt for the immutable Mission ID,
+  exact shared contract, and matching requested local-policy profile plus opaque
+  grant hash. Only the second independent receipt derives aggregate activation.
+- Event append accepts only the strict client input variant. The service supplies
+  event ID, Mission ID, sequence, timestamp, causal parent, and delivery targets, and
+  checks its actor argument against coordinator event ownership. Every Node-produced
+  result must name a still-unsettled source delivery assigned to that actor with the
+  exact work kind, contract version, and verification round. Authentication and
+  lease fencing must be added by the future Node route.
+- A Mission-scoped transaction lock serializes concurrent appends. The service first
+  resolves exact idempotent replay, then reconstructs the reducer from ordered stored
+  events and rejects a divergent snapshot or invalid transition.
+- An event, reducer projection, source-work settlement, every derived delivery, and
+  audit row commit together. An acceptance receipt and its audit commit together;
+  the second receipt also commits aggregate activation and the first turn. A failed
+  derived-delivery insert rolls back the whole triggering mutation.
+- Deliveries are derived for the next turn, both sides of a contract acknowledgement,
+  or both participants' verification phase. Contract acknowledgement work carries
+  the pending contract version; verification work carries its coordinator round.
+  Result submission logically settles source work, and a failed verification settles
+  every outstanding delivery from that round. Transport state remains `stored`; no
+  code can lease, acknowledge, retry, or execute deliveries yet.
+- `listStoredDeliveryEvents` filters by one Node ID argument inside the trusted
+  internal service boundary, reads strictly increasing
+  global-`bigserial` cursors, excludes settled work, joins each delivery to its
+  immutable event plus persisted actor/source/causal provenance, and never mutates
+  delivery state. An empty page retains the caller's checkpoint. Cursor gaps after
+  rolled-back transactions are valid. The future claim operation must also scan
+  recoverable expired leases independently of this new-work cursor.
+
+This internal surface is intentionally not mounted under `/agents`, `/a2a`, or a
+temporary agent-authenticated Node route.
 
 ## HTTP surface
 
@@ -294,8 +347,9 @@ Important limits:
 ## Audit and revocation
 
 Relay audit rows cover invite mint/redeem, handoff create/accept/complete/cancel,
-message append, and block/unblock. Registration, card updates, key rotation, and agent
-disable still write no audit row. Audit also does not record commands, tool
+message append, block/unblock, and internal Mission create/participant accept/event
+append. Registration, card updates, key rotation, and agent disable still write no
+audit row. Audit also does not record commands, tool
 arguments/results, file edits, tests, or permission decisions performed by a local
 coding-agent host.
 
@@ -361,6 +415,7 @@ command.
 ## Boundary with the next design
 
 Do not extend `accepted_by_session` or the four-state handoff table into a distributed
-runtime scheduler. The next slice persists explicit Nodes, workspace bindings,
-Missions, events, deliveries, claims, runs, acknowledgements, and idempotency receipts
-while keeping the mailbox API as a compatibility and inspection surface.
+runtime scheduler. Nodes, workspace bindings, Missions, events, and stored deliveries
+now have a separate internal ledger. The next slice adds Node credentials and a
+fenced claim/renew/complete API with immutable attempt evidence and durable operation
+receipts, while keeping the mailbox API as a compatibility and inspection surface.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -52,13 +52,26 @@ in-memory scripted proof, not durable relay or real-runtime evidence.
 
 ## 3. Build durable delivery
 
-- [ ] Persist Nodes, workspace bindings, Missions, events, deliveries, claims, runs,
-  and acknowledgements.
-- [ ] Append each event and delivery record transactionally with its domain mutation.
-- [ ] Add per-Mission sequence numbers and cursor replay.
+- [x] Persist internal Nodes, workspace bindings, exact Mission participant routing,
+  Mission config/projection, append-only events, and initially stored deliveries.
+- [x] Append each coordinator event, reducer projection, derived delivery set, and
+  audit row transactionally.
+- [x] Add relay-owned per-Mission event sequence numbers and read-only per-Node cursor
+  replay over joined immutable events.
+- [x] Persist two independent exact acceptance receipts, bind results to source work,
+  and prevent settled or stale verification-round work from advancing a Mission.
+- [ ] Add independently revocable Node credentials and authenticated enrollment,
+  Mission, and polling routes.
 - [ ] Add claim leases, renewal, expiry, retry, cancellation, and dead-letter policy.
-- [ ] Store idempotency receipts for the Mission retention period.
+- [ ] Persist claim/attempt history, runs, acknowledgements, and exact operation
+  receipts for the Mission retention period.
 - [ ] Prove reconnect and recovery through cursor polling; leave SSE out of this slice.
+
+The completed kernel is deliberately internal: no agent credential can impersonate a
+Node, and no runtime can consume an unfenced delivery. Event append replays immutable
+event and derived-delivery IDs; logical settlement is distinct from transport
+acknowledgement. The next state-changing Node operations need fenced, durable
+operation receipts.
 
 Required tests: disconnect before claim, after claim, and after host acceptance;
 duplicate signal; relay restart; late output after terminal Mission.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> **Updated:** 2026-08-01. This roadmap replaces the old mailbox -> Auto Mode ->
+> **Updated:** 2026-08-02. This roadmap replaces the old mailbox -> Auto Mode ->
 > Ambient Agent release sequence. The architectural contract is
 > [`RFC 001: AgentRelay Node and Missions`](rfcs/001-agentrelay-node-and-missions.md).
 
@@ -49,6 +49,11 @@ relay delivery and real Nodes remain unproved.
 including one contract revision, without a real coding-agent runtime.
 
 ## Stage 2: durable delivery ledger
+
+**Status:** internal ledger kernel implemented with independent acceptance receipts,
+source-bound result settlement, verification generations, and joined cursor replay.
+Node credentials, public polling, fenced leases, transport acknowledgements,
+recovery, and the Stage 2 exit gate remain open.
 
 - Add node identity, workspace-binding, Mission, event, delivery, claim, run, and
   acknowledgement persistence.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
 
   relay:
     dependencies:
+      '@agentrelay/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       '@hono/node-server':
         specifier: ^1.13.7
         version: 1.19.14(hono@4.12.15)

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -4,8 +4,9 @@ Executable contracts for AgentRelay's bounded two-participant Mission loop.
 
 The package contains:
 
-- strict Zod schemas for Mission manifests, contract revisions, typed messages,
-  artifact references, policy requests, delivery leases, runs, and evidence;
+- strict Zod schemas for relay-visible Nodes/workspaces, Mission manifests,
+  participant acceptance receipts, contract revisions, typed messages, artifact
+  references, delivery/cursor envelopes, runs, and evidence;
 - pure Mission, fenced-delivery, and deterministic coordinator reducers that reject
   invalid transitions;
 - a runtime-neutral host adapter contract, with a deterministic fake under
@@ -39,7 +40,15 @@ identities require explicit events for the exact revision artifact, and the next
 then belongs to the participant opposite the proposer. Each readiness cycle receives
 a new verification round, so delayed evidence from an older cycle is rejected.
 Required verification command IDs come from local coordinator configuration, never
-peer text. Authenticated event ingestion remains a relay responsibility.
+peer text. Every participant result carries its source delivery ID, and verification
+deliveries/results carry one exact coordinator round. Authenticated event ingestion,
+source-work ownership, settlement, and lease fencing remain relay responsibilities.
+
+`storedMissionDeliveryCursorPageSchema` carries each stored delivery together with
+its immutable Mission event and trusted actor/source/causal provenance. Empty pages
+may retain the caller's cursor checkpoint. `missionParticipantAcceptanceInputSchema`
+records the exact shared contract and an opaque hash for the matching local-policy
+grant without putting local policy details on the relay wire.
 
 The adapter contract makes replay semantics explicit: every event has a stable
 turn-local sequence, available usage is a monotonic cumulative turn snapshot, and

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -24,7 +24,7 @@
 		"build": "tsc -p tsconfig.json",
 		"prepack": "pnpm run build",
 		"test": "vitest run",
-		"test:exports": "node --input-type=module -e \"const p = await import('@agentrelay/protocol'); const t = await import('@agentrelay/protocol/testing'); if (!p.missionManifestSchema || !p.transitionDeliveryState || !p.acceptHostEvent || !p.missionCoordinatorEventSchema || !t.FakeAgentHostAdapter || !t.runMissionFixture || !t.backendAndroidMissionFixture) throw new Error('protocol exports missing')\"",
+		"test:exports": "node --input-type=module -e \"const p = await import('@agentrelay/protocol'); const t = await import('@agentrelay/protocol/testing'); if (!p.missionManifestSchema || !p.transitionDeliveryState || !p.acceptHostEvent || !p.missionCoordinatorEventSchema || !p.missionCoordinatorAppendInputSchema || !p.missionParticipantAcceptanceInputSchema || !p.storedMissionDeliveryItemSchema || !p.storedMissionDeliveryCursorPageSchema || !p.nodeDescriptorSchema || !p.workspaceBindingDescriptorSchema || !p.storedDeliveryCursorPageSchema || !t.FakeAgentHostAdapter || !t.runMissionFixture || !t.backendAndroidMissionFixture) throw new Error('protocol exports missing')\"",
 		"test:watch": "vitest",
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},

--- a/protocol/src/mission-coordinator.test.ts
+++ b/protocol/src/mission-coordinator.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
 	InvalidMissionCoordinatorEventError,
 	createMissionCoordinatorState,
+	missionCoordinatorAppendInputSchema,
 	missionCoordinatorEventSchema,
+	missionParticipantAcceptanceInputSchema,
 	reduceMissionCoordinatorEvent,
 	replayMissionCoordinatorEvents,
+	storedMissionDeliveryCursorPageSchema,
 } from "./mission-coordinator.js";
 
 const IDS = {
@@ -17,6 +20,8 @@ const IDS = {
 	revision: "00000000-0000-4000-8000-000000000007",
 	message1: "00000000-0000-4000-8000-000000000008",
 	message2: "00000000-0000-4000-8000-000000000009",
+	backendNode: "00000000-0000-4000-8000-000000000010",
+	androidNode: "00000000-0000-4000-8000-000000000011",
 } as const;
 
 const CONTRACT_V1 = {
@@ -79,6 +84,142 @@ const CONFIG = {
 };
 
 describe("Mission coordinator", () => {
+	it("accepts client append inputs without relay-owned event fields", () => {
+		const inputs = [
+			acceptedEvent(1),
+			replyTurn(2, IDS.backend, 1, IDS.message1, null, "Reply."),
+			acknowledgement(3, IDS.backend),
+			verificationEvent(4, IDS.backend, 1, "backend-contract"),
+		].map(toAppendInput);
+
+		for (const input of inputs) {
+			expect(missionCoordinatorAppendInputSchema.parse(input)).toEqual(input);
+			expect(input).toHaveProperty("idempotency_key");
+		}
+
+		expect(
+			missionCoordinatorAppendInputSchema.safeParse({
+				...inputs[0],
+				event_id: eventId(99),
+			}).success,
+		).toBe(false);
+		expect(
+			missionCoordinatorAppendInputSchema.safeParse({
+				...inputs[1],
+				message: null,
+			}).success,
+		).toBe(false);
+		for (const input of inputs.slice(2)) {
+			const withoutDelivery = { ...input };
+			delete withoutDelivery.delivery_id;
+			expect(missionCoordinatorAppendInputSchema.safeParse(withoutDelivery).success).toBe(false);
+		}
+	});
+
+	it("accepts one participant receipt without accepting participant identity from the payload", () => {
+		const acceptance = {
+			idempotency_key: "mission-acceptance:backend",
+			contract: CONTRACT_V1,
+			local_policy_grant: {
+				profile_name: "bounded-code",
+				grant_sha256: "e".repeat(64),
+			},
+		};
+
+		expect(missionParticipantAcceptanceInputSchema.parse(acceptance)).toEqual(acceptance);
+		expect(
+			missionParticipantAcceptanceInputSchema.safeParse({
+				...acceptance,
+				participant_agent_id: IDS.backend,
+			}).success,
+		).toBe(false);
+		expect(
+			missionParticipantAcceptanceInputSchema.safeParse({
+				...acceptance,
+				contract: { ...CONTRACT_V1, local_path: "/tmp/contract.json" },
+			}).success,
+		).toBe(false);
+		expect(
+			missionParticipantAcceptanceInputSchema.safeParse({
+				...acceptance,
+				local_policy_grant: { ...acceptance.local_policy_grant, grant_sha256: "not-a-hash" },
+			}).success,
+		).toBe(false);
+	});
+
+	it("validates joined Mission events in one ordered Node cursor page", () => {
+		const firstEvent = acceptedEvent(1);
+		const secondEvent = replyTurn(2, IDS.backend, 1, IDS.message1, null, "Reply.");
+		const first = storedMissionDeliveryItem(1, firstEvent);
+		const second = storedMissionDeliveryItem(2, secondEvent);
+		const page = { items: [first, second], next_cursor: "2" };
+
+		expect(storedMissionDeliveryCursorPageSchema.parse(page)).toEqual(page);
+		expect(storedMissionDeliveryCursorPageSchema.parse({ items: [], next_cursor: "42" })).toEqual({
+			items: [],
+			next_cursor: "42",
+		});
+
+		expect(
+			storedMissionDeliveryCursorPageSchema.safeParse({
+				items: [
+					{
+						...first,
+						delivery: { ...first.delivery, mission_event_id: IDS.outsider },
+					},
+				],
+				next_cursor: "1",
+			}).success,
+		).toBe(false);
+		expect(
+			storedMissionDeliveryCursorPageSchema.safeParse({
+				items: [{ ...second, actor_agent_id: IDS.android }],
+				next_cursor: "2",
+			}).success,
+		).toBe(false);
+		expect(
+			storedMissionDeliveryCursorPageSchema.safeParse({
+				items: [{ ...second, source_delivery_id: IDS.outsider }],
+				next_cursor: "2",
+			}).success,
+		).toBe(false);
+		expect(
+			storedMissionDeliveryCursorPageSchema.safeParse({
+				items: [
+					{
+						...first,
+						event: { ...first.event, mission_id: IDS.outsider },
+					},
+				],
+				next_cursor: "1",
+			}).success,
+		).toBe(false);
+		expect(
+			storedMissionDeliveryCursorPageSchema.safeParse({
+				items: [second, first],
+				next_cursor: "1",
+			}).success,
+		).toBe(false);
+		expect(
+			storedMissionDeliveryCursorPageSchema.safeParse({
+				items: [
+					first,
+					{
+						...second,
+						delivery: { ...second.delivery, node_id: IDS.androidNode },
+					},
+				],
+				next_cursor: "2",
+			}).success,
+		).toBe(false);
+		expect(
+			storedMissionDeliveryCursorPageSchema.safeParse({
+				items: [first],
+				next_cursor: null,
+			}).success,
+		).toBe(false);
+	});
+
 	it("starts only from exact participant and contract acceptance", () => {
 		const initial = createMissionCoordinatorState(CONFIG);
 		const event = acceptedEvent(1);
@@ -497,6 +638,7 @@ function acknowledgement(sequence: number, participantAgentId: string) {
 		...envelope(sequence),
 		type: "contract_acknowledged" as const,
 		participant_agent_id: participantAgentId,
+		delivery_id: deliveryId(sequence),
 		revision_id: IDS.revision,
 		contract_version: 2,
 		artifact: structuredClone(CONTRACT_V2),
@@ -560,6 +702,7 @@ function verificationEvent(
 		...envelope(sequence),
 		type: "verification_recorded" as const,
 		participant_agent_id: participantAgentId,
+		delivery_id: deliveryId(sequence),
 		contract_version: contractVersion,
 		verification_round: verificationRound,
 		evidence: {
@@ -584,6 +727,51 @@ function envelope(sequence: number) {
 		sequence_no: sequence,
 		created_at: timestamp(sequence),
 	};
+}
+
+function storedMissionDeliveryItem(
+	cursor: number,
+	event: ReturnType<typeof acceptedEvent> | ReturnType<typeof replyTurn>,
+) {
+	const createdAt = timestamp(cursor);
+	return {
+		delivery: {
+			delivery_id: numberedUuid(400 + cursor),
+			node_id: IDS.backendNode,
+			mission_id: event.mission_id,
+			mission_event_id: event.event_id,
+			kind: "turn" as const,
+			cursor: String(cursor),
+			status: "stored" as const,
+			attempt_count: 0,
+			max_attempts: 3,
+			last_fencing_token: "0",
+			contract_version: 1,
+			verification_round: null,
+			lease: null,
+			idempotency_key: `delivery:${cursor}`,
+			causal_parent_delivery_id: null,
+			available_at: createdAt,
+			created_at: createdAt,
+			updated_at: createdAt,
+			acknowledged_at: null,
+			dead_lettered_at: null,
+		},
+		event,
+		actor_agent_id:
+			event.type === "participants_accepted" ? IDS.backend : event.participant_agent_id,
+		source_delivery_id: event.type === "participants_accepted" ? null : event.delivery_id,
+		causal_parent_event_id: cursor === 1 ? null : eventId(cursor - 1),
+	};
+}
+
+function toAppendInput(event: Record<string, unknown>): Record<string, unknown> {
+	const input = { ...event };
+	delete input.event_id;
+	delete input.mission_id;
+	delete input.sequence_no;
+	delete input.created_at;
+	return input;
 }
 
 function eventId(sequence: number): string {

--- a/protocol/src/mission-coordinator.ts
+++ b/protocol/src/mission-coordinator.ts
@@ -11,20 +11,18 @@ import {
 	artifactRefSchema,
 	contractRevisionSchema,
 	contractVersionSchema,
-	isoTimestampSchema,
+	deliveryCursorSchema,
 	messageSchema,
 	missionContextSchema,
+	missionEventEnvelopeSchema,
+	policyProfileNameSchema,
+	storedDeliverySchema,
 	turnDispositionSchema,
 	uuidSchema,
 	verificationEvidenceSchema,
 } from "./schemas.js";
 import { transitionMissionStatus } from "./state-machines.js";
 
-const idempotencyKeySchema = z
-	.string()
-	.min(1)
-	.max(128)
-	.regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/);
 const commandIdSchema = z
 	.string()
 	.min(1)
@@ -62,58 +60,72 @@ export const missionCoordinatorConfigSchema = z
 		}
 	});
 
-const eventEnvelopeShape = {
-	event_id: uuidSchema,
-	idempotency_key: idempotencyKeySchema,
-	mission_id: uuidSchema,
-	sequence_no: z.number().int().safe().positive(),
-	created_at: isoTimestampSchema,
-};
+const relayOwnedEventFields = {
+	event_id: true,
+	mission_id: true,
+	sequence_no: true,
+	created_at: true,
+} as const;
+
+const participantsAcceptedEventSchema = z
+	.object({
+		...missionEventEnvelopeSchema.shape,
+		type: z.literal("participants_accepted"),
+		participant_agent_ids: z.array(uuidSchema).length(2),
+		contract: artifactRefSchema,
+	})
+	.strict();
+const turnCompletedEventSchema = z
+	.object({
+		...missionEventEnvelopeSchema.shape,
+		type: z.literal("turn_completed"),
+		participant_agent_id: uuidSchema,
+		delivery_id: uuidSchema,
+		contract_version: contractVersionSchema,
+		disposition: turnDispositionSchema,
+		message: messageSchema.nullable(),
+		revision: contractRevisionSchema.nullable(),
+	})
+	.strict();
+const contractAcknowledgedEventSchema = z
+	.object({
+		...missionEventEnvelopeSchema.shape,
+		type: z.literal("contract_acknowledged"),
+		participant_agent_id: uuidSchema,
+		delivery_id: uuidSchema,
+		revision_id: uuidSchema,
+		contract_version: contractVersionSchema,
+		artifact: artifactRefSchema,
+	})
+	.strict();
+const verificationRecordedEventSchema = z
+	.object({
+		...missionEventEnvelopeSchema.shape,
+		type: z.literal("verification_recorded"),
+		participant_agent_id: uuidSchema,
+		delivery_id: uuidSchema,
+		contract_version: contractVersionSchema,
+		verification_round: z.number().int().safe().positive(),
+		evidence: verificationEvidenceSchema,
+	})
+	.strict();
 
 const rawMissionCoordinatorEventSchema = z.discriminatedUnion("type", [
-	z
-		.object({
-			...eventEnvelopeShape,
-			type: z.literal("participants_accepted"),
-			participant_agent_ids: z.array(uuidSchema).length(2),
-			contract: artifactRefSchema,
-		})
-		.strict(),
-	z
-		.object({
-			...eventEnvelopeShape,
-			type: z.literal("turn_completed"),
-			participant_agent_id: uuidSchema,
-			delivery_id: uuidSchema,
-			contract_version: contractVersionSchema,
-			disposition: turnDispositionSchema,
-			message: messageSchema.nullable(),
-			revision: contractRevisionSchema.nullable(),
-		})
-		.strict(),
-	z
-		.object({
-			...eventEnvelopeShape,
-			type: z.literal("contract_acknowledged"),
-			participant_agent_id: uuidSchema,
-			revision_id: uuidSchema,
-			contract_version: contractVersionSchema,
-			artifact: artifactRefSchema,
-		})
-		.strict(),
-	z
-		.object({
-			...eventEnvelopeShape,
-			type: z.literal("verification_recorded"),
-			participant_agent_id: uuidSchema,
-			contract_version: contractVersionSchema,
-			verification_round: z.number().int().safe().positive(),
-			evidence: verificationEvidenceSchema,
-		})
-		.strict(),
+	participantsAcceptedEventSchema,
+	turnCompletedEventSchema,
+	contractAcknowledgedEventSchema,
+	verificationRecordedEventSchema,
+]);
+
+const rawMissionCoordinatorAppendInputSchema = z.discriminatedUnion("type", [
+	participantsAcceptedEventSchema.omit(relayOwnedEventFields),
+	turnCompletedEventSchema.omit(relayOwnedEventFields),
+	contractAcknowledgedEventSchema.omit(relayOwnedEventFields),
+	verificationRecordedEventSchema.omit(relayOwnedEventFields),
 ]);
 
 type RawMissionCoordinatorEvent = z.infer<typeof rawMissionCoordinatorEventSchema>;
+type RawMissionCoordinatorAppendInput = z.infer<typeof rawMissionCoordinatorAppendInputSchema>;
 export type CoordinatorTurnDisposition = Extract<
 	TurnDisposition,
 	{ readonly kind: "reply" | "propose_contract" | "ready" }
@@ -128,46 +140,179 @@ export type MissionCoordinatorEvent =
 			readonly disposition: CoordinatorTurnDisposition;
 	  });
 
+type RawAppendTurnCompletedInput = Extract<
+	RawMissionCoordinatorAppendInput,
+	{ readonly type: "turn_completed" }
+>;
+export type MissionCoordinatorAppendInput =
+	| Exclude<RawMissionCoordinatorAppendInput, { readonly type: "turn_completed" }>
+	| (Omit<RawAppendTurnCompletedInput, "disposition"> & {
+			readonly disposition: CoordinatorTurnDisposition;
+	  });
+
 export const missionCoordinatorEventSchema = rawMissionCoordinatorEventSchema
-	.superRefine((event, ctx) => {
-		if (event.type === "participants_accepted") {
-			if (new Set(event.participant_agent_ids).size !== event.participant_agent_ids.length) {
+	.superRefine(validateCoordinatorEventPayload)
+	.transform((event): MissionCoordinatorEvent => event as MissionCoordinatorEvent);
+
+export const missionCoordinatorAppendInputSchema = rawMissionCoordinatorAppendInputSchema
+	.superRefine(validateCoordinatorEventPayload)
+	.transform((event): MissionCoordinatorAppendInput => event as MissionCoordinatorAppendInput);
+
+export const missionParticipantAcceptanceInputSchema = z
+	.object({
+		idempotency_key: missionEventEnvelopeSchema.shape.idempotency_key,
+		contract: artifactRefSchema,
+		local_policy_grant: z
+			.object({
+				profile_name: policyProfileNameSchema,
+				grant_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+			})
+			.strict(),
+	})
+	.strict();
+
+export const storedMissionDeliveryItemSchema = z
+	.object({
+		delivery: storedDeliverySchema,
+		event: missionCoordinatorEventSchema,
+		actor_agent_id: uuidSchema,
+		source_delivery_id: uuidSchema.nullable(),
+		causal_parent_event_id: uuidSchema.nullable(),
+	})
+	.strict()
+	.superRefine((item, ctx) => {
+		if (item.delivery.mission_event_id !== item.event.event_id) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Delivery must reference the returned Mission event",
+				path: ["delivery", "mission_event_id"],
+			});
+		}
+		if (item.delivery.mission_id !== item.event.mission_id) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Delivery and event must belong to the same Mission",
+				path: ["delivery", "mission_id"],
+			});
+		}
+		if (item.event.type === "participants_accepted") {
+			if (item.source_delivery_id !== null) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
-					message: "Accepted Mission participants must be unique",
-					path: ["participant_agent_ids"],
+					message: "Derived participant acceptance has no source delivery",
+					path: ["source_delivery_id"],
 				});
 			}
-			return;
+		} else {
+			if (item.actor_agent_id !== item.event.participant_agent_id) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Stored event actor must match the participant result",
+					path: ["actor_agent_id"],
+				});
+			}
+			if (item.source_delivery_id !== item.event.delivery_id) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Stored event must retain its source delivery",
+					path: ["source_delivery_id"],
+				});
+			}
 		}
-		if (event.type !== "turn_completed") {
-			return;
+	});
+
+export const storedMissionDeliveryCursorPageSchema = z
+	.object({
+		items: z.array(storedMissionDeliveryItemSchema).max(200),
+		next_cursor: deliveryCursorSchema.nullable(),
+	})
+	.strict()
+	.superRefine((page, ctx) => {
+		for (let index = 1; index < page.items.length; index += 1) {
+			const previousCursor = page.items[index - 1]!.delivery.cursor;
+			const cursor = page.items[index]!.delivery.cursor;
+			if (compareDeliveryCursors(previousCursor, cursor) >= 0) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Delivery cursors must be strictly increasing",
+					path: ["items", index, "delivery", "cursor"],
+				});
+			}
 		}
 
-		const kind = event.disposition.kind;
-		if ((kind === "reply") !== (event.message !== null)) {
+		const nodeIds = new Set(page.items.map((item) => item.delivery.node_id));
+		if (nodeIds.size > 1) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
-				message: "Reply dispositions require exactly one Message companion",
-				path: ["message"],
+				message: "A Mission delivery cursor page belongs to one Node",
+				path: ["items"],
 			});
 		}
-		if ((kind === "propose_contract") !== (event.revision !== null)) {
+
+		const finalCursor = page.items.at(-1)?.delivery.cursor;
+		if (finalCursor !== undefined && page.next_cursor !== finalCursor) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
-				message: "Contract proposals require exactly one revision companion",
-				path: ["revision"],
+				message: "Next cursor must match the final returned delivery",
+				path: ["next_cursor"],
 			});
 		}
-		if (kind !== "reply" && kind !== "propose_contract" && kind !== "ready") {
+	});
+
+export type MissionParticipantAcceptanceInput = z.infer<
+	typeof missionParticipantAcceptanceInputSchema
+>;
+export type StoredMissionDeliveryItem = z.infer<typeof storedMissionDeliveryItemSchema>;
+export type StoredMissionDeliveryCursorPage = z.infer<typeof storedMissionDeliveryCursorPageSchema>;
+
+function compareDeliveryCursors(left: string, right: string): number {
+	if (left.length !== right.length) {
+		return left.length > right.length ? 1 : -1;
+	}
+	return left === right ? 0 : left > right ? 1 : -1;
+}
+
+function validateCoordinatorEventPayload(
+	event: RawMissionCoordinatorEvent | RawMissionCoordinatorAppendInput,
+	ctx: z.RefinementCtx,
+): void {
+	if (event.type === "participants_accepted") {
+		if (new Set(event.participant_agent_ids).size !== event.participant_agent_ids.length) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
-				message: "This coordinator slice supports reply, propose_contract, and ready turns",
-				path: ["disposition", "kind"],
+				message: "Accepted Mission participants must be unique",
+				path: ["participant_agent_ids"],
 			});
 		}
-	})
-	.transform((event): MissionCoordinatorEvent => event as MissionCoordinatorEvent);
+		return;
+	}
+	if (event.type !== "turn_completed") {
+		return;
+	}
+
+	const kind = event.disposition.kind;
+	if ((kind === "reply") !== (event.message !== null)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "Reply dispositions require exactly one Message companion",
+			path: ["message"],
+		});
+	}
+	if ((kind === "propose_contract") !== (event.revision !== null)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "Contract proposals require exactly one revision companion",
+			path: ["revision"],
+		});
+	}
+	if (kind !== "reply" && kind !== "propose_contract" && kind !== "ready") {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "This coordinator slice supports reply, propose_contract, and ready turns",
+			path: ["disposition", "kind"],
+		});
+	}
+}
 
 export type MissionCoordinatorConfig = z.infer<typeof missionCoordinatorConfigSchema>;
 

--- a/protocol/src/schemas.test.ts
+++ b/protocol/src/schemas.test.ts
@@ -6,11 +6,16 @@ import {
 	deliverySchema,
 	messageSchema,
 	missionContextSchema,
+	missionEventEnvelopeSchema,
 	missionManifestSchema,
+	nodeDescriptorSchema,
 	policyRequestSchema,
 	runSchema,
+	storedDeliveryCursorPageRequestSchema,
+	storedDeliveryCursorPageSchema,
 	turnDispositionSchema,
 	verificationEvidenceSchema,
+	workspaceBindingDescriptorSchema,
 } from "./schemas.js";
 
 const ids = {
@@ -26,6 +31,8 @@ const ids = {
 	lease: "00000000-0000-4000-8000-000000000010",
 	run: "00000000-0000-4000-8000-000000000011",
 	revision: "00000000-0000-4000-8000-000000000012",
+	workspaceBinding: "00000000-0000-4000-8000-000000000013",
+	otherNode: "00000000-0000-4000-8000-000000000014",
 } as const;
 
 const artifact = {
@@ -89,6 +96,100 @@ const manifest = {
 function clone<T>(value: T): T {
 	return structuredClone(value);
 }
+
+describe("relay-visible Node contracts", () => {
+	const node = {
+		node_id: ids.node,
+		agent_id: ids.backendAgent,
+		name: "backend-mac",
+		status: "active" as const,
+		capabilities: ["runtime.fake"],
+		last_seen_at: "2026-08-02T10:01:00.000Z",
+		created_at: "2026-08-02T10:00:00.000Z",
+		updated_at: "2026-08-02T10:01:00.000Z",
+		revoked_at: null,
+	};
+	const binding = {
+		workspace_binding_id: ids.workspaceBinding,
+		node_id: ids.node,
+		agent_id: ids.backendAgent,
+		alias: "backend-api",
+		repository_url: "https://github.com/acme/backend.git",
+		allowed_base_refs: ["refs/heads/main"],
+		status: "active" as const,
+		created_at: "2026-08-02T10:01:00.000Z",
+		updated_at: "2026-08-02T10:01:00.000Z",
+		revoked_at: null,
+	};
+
+	it("describes a Node and logical workspace without exposing local authority", () => {
+		expect(nodeDescriptorSchema.parse(node)).toEqual(node);
+		expect(workspaceBindingDescriptorSchema.parse(binding)).toEqual(binding);
+
+		expect(
+			workspaceBindingDescriptorSchema.safeParse({
+				...binding,
+				local_path: "/Users/alice/backend",
+				allowed_commands: ["git push"],
+			}).success,
+		).toBe(false);
+	});
+
+	it("requires revocation state and chronology to agree", () => {
+		expect(
+			nodeDescriptorSchema.safeParse({
+				...node,
+				status: "revoked",
+				revoked_at: null,
+			}).success,
+		).toBe(false);
+		expect(
+			nodeDescriptorSchema.safeParse({
+				...node,
+				capabilities: ["runtime.fake", "runtime.fake"],
+			}).success,
+		).toBe(false);
+		expect(
+			workspaceBindingDescriptorSchema.safeParse({
+				...binding,
+				status: "revoked",
+				revoked_at: "2026-08-02T09:59:00.000Z",
+			}).success,
+		).toBe(false);
+		expect(
+			workspaceBindingDescriptorSchema.safeParse({
+				...binding,
+				allowed_base_refs: ["../outside"],
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe("missionEventEnvelopeSchema", () => {
+	const envelope = {
+		event_id: ids.event,
+		idempotency_key: "mission-event:1",
+		mission_id: ids.mission,
+		sequence_no: 1,
+		created_at: "2026-08-02T10:02:00.000Z",
+	};
+
+	it("accepts only relay-owned event identity and ordering fields", () => {
+		expect(missionEventEnvelopeSchema.parse(envelope)).toEqual(envelope);
+		expect(
+			missionEventEnvelopeSchema.safeParse({
+				...envelope,
+				sequence_no: 0,
+			}).success,
+		).toBe(false);
+		expect(
+			missionEventEnvelopeSchema.safeParse({
+				...envelope,
+				local_path: "/tmp/repo",
+			}).success,
+		).toBe(false);
+	});
+});
 
 describe("missionManifestSchema", () => {
 	it("accepts a bounded two-participant version-1 Mission", () => {
@@ -406,6 +507,7 @@ describe("deliverySchema", () => {
 		max_attempts: 3,
 		last_fencing_token: "1",
 		contract_version: 1,
+		verification_round: null,
 		lease: {
 			lease_id: ids.lease,
 			fencing_token: "1",
@@ -419,9 +521,89 @@ describe("deliverySchema", () => {
 		acknowledged_at: null,
 		dead_lettered_at: null,
 	};
+	const storedDelivery = {
+		...leasedDelivery,
+		status: "stored" as const,
+		attempt_count: 0,
+		last_fencing_token: "0",
+		lease: null,
+		updated_at: leasedDelivery.created_at,
+	};
 
 	it("accepts a leased durable delivery", () => {
 		expect(deliverySchema.parse(leasedDelivery)).toEqual(leasedDelivery);
+	});
+
+	it("supports contract-acknowledgement delivery work", () => {
+		const acknowledgement = {
+			...storedDelivery,
+			kind: "contract_acknowledgement" as const,
+		};
+		expect(deliverySchema.parse(acknowledgement)).toEqual(acknowledgement);
+	});
+
+	it("binds verification work to one coordinator round", () => {
+		const verification = {
+			...storedDelivery,
+			kind: "verification" as const,
+			verification_round: 2,
+		};
+		expect(deliverySchema.parse(verification)).toEqual(verification);
+		expect(deliverySchema.safeParse({ ...verification, verification_round: null }).success).toBe(
+			false,
+		);
+		expect(deliverySchema.safeParse({ ...storedDelivery, verification_round: 1 }).success).toBe(
+			false,
+		);
+	});
+
+	it("validates an ordered, single-Node stored-delivery cursor page", () => {
+		expect(storedDeliveryCursorPageRequestSchema.parse({})).toEqual({
+			after_cursor: null,
+			limit: 50,
+		});
+		const second = {
+			...storedDelivery,
+			delivery_id: "00000000-0000-4000-8000-000000000099",
+			cursor: "2",
+		};
+		const page = { items: [storedDelivery, second], next_cursor: "2" };
+		expect(storedDeliveryCursorPageSchema.parse(page)).toEqual(page);
+		expect(storedDeliveryCursorPageSchema.parse({ items: [], next_cursor: "42" })).toEqual({
+			items: [],
+			next_cursor: "42",
+		});
+		expect(
+			storedDeliveryCursorPageRequestSchema.safeParse({
+				after_cursor: "9223372036854775808",
+				limit: 50,
+			}).success,
+		).toBe(false);
+
+		expect(
+			storedDeliveryCursorPageSchema.safeParse({
+				items: [second, storedDelivery],
+				next_cursor: "1",
+			}).success,
+		).toBe(false);
+		expect(
+			storedDeliveryCursorPageSchema.safeParse({
+				items: [storedDelivery, { ...second, node_id: ids.otherNode }],
+				next_cursor: "2",
+			}).success,
+		).toBe(false);
+		expect(
+			storedDeliveryCursorPageSchema.safeParse({
+				items: [leasedDelivery],
+				next_cursor: "1",
+			}).success,
+		).toBe(false);
+		expect(
+			storedDeliveryCursorPageSchema.safeParse({
+				items: [storedDelivery],
+				next_cursor: null,
+			}).success,
+		).toBe(false);
 	});
 
 	it("requires active leases and matching terminal timestamps", () => {

--- a/protocol/src/schemas.ts
+++ b/protocol/src/schemas.ts
@@ -33,6 +33,20 @@ const aliasSchema = z
 	.refine((value) => value !== "." && value !== "..", "Alias cannot be a path segment");
 const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
 const baseCommitSchema = z.string().regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/);
+export const repositoryRefSchema = z
+	.string()
+	.min(1)
+	.max(256)
+	.regex(/^[A-Za-z0-9][A-Za-z0-9._/-]*$/)
+	.refine(
+		(value) =>
+			!value.includes("..") &&
+			!value.includes("//") &&
+			!value.endsWith("/") &&
+			!value.endsWith(".") &&
+			!value.endsWith(".lock"),
+		"Repository ref is not a safe canonical ref name",
+	);
 function boundedOpaqueReferenceSchema(maxLength: number) {
 	return z
 		.string()
@@ -84,6 +98,16 @@ export const deliveryStatusSchema = z.enum([
 	"dead_lettered",
 ]);
 
+export const deliveryKindSchema = z.enum(["turn", "verification", "contract_acknowledgement"]);
+
+export const deliveryCursorSchema = z
+	.string()
+	.regex(/^[1-9][0-9]*$/)
+	.max(19)
+	.refine((cursor) => compareDecimalStrings(cursor, "9223372036854775807") <= 0, {
+		message: "Delivery cursor exceeds Postgres bigint range",
+	});
+
 export const runStatusSchema = z.enum(["running", "completed", "failed", "cancelled"]);
 
 export const artifactTypeSchema = z
@@ -115,6 +139,69 @@ export const actorRefSchema = z
 		kind: z.enum(["owner", "agent"]),
 	})
 	.strict();
+
+export const nodeStatusSchema = z.enum(["active", "revoked"]);
+
+export const nodeDescriptorSchema = z
+	.object({
+		node_id: uuidSchema,
+		agent_id: uuidSchema,
+		name: aliasSchema,
+		status: nodeStatusSchema,
+		capabilities: z.array(identifierSchema).max(32),
+		last_seen_at: isoTimestampSchema.nullable(),
+		created_at: isoTimestampSchema,
+		updated_at: isoTimestampSchema,
+		revoked_at: isoTimestampSchema.nullable(),
+	})
+	.strict()
+	.superRefine((node, ctx) => {
+		if ((node.status === "revoked") !== (node.revoked_at !== null)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Node revocation timestamp must match revoked status",
+				path: ["revoked_at"],
+			});
+		}
+		if (
+			node.revoked_at !== null &&
+			(Date.parse(node.revoked_at) < Date.parse(node.created_at) ||
+				Date.parse(node.revoked_at) > Date.parse(node.updated_at))
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Node revocation timestamp must fall within its persisted lifetime",
+				path: ["revoked_at"],
+			});
+		}
+		if (Date.parse(node.updated_at) < Date.parse(node.created_at)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Node update cannot precede enrollment",
+				path: ["updated_at"],
+			});
+		}
+		if (
+			node.last_seen_at !== null &&
+			(Date.parse(node.last_seen_at) < Date.parse(node.created_at) ||
+				Date.parse(node.last_seen_at) > Date.parse(node.updated_at))
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Node last-seen timestamp must fall within its persisted lifetime",
+				path: ["last_seen_at"],
+			});
+		}
+		if (new Set(node.capabilities).size !== node.capabilities.length) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Node capabilities must be unique",
+				path: ["capabilities"],
+			});
+		}
+	});
+
+export const workspaceBindingStatusSchema = z.enum(["active", "revoked"]);
 
 export const repositoryUrlSchema = z
 	.string()
@@ -157,6 +244,55 @@ export const repositoryUrlSchema = z
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				message: "Repository URL must not contain query parameters or fragments",
+			});
+		}
+	});
+
+export const workspaceBindingDescriptorSchema = z
+	.object({
+		workspace_binding_id: uuidSchema,
+		node_id: uuidSchema,
+		agent_id: uuidSchema,
+		alias: aliasSchema,
+		repository_url: repositoryUrlSchema,
+		allowed_base_refs: z.array(repositoryRefSchema).max(32),
+		status: workspaceBindingStatusSchema,
+		created_at: isoTimestampSchema,
+		updated_at: isoTimestampSchema,
+		revoked_at: isoTimestampSchema.nullable(),
+	})
+	.strict()
+	.superRefine((binding, ctx) => {
+		if ((binding.status === "revoked") !== (binding.revoked_at !== null)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Workspace-binding revocation timestamp must match revoked status",
+				path: ["revoked_at"],
+			});
+		}
+		if (
+			binding.revoked_at !== null &&
+			(Date.parse(binding.revoked_at) < Date.parse(binding.created_at) ||
+				Date.parse(binding.revoked_at) > Date.parse(binding.updated_at))
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Workspace-binding revocation must fall within its persisted lifetime",
+				path: ["revoked_at"],
+			});
+		}
+		if (Date.parse(binding.updated_at) < Date.parse(binding.created_at)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Workspace-binding update cannot precede creation",
+				path: ["updated_at"],
+			});
+		}
+		if (new Set(binding.allowed_base_refs).size !== binding.allowed_base_refs.length) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Allowed base refs must be unique",
+				path: ["allowed_base_refs"],
 			});
 		}
 	});
@@ -390,6 +526,17 @@ export const missionContextSchema = z
 	})
 	.strict();
 
+/** Persisted common fields; the client supplies idempotency_key and the relay owns the rest. */
+export const missionEventEnvelopeSchema = z
+	.object({
+		event_id: uuidSchema,
+		idempotency_key: identifierSchema,
+		mission_id: uuidSchema,
+		sequence_no: z.number().int().positive().max(2_147_483_647),
+		created_at: isoTimestampSchema,
+	})
+	.strict();
+
 export const deliveryLeaseSchema = z
 	.object({
 		lease_id: uuidSchema,
@@ -406,16 +553,14 @@ export const deliverySchema = z
 		node_id: uuidSchema,
 		mission_id: uuidSchema,
 		mission_event_id: uuidSchema,
-		kind: z.enum(["turn", "verification"]),
-		cursor: z
-			.string()
-			.regex(/^[1-9][0-9]*$/)
-			.max(64),
+		kind: deliveryKindSchema,
+		cursor: deliveryCursorSchema,
 		status: deliveryStatusSchema,
 		attempt_count: z.number().int().nonnegative().max(100),
 		max_attempts: z.number().int().positive().max(100),
 		last_fencing_token: fencingTokenSchema,
 		contract_version: contractVersionSchema,
+		verification_round: z.number().int().positive().max(2_147_483_647).nullable(),
 		lease: deliveryLeaseSchema.nullable(),
 		idempotency_key: identifierSchema,
 		causal_parent_delivery_id: uuidSchema.nullable(),
@@ -428,6 +573,13 @@ export const deliverySchema = z
 	.strict()
 	.superRefine((delivery, ctx) => {
 		const needsLease = delivery.status === "leased" || delivery.status === "executing";
+		if ((delivery.kind === "verification") !== (delivery.verification_round !== null)) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Only verification deliveries carry a verification round",
+				path: ["verification_round"],
+			});
+		}
 		if (needsLease && delivery.lease === null) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
@@ -562,6 +714,57 @@ export const deliverySchema = z
 		}
 	});
 
+export const storedDeliverySchema = deliverySchema.refine(
+	(delivery): delivery is Delivery & { status: "stored" } => delivery.status === "stored",
+	{
+		message: "Cursor polling returns only stored deliveries",
+		path: ["status"],
+	},
+);
+
+export const storedDeliveryCursorPageRequestSchema = z
+	.object({
+		after_cursor: deliveryCursorSchema.nullable().default(null),
+		limit: z.number().int().positive().max(200).default(50),
+	})
+	.strict();
+
+export const storedDeliveryCursorPageSchema = z
+	.object({
+		items: z.array(storedDeliverySchema).max(200),
+		next_cursor: deliveryCursorSchema.nullable(),
+	})
+	.strict()
+	.superRefine((page, ctx) => {
+		for (let index = 1; index < page.items.length; index += 1) {
+			if (compareDecimalStrings(page.items[index - 1]!.cursor, page.items[index]!.cursor) >= 0) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Delivery cursors must be strictly increasing",
+					path: ["items", index, "cursor"],
+				});
+			}
+		}
+
+		const nodeIds = new Set(page.items.map((delivery) => delivery.node_id));
+		if (nodeIds.size > 1) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "A delivery cursor page belongs to one Node",
+				path: ["items"],
+			});
+		}
+
+		const finalCursor = page.items.at(-1)?.cursor;
+		if (finalCursor !== undefined && page.next_cursor !== finalCursor) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Next cursor must match the final returned delivery",
+				path: ["next_cursor"],
+			});
+		}
+	});
+
 export const runtimeNameSchema = boundedOpaqueReferenceSchema(128);
 export const runtimeVersionSchema = boundedOpaqueReferenceSchema(128);
 
@@ -671,6 +874,8 @@ export type IsoTimestamp = z.infer<typeof isoTimestampSchema>;
 export type OpaqueReference = z.infer<typeof opaqueReferenceSchema>;
 export type MissionStatus = z.infer<typeof missionStatusSchema>;
 export type DeliveryStatus = z.infer<typeof deliveryStatusSchema>;
+export type DeliveryKind = z.infer<typeof deliveryKindSchema>;
+export type DeliveryCursor = z.infer<typeof deliveryCursorSchema>;
 export type DeliveryLease = z.infer<typeof deliveryLeaseSchema>;
 export type RunStatus = z.infer<typeof runStatusSchema>;
 export type TokenUsage = z.infer<typeof tokenUsageSchema>;
@@ -680,6 +885,10 @@ export type MessageType = z.infer<typeof messageTypeSchema>;
 export type PolicyProfileName = z.infer<typeof policyProfileNameSchema>;
 export type PolicyRequest = z.infer<typeof policyRequestSchema>;
 export type ActorRef = z.infer<typeof actorRefSchema>;
+export type NodeStatus = z.infer<typeof nodeStatusSchema>;
+export type NodeDescriptor = z.infer<typeof nodeDescriptorSchema>;
+export type WorkspaceBindingStatus = z.infer<typeof workspaceBindingStatusSchema>;
+export type WorkspaceBindingDescriptor = z.infer<typeof workspaceBindingDescriptorSchema>;
 export type Participant = z.infer<typeof participantSchema>;
 export type ArtifactRef = z.infer<typeof artifactRefSchema>;
 export type SharedContractArtifact = z.infer<typeof sharedContractArtifactSchema>;
@@ -689,5 +898,16 @@ export type VerificationEvidence = z.infer<typeof verificationEvidenceSchema>;
 export type TurnDisposition = z.infer<typeof turnDispositionSchema>;
 export type MissionManifest = z.infer<typeof missionManifestSchema>;
 export type MissionContext = z.infer<typeof missionContextSchema>;
+export type MissionEventEnvelope = z.infer<typeof missionEventEnvelopeSchema>;
 export type Delivery = z.infer<typeof deliverySchema>;
+export type StoredDelivery = z.infer<typeof storedDeliverySchema>;
+export type StoredDeliveryCursorPageRequest = z.infer<typeof storedDeliveryCursorPageRequestSchema>;
+export type StoredDeliveryCursorPage = z.infer<typeof storedDeliveryCursorPageSchema>;
 export type Run = z.infer<typeof runSchema>;
+
+function compareDecimalStrings(left: string, right: string): number {
+	if (left.length !== right.length) {
+		return left.length > right.length ? 1 : -1;
+	}
+	return left === right ? 0 : left > right ? 1 : -1;
+}

--- a/protocol/src/testing/mission-fixture-runner.ts
+++ b/protocol/src/testing/mission-fixture-runner.ts
@@ -172,6 +172,7 @@ async function runPreparedMissionFixture<TEnvironment extends MissionFixtureEnvi
 				...eventEnvelope(state.sequence_no + 1, context.manifest.mission_id),
 				type: "contract_acknowledged" as const,
 				participant_agent_id: scripted.participantAgentId,
+				delivery_id: fixtureUuid("23000000", state.sequence_no + 1),
 				revision_id: scripted.revisionId,
 				contract_version: scripted.contractVersion,
 				artifact: scripted.artifact,
@@ -276,6 +277,7 @@ async function runPreparedMissionFixture<TEnvironment extends MissionFixtureEnvi
 				...eventEnvelope(sequence, context.manifest.mission_id),
 				type: "verification_recorded",
 				participant_agent_id: participant.agent_id,
+				delivery_id: fixtureUuid("24000000", sequence),
 				contract_version: state.contract_version,
 				verification_round: state.verification_round,
 				evidence: {

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -20,12 +20,14 @@ WORKDIR /app
 # Workspace metadata first — gives us the dependency graph for the install.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY relay/package.json relay/tsconfig.json ./relay/
+COPY protocol/package.json protocol/tsconfig.json ./protocol/
 
 # Install dev deps so we can run tsc during the build. Filtered to just the
 # relay subgraph (no mcp-server deps pulled into the build).
 RUN pnpm install --frozen-lockfile --filter relay...
 
-# Copy source (everything in relay/) and build.
+# Copy source for the relay and its protocol workspace dependency, then build.
+COPY protocol/src/ ./protocol/src/
 COPY relay/ ./relay/
 RUN pnpm --filter relay build
 
@@ -43,6 +45,8 @@ COPY --from=builder --chown=agentrelay:agentrelay /app/package.json /app/pnpm-lo
 COPY --from=builder --chown=agentrelay:agentrelay /app/relay/package.json ./relay/
 COPY --from=builder --chown=agentrelay:agentrelay /app/relay/dist ./relay/dist
 COPY --from=builder --chown=agentrelay:agentrelay /app/relay/drizzle ./relay/drizzle
+COPY --from=builder --chown=agentrelay:agentrelay /app/protocol/package.json ./protocol/
+COPY --from=builder --chown=agentrelay:agentrelay /app/protocol/dist ./protocol/dist
 
 # Production deps only.
 RUN pnpm install --frozen-lockfile --prod --filter relay... && \

--- a/relay/drizzle/0005_durable_delivery_ledger.sql
+++ b/relay/drizzle/0005_durable_delivery_ledger.sql
@@ -1,0 +1,259 @@
+-- Keep concurrent relay startup migrations from applying this file twice.
+SELECT pg_advisory_xact_lock(
+  hashtextextended('agentrelay:migration:0005_durable_delivery_ledger', 0)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "nodes" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "agent_id" uuid NOT NULL REFERENCES "agents"("id") ON DELETE restrict,
+  "name" text NOT NULL,
+  "status" text DEFAULT 'active' NOT NULL,
+  "capabilities" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "last_seen_at" timestamp with time zone,
+  "revoked_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "idx_nodes_identity_owner" UNIQUE ("id", "agent_id"),
+  CONSTRAINT "nodes_status_chk" CHECK ("status" IN ('active','revoked')),
+  CONSTRAINT "nodes_revoked_at_chk" CHECK (
+    ("status" = 'revoked') = ("revoked_at" IS NOT NULL)
+  )
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_nodes_agent" ON "nodes" ("agent_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_nodes_active_name"
+  ON "nodes" ("agent_id", "name") WHERE "status" = 'active';
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "workspace_bindings" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "node_id" uuid NOT NULL REFERENCES "nodes"("id") ON DELETE restrict,
+  "alias" text NOT NULL,
+  "repository_url" text NOT NULL,
+  "allowed_base_refs" text[] DEFAULT '{}'::text[] NOT NULL,
+  "status" text DEFAULT 'active' NOT NULL,
+  "revoked_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "idx_workspace_bindings_identity_node" UNIQUE ("id", "node_id"),
+  CONSTRAINT "workspace_bindings_status_chk" CHECK ("status" IN ('active','revoked')),
+  CONSTRAINT "workspace_bindings_revoked_at_chk" CHECK (
+    ("status" = 'revoked') = ("revoked_at" IS NOT NULL)
+  )
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_workspace_bindings_node" ON "workspace_bindings" ("node_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_workspace_bindings_active_alias"
+  ON "workspace_bindings" ("node_id", "alias") WHERE "status" = 'active';
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "missions" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "created_by_agent_id" uuid NOT NULL REFERENCES "agents"("id") ON DELETE restrict,
+  "coordinator_config" jsonb NOT NULL,
+  "state" jsonb NOT NULL,
+  "status" text DEFAULT 'awaiting_acceptance' NOT NULL,
+  "last_event_sequence" integer DEFAULT 0 NOT NULL,
+  "contract_version" integer DEFAULT 1 NOT NULL,
+  "expires_at" timestamp with time zone NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "missions_status_chk" CHECK (
+    "status" IN ('awaiting_acceptance','active','verifying','blocked','completed','cancelled','expired','failed')
+  ),
+  CONSTRAINT "missions_sequence_chk" CHECK ("last_event_sequence" >= 0),
+  CONSTRAINT "missions_contract_version_chk" CHECK ("contract_version" > 0)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_missions_creator"
+  ON "missions" ("created_by_agent_id", "created_at" DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_missions_status" ON "missions" ("status", "updated_at" DESC);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "mission_participants" (
+  "mission_id" uuid NOT NULL REFERENCES "missions"("id") ON DELETE restrict,
+  "agent_id" uuid NOT NULL REFERENCES "agents"("id") ON DELETE restrict,
+  "node_id" uuid NOT NULL REFERENCES "nodes"("id") ON DELETE restrict,
+  "workspace_binding_id" uuid NOT NULL REFERENCES "workspace_bindings"("id") ON DELETE restrict,
+  "role" text NOT NULL,
+  "status" text DEFAULT 'pending' NOT NULL,
+  "accepted_at" timestamp with time zone,
+  "acceptance_idempotency_key" text,
+  "acceptance_receipt" jsonb,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "mission_participants_pkey" PRIMARY KEY ("mission_id", "agent_id"),
+  CONSTRAINT "mission_participants_node_owner_fk"
+    FOREIGN KEY ("node_id", "agent_id") REFERENCES "nodes"("id", "agent_id") ON DELETE no action,
+  CONSTRAINT "mission_participants_binding_node_fk"
+    FOREIGN KEY ("workspace_binding_id", "node_id") REFERENCES "workspace_bindings"("id", "node_id") ON DELETE no action,
+  CONSTRAINT "mission_participants_status_chk" CHECK ("status" IN ('pending','accepted')),
+  CONSTRAINT "mission_participants_accepted_at_chk" CHECK (
+    ("status" = 'accepted') = ("accepted_at" IS NOT NULL)
+    AND ("status" = 'accepted') = ("acceptance_idempotency_key" IS NOT NULL)
+    AND ("status" = 'accepted') = ("acceptance_receipt" IS NOT NULL)
+  )
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_mission_participants_node"
+  ON "mission_participants" ("node_id", "mission_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_mission_participants_mission_node"
+  ON "mission_participants" ("mission_id", "node_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_mission_participants_acceptance_idempotency"
+  ON "mission_participants" ("mission_id", "acceptance_idempotency_key")
+  WHERE "acceptance_idempotency_key" IS NOT NULL;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "mission_events" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "mission_id" uuid NOT NULL REFERENCES "missions"("id") ON DELETE restrict,
+  "sequence_no" integer NOT NULL,
+  "type" text NOT NULL,
+  "actor_agent_id" uuid NOT NULL REFERENCES "agents"("id") ON DELETE restrict,
+  "idempotency_key" text NOT NULL,
+  "source_delivery_id" uuid,
+  "causal_parent_event_id" uuid,
+  "payload" jsonb NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "idx_mission_events_mission_identity" UNIQUE ("mission_id", "id"),
+  CONSTRAINT "mission_events_causal_parent_fk"
+    FOREIGN KEY ("mission_id", "causal_parent_event_id")
+    REFERENCES "mission_events"("mission_id", "id") ON DELETE no action,
+  CONSTRAINT "mission_events_actor_participant_fk"
+    FOREIGN KEY ("mission_id", "actor_agent_id")
+    REFERENCES "mission_participants"("mission_id", "agent_id") ON DELETE no action,
+  CONSTRAINT "mission_events_type_chk" CHECK (
+    "type" IN ('participants_accepted','turn_completed','contract_acknowledged','verification_recorded')
+  ),
+  CONSTRAINT "mission_events_sequence_chk" CHECK ("sequence_no" > 0)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_mission_events_sequence"
+  ON "mission_events" ("mission_id", "sequence_no");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_mission_events_idempotency"
+  ON "mission_events" ("mission_id", "idempotency_key");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_mission_events_created"
+  ON "mission_events" ("mission_id", "created_at");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "node_deliveries" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "node_id" uuid NOT NULL REFERENCES "nodes"("id") ON DELETE restrict,
+  "mission_id" uuid NOT NULL REFERENCES "missions"("id") ON DELETE restrict,
+  "mission_event_id" uuid NOT NULL REFERENCES "mission_events"("id") ON DELETE restrict,
+  "kind" text NOT NULL,
+  "cursor" bigserial NOT NULL,
+  "status" text DEFAULT 'stored' NOT NULL,
+  "attempt_count" integer DEFAULT 0 NOT NULL,
+  "max_attempts" integer DEFAULT 5 NOT NULL,
+  "last_fencing_token" text DEFAULT '0' NOT NULL,
+  "active_lease_id" uuid,
+  "lease_expires_at" timestamp with time zone,
+  "contract_version" integer NOT NULL,
+  "verification_round" integer,
+  "idempotency_key" text NOT NULL,
+  "causal_parent_delivery_id" uuid,
+  "settled_by_event_id" uuid,
+  "settled_at" timestamp with time zone,
+  "available_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "acknowledged_at" timestamp with time zone,
+  "dead_lettered_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "idx_node_deliveries_identity_scope" UNIQUE ("node_id", "mission_id", "id"),
+  CONSTRAINT "idx_node_deliveries_mission_identity" UNIQUE ("mission_id", "id"),
+  CONSTRAINT "node_deliveries_causal_parent_fk"
+    FOREIGN KEY ("node_id", "mission_id", "causal_parent_delivery_id")
+    REFERENCES "node_deliveries"("node_id", "mission_id", "id") ON DELETE no action,
+  CONSTRAINT "node_deliveries_event_mission_fk"
+    FOREIGN KEY ("mission_id", "mission_event_id")
+    REFERENCES "mission_events"("mission_id", "id") ON DELETE no action,
+  CONSTRAINT "node_deliveries_participant_node_fk"
+    FOREIGN KEY ("mission_id", "node_id")
+    REFERENCES "mission_participants"("mission_id", "node_id") ON DELETE no action,
+  CONSTRAINT "node_deliveries_settlement_event_mission_fk"
+    FOREIGN KEY ("mission_id", "settled_by_event_id")
+    REFERENCES "mission_events"("mission_id", "id") ON DELETE no action,
+  CONSTRAINT "node_deliveries_kind_chk" CHECK (
+    "kind" IN ('turn','verification','contract_acknowledgement')
+  ),
+  CONSTRAINT "node_deliveries_status_chk" CHECK (
+    "status" IN ('stored','leased','executing','acknowledged','dead_lettered')
+  ),
+  CONSTRAINT "node_deliveries_verification_round_chk" CHECK (
+    (("kind" = 'verification') = ("verification_round" IS NOT NULL))
+    AND ("verification_round" IS NULL OR "verification_round" > 0)
+  ),
+  CONSTRAINT "node_deliveries_attempt_chk" CHECK (
+    "attempt_count" >= 0 AND "max_attempts" > 0 AND "attempt_count" <= "max_attempts"
+  ),
+  CONSTRAINT "node_deliveries_fencing_token_chk" CHECK (
+    "last_fencing_token" ~ '^(0|[1-9][0-9]*)$'
+  ),
+  CONSTRAINT "node_deliveries_initial_fence_chk" CHECK (
+    ("attempt_count" = 0) = ("last_fencing_token" = '0')
+  ),
+  CONSTRAINT "node_deliveries_lease_chk" CHECK (
+    (("status" IN ('leased','executing')) = ("active_lease_id" IS NOT NULL))
+    AND (("status" IN ('leased','executing')) = ("lease_expires_at" IS NOT NULL))
+    AND ("status" NOT IN ('leased','executing') OR "attempt_count" > 0)
+  ),
+  CONSTRAINT "node_deliveries_acknowledged_at_chk" CHECK (
+    (("status" = 'acknowledged') = ("acknowledged_at" IS NOT NULL))
+    AND ("status" != 'acknowledged' OR "attempt_count" > 0)
+  ),
+  CONSTRAINT "node_deliveries_dead_lettered_at_chk" CHECK (
+    ("status" = 'dead_lettered') = ("dead_lettered_at" IS NOT NULL)
+  ),
+  CONSTRAINT "node_deliveries_settlement_chk" CHECK (
+    ("settled_by_event_id" IS NOT NULL) = ("settled_at" IS NOT NULL)
+  )
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_node_deliveries_cursor" ON "node_deliveries" ("cursor");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_node_deliveries_node_cursor"
+  ON "node_deliveries" ("node_id", "cursor");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_node_deliveries_event_kind"
+  ON "node_deliveries" ("node_id", "mission_event_id", "kind");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_node_deliveries_idempotency"
+  ON "node_deliveries" ("node_id", "idempotency_key");
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'mission_events_source_delivery_fk'
+      AND conrelid = 'mission_events'::regclass
+  ) THEN
+    ALTER TABLE "mission_events"
+      ADD CONSTRAINT "mission_events_source_delivery_fk"
+      FOREIGN KEY ("mission_id", "source_delivery_id")
+      REFERENCES "node_deliveries"("mission_id", "id") ON DELETE no action;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS nodes_set_updated_at ON nodes;
+--> statement-breakpoint
+CREATE TRIGGER nodes_set_updated_at
+  BEFORE UPDATE ON nodes FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS workspace_bindings_set_updated_at ON workspace_bindings;
+--> statement-breakpoint
+CREATE TRIGGER workspace_bindings_set_updated_at
+  BEFORE UPDATE ON workspace_bindings FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS missions_set_updated_at ON missions;
+--> statement-breakpoint
+CREATE TRIGGER missions_set_updated_at
+  BEFORE UPDATE ON missions FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS node_deliveries_set_updated_at ON node_deliveries;
+--> statement-breakpoint
+CREATE TRIGGER node_deliveries_set_updated_at
+  BEFORE UPDATE ON node_deliveries FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/relay/drizzle/meta/_journal.json
+++ b/relay/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1785675000000,
 			"tag": "0004_mailbox_integrity",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1785762000000,
+			"tag": "0005_durable_delivery_ledger",
+			"breakpoints": true
 		}
 	]
 }

--- a/relay/package.json
+++ b/relay/package.json
@@ -11,12 +11,16 @@
 	"main": "dist/main.js",
 	"files": ["dist"],
 	"scripts": {
+		"prebuild": "pnpm --filter @agentrelay/protocol build",
 		"build": "tsc -p tsconfig.json",
 		"start": "node dist/main.js",
 		"dev": "node --import tsx/esm src/main.ts",
+		"pretest": "pnpm --filter @agentrelay/protocol build",
 		"test": "vitest run",
 		"test:watch": "vitest",
+		"pretest:integration": "pnpm --filter @agentrelay/protocol build",
 		"test:integration": "bash scripts/test-integration.sh",
+		"pretypecheck": "pnpm --filter @agentrelay/protocol build",
 		"typecheck": "tsc -p tsconfig.json --noEmit",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "node --import tsx/esm src/db/migrate.ts",
@@ -24,6 +28,7 @@
 		"db:push": "drizzle-kit push"
 	},
 	"dependencies": {
+		"@agentrelay/protocol": "workspace:*",
 		"@hono/node-server": "^1.13.7",
 		"dotenv": "^16.4.7",
 		"drizzle-orm": "^0.36.4",

--- a/relay/scripts/test-integration.sh
+++ b/relay/scripts/test-integration.sh
@@ -37,13 +37,13 @@ truncate_all() {
   if [[ -n "${RELAY_TEST_TRUNCATE_VIA_PSQL:-}" ]]; then
     command -v psql >/dev/null || { echo "psql not on PATH" >&2; exit 1; }
     psql "$RELAY_TEST_DATABASE_URL" -q -c \
-      "TRUNCATE agents, agent_cards, api_keys, handoffs, messages, audit_log, agent_blocks, invites RESTART IDENTITY CASCADE;" \
+      "TRUNCATE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, nodes, agents, agent_cards, api_keys, handoffs, messages, audit_log, agent_blocks, invites RESTART IDENTITY CASCADE;" \
       >/dev/null 2>&1
     return
   fi
 
   docker exec "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -q -c \
-    "TRUNCATE agents, agent_cards, api_keys, handoffs, messages, audit_log, agent_blocks, invites RESTART IDENTITY CASCADE;" \
+    "TRUNCATE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, nodes, agents, agent_cards, api_keys, handoffs, messages, audit_log, agent_blocks, invites RESTART IDENTITY CASCADE;" \
     >/dev/null 2>&1
 }
 
@@ -52,7 +52,9 @@ truncate_all() {
 # are pure unit tests and run fine via the regular `test` script.
 INTEGRATION_FILES=(
   src/db/migration-0004.test.ts
+  src/db/migration-0005.test.ts
   src/db/schema.test.ts
+  src/services/mission-ledger.test.ts
   src/routes/admin.test.ts
   src/routes/agents.test.ts
   src/routes/invites.test.ts

--- a/relay/src/db/migration-0005.test.ts
+++ b/relay/src/db/migration-0005.test.ts
@@ -1,0 +1,540 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import postgres, { type Sql } from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { tryConnect } from "./test-utils.js";
+
+const TEST_URL = process.env.RELAY_TEST_DATABASE_URL ?? process.env.RELAY_DATABASE_URL;
+const conn = await tryConnect();
+const d = conn.available && TEST_URL ? describe : describe.skip;
+
+if (!conn.available || !TEST_URL) {
+	console.warn(`[migration-0005.test] skipping: ${conn.reason ?? "database URL unset"}`);
+}
+
+d("0005 durable delivery ledger migration", () => {
+	let sql: Sql;
+	let migration: string;
+	const schemaName = `migration_0005_${randomUUID().replaceAll("-", "")}`;
+
+	beforeAll(async () => {
+		sql = postgres(TEST_URL as string, { max: 1, onnotice: () => undefined });
+		await sql.unsafe(`CREATE SCHEMA "${schemaName}"`);
+		await sql.unsafe(`SET search_path TO "${schemaName}", public`);
+		await sql.unsafe(`
+			CREATE TABLE agents (
+				id uuid PRIMARY KEY,
+				handle text NOT NULL
+			);
+			CREATE FUNCTION set_updated_at() RETURNS TRIGGER AS $$
+			BEGIN
+				NEW.updated_at = now();
+				RETURN NEW;
+			END;
+			$$ LANGUAGE plpgsql;
+		`);
+		migration = await readFile(
+			new URL("../../drizzle/0005_durable_delivery_ledger.sql", import.meta.url),
+			"utf8",
+		);
+		await applyMigration(sql, migration);
+	});
+
+	afterAll(async () => {
+		if (sql) {
+			await sql.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+			await sql.end({ timeout: 2 });
+		}
+		if (conn.handle) await conn.handle.close();
+	});
+
+	it("applies idempotently without rewriting accepted participants or stored deliveries", async () => {
+		const fixture = await seedMigrationFixture(sql);
+		await applyMigration(sql, migration);
+
+		const [participant] = await sql<
+			Array<{
+				status: string;
+				acceptance_idempotency_key: string;
+				acceptance_receipt: unknown;
+			}>
+		>`
+			SELECT status, acceptance_idempotency_key, acceptance_receipt
+			FROM mission_participants
+			WHERE mission_id = ${fixture.missionAId} AND agent_id = ${fixture.agentAId}
+		`;
+		expect(participant).toEqual({
+			status: "accepted",
+			acceptance_idempotency_key: fixture.acceptanceA.idempotency_key,
+			acceptance_receipt: fixture.acceptanceA,
+		});
+
+		const [stored] = await sql<
+			Array<{
+				id: string;
+				cursor: string;
+				status: string;
+				attempt_count: number;
+				last_fencing_token: string;
+			}>
+		>`
+			SELECT id, cursor::text, status, attempt_count, last_fencing_token
+			FROM node_deliveries
+			WHERE id = ${fixture.deliveryAId}
+		`;
+		expect(stored).toEqual({
+			id: fixture.deliveryAId,
+			cursor: "1",
+			status: "stored",
+			attempt_count: 0,
+			last_fencing_token: "0",
+		});
+
+		const pathColumns = await sql<Array<{ column_name: string }>>`
+			SELECT column_name
+			FROM information_schema.columns
+			WHERE table_schema = ${schemaName}
+				AND table_name = 'workspace_bindings'
+				AND column_name LIKE '%path%'
+		`;
+		expect(pathColumns).toEqual([]);
+
+		await expect(sql`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_agent_id, idempotency_key, payload
+			) VALUES (
+				${randomUUID()},
+				${fixture.missionAId},
+				1,
+				${"participants_accepted"},
+				${fixture.agentAId},
+				${"accept:duplicate-sequence"},
+				${sql.json({})}
+			)
+		`).rejects.toThrow(/idx_mission_events_sequence/);
+	});
+
+	it("rejects participant agent/Node and workspace/Node identity mismatches", async () => {
+		const fixture = await seedMigrationFixture(sql);
+		const mismatchMissionId = randomUUID();
+		await sql`
+			INSERT INTO missions (id, created_by_agent_id, coordinator_config, state, expires_at)
+			VALUES (
+				${mismatchMissionId}, ${fixture.agentAId}, ${sql.json({ schema_version: 1 })},
+				${sql.json({ status: "awaiting_acceptance" })}, ${new Date(Date.now() + 60_000)}
+			)
+		`;
+
+		await expect(sql`
+			INSERT INTO mission_participants (
+				mission_id, agent_id, node_id, workspace_binding_id, role
+			) VALUES (
+				${mismatchMissionId}, ${fixture.agentAId}, ${fixture.nodeBId},
+				${fixture.bindingBId}, ${"backend"}
+			)
+		`).rejects.toThrow(/mission_participants_node_owner_fk/);
+
+		await expect(sql`
+			INSERT INTO mission_participants (
+				mission_id, agent_id, node_id, workspace_binding_id, role
+			) VALUES (
+				${mismatchMissionId}, ${fixture.agentAId}, ${fixture.nodeAId},
+				${fixture.bindingBId}, ${"backend"}
+			)
+		`).rejects.toThrow(/mission_participants_binding_node_fk/);
+	});
+
+	it("rejects cross-Mission event and delivery references", async () => {
+		const fixture = await seedMigrationFixture(sql);
+
+		await expect(sql`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_agent_id, idempotency_key,
+				causal_parent_event_id, payload
+			) VALUES (
+				${randomUUID()},
+				${fixture.missionAId},
+				2,
+				${"turn_completed"},
+				${fixture.agentAId},
+				${"event:cross-mission-parent"},
+				${fixture.eventBId},
+				${sql.json({})}
+			)
+		`).rejects.toThrow(/mission_events_causal_parent_fk/);
+
+		await expect(sql`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_agent_id, idempotency_key, payload
+			) VALUES (
+				${randomUUID()},
+				${fixture.missionBId},
+				2,
+				${"turn_completed"},
+				${fixture.agentAId},
+				${"event:non-participant-actor"},
+				${sql.json({})}
+			)
+		`).rejects.toThrow(/mission_events_actor_participant_fk/);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, contract_version,
+				verification_round, idempotency_key
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeAId},
+				${fixture.missionAId},
+				${fixture.eventBId},
+				${"verification"},
+				1,
+				1,
+				${"delivery:cross-mission-event"}
+			)
+		`).rejects.toThrow(/node_deliveries_event_mission_fk/);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, contract_version, idempotency_key
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeAId},
+				${fixture.missionBId},
+				${fixture.eventBId},
+				${"turn"},
+				1,
+				${"delivery:non-participant-node"}
+			)
+		`).rejects.toThrow(/node_deliveries_participant_node_fk/);
+	});
+
+	it("rejects delivery causal parents from another Node or Mission", async () => {
+		const fixture = await seedMigrationFixture(sql);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, contract_version,
+				verification_round, idempotency_key, causal_parent_delivery_id
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeBId},
+				${fixture.missionAId},
+				${fixture.eventAId},
+				${"verification"},
+				1,
+				1,
+				${"delivery:cross-node-parent"},
+				${fixture.deliveryAId}
+			)
+		`).rejects.toThrow(/node_deliveries_causal_parent_fk/);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, contract_version,
+				verification_round, idempotency_key, causal_parent_delivery_id
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeBId},
+				${fixture.missionBId},
+				${fixture.eventBId},
+				${"verification"},
+				1,
+				1,
+				${"delivery:cross-mission-parent"},
+				${fixture.deliveryAId}
+			)
+		`).rejects.toThrow(/node_deliveries_causal_parent_fk/);
+	});
+
+	it("requires verification rounds and complete settlement pairs", async () => {
+		const fixture = await seedMigrationFixture(sql);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, contract_version,
+				verification_round, idempotency_key
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeBId},
+				${fixture.missionAId},
+				${fixture.eventAId},
+				${"turn"},
+				1,
+				1,
+				${"delivery:turn-with-round"}
+			)
+		`).rejects.toThrow(/node_deliveries_verification_round_chk/);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, contract_version, idempotency_key
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeBId},
+				${fixture.missionAId},
+				${fixture.eventAId},
+				${"verification"},
+				1,
+				${"delivery:verification-without-round"}
+			)
+		`).rejects.toThrow(/node_deliveries_verification_round_chk/);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, contract_version,
+				idempotency_key, settled_by_event_id
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeBId},
+				${fixture.missionAId},
+				${fixture.eventAId},
+				${"contract_acknowledgement"},
+				1,
+				${"delivery:settlement-without-time"},
+				${fixture.eventAId}
+			)
+		`).rejects.toThrow(/node_deliveries_settlement_chk/);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, contract_version,
+				idempotency_key, settled_at
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeBId},
+				${fixture.missionAId},
+				${fixture.eventAId},
+				${"contract_acknowledgement"},
+				1,
+				${"delivery:settlement-time-without-event"},
+				${new Date()}
+			)
+		`).rejects.toThrow(/node_deliveries_settlement_chk/);
+	});
+
+	it("rejects partial and zero-attempt active leases", async () => {
+		const fixture = await seedMigrationFixture(sql);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, status, attempt_count,
+				last_fencing_token, active_lease_id, lease_expires_at, contract_version,
+				verification_round, idempotency_key
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeAId},
+				${fixture.missionAId},
+				${fixture.eventAId},
+				${"verification"},
+				${"leased"},
+				1,
+				${"1"},
+				${randomUUID()},
+				${null},
+				1,
+				1,
+				${"delivery:partial-lease"}
+			)
+		`).rejects.toThrow(/node_deliveries_lease_chk/);
+
+		await expect(sql`
+			INSERT INTO node_deliveries (
+				id, node_id, mission_id, mission_event_id, kind, status, attempt_count,
+				last_fencing_token, active_lease_id, lease_expires_at, contract_version,
+				verification_round, idempotency_key
+			) VALUES (
+				${randomUUID()},
+				${fixture.nodeAId},
+				${fixture.missionAId},
+				${fixture.eventAId},
+				${"verification"},
+				${"executing"},
+				0,
+				${"0"},
+				${randomUUID()},
+				${new Date(Date.now() + 60_000)},
+				1,
+				1,
+				${"delivery:zero-attempt-lease"}
+			)
+		`).rejects.toThrow(/node_deliveries_lease_chk/);
+	});
+});
+
+interface MigrationFixture {
+	readonly agentAId: string;
+	readonly agentBId: string;
+	readonly nodeAId: string;
+	readonly nodeBId: string;
+	readonly bindingAId: string;
+	readonly bindingBId: string;
+	readonly missionAId: string;
+	readonly missionBId: string;
+	readonly eventAId: string;
+	readonly eventBId: string;
+	readonly deliveryAId: string;
+	readonly deliveryBId: string;
+	readonly acceptanceA: AcceptanceReceipt;
+	readonly acceptanceB: AcceptanceReceipt;
+}
+
+interface AcceptanceReceipt {
+	readonly idempotency_key: string;
+	readonly contract: {
+		readonly artifact_id: string;
+		readonly type: "api_contract";
+		readonly version: 1;
+		readonly sha256: string;
+		readonly media_type: "application/json";
+		readonly byte_size: number;
+	};
+	readonly local_policy_grant: {
+		readonly profile_name: "bounded-code";
+		readonly grant_sha256: string;
+	};
+}
+
+async function applyMigration(sql: Sql, migration: string): Promise<void> {
+	await sql.begin(async (tx) => {
+		for (const statement of migration.split("--> statement-breakpoint")) {
+			if (statement.trim()) await tx.unsafe(statement);
+		}
+	});
+}
+
+async function seedMigrationFixture(sql: Sql): Promise<MigrationFixture> {
+	const agentAId = randomUUID();
+	const agentBId = randomUUID();
+	const nodeAId = randomUUID();
+	const nodeBId = randomUUID();
+	const bindingAId = randomUUID();
+	const bindingBId = randomUUID();
+	const missionAId = randomUUID();
+	const missionBId = randomUUID();
+	const eventAId = randomUUID();
+	const eventBId = randomUUID();
+	const deliveryAId = randomUUID();
+	const deliveryBId = randomUUID();
+	const acceptanceA = acceptanceReceipt(`accept:${missionAId}:a`, "a");
+	const acceptanceB = acceptanceReceipt(`accept:${missionBId}:b`, "b");
+	const acceptanceAForB = acceptanceReceipt(`accept:${missionAId}:b`, "c");
+
+	await sql`
+		INSERT INTO agents (id, handle) VALUES
+			(${agentAId}, ${`agent-a-${agentAId}@acme`}),
+			(${agentBId}, ${`agent-b-${agentBId}@acme`})
+	`;
+	await sql`
+		INSERT INTO nodes (id, agent_id, name, capabilities) VALUES
+			(${nodeAId}, ${agentAId}, ${"node-a"}, ${sql.json(["fake-runtime"])}),
+			(${nodeBId}, ${agentBId}, ${"node-b"}, ${sql.json(["fake-runtime"])})
+	`;
+	await sql`
+		INSERT INTO workspace_bindings (id, node_id, alias, repository_url, allowed_base_refs)
+		VALUES
+			(
+				${bindingAId}, ${nodeAId}, ${"workspace-a"},
+				${"https://github.com/example/a.git"}, ${["main"]}
+			),
+			(
+				${bindingBId}, ${nodeBId}, ${"workspace-b"},
+				${"https://github.com/example/b.git"}, ${["main"]}
+			)
+	`;
+	await sql`
+		INSERT INTO missions (id, created_by_agent_id, coordinator_config, state, status, expires_at)
+		VALUES
+			(
+				${missionAId}, ${agentAId}, ${sql.json({ schema_version: 1 })},
+				${sql.json({ status: "active" })}, ${"active"},
+				${new Date(Date.now() + 60_000)}
+			),
+			(
+				${missionBId}, ${agentBId}, ${sql.json({ schema_version: 1 })},
+				${sql.json({ status: "active" })}, ${"active"},
+				${new Date(Date.now() + 60_000)}
+			)
+	`;
+	await sql`
+		INSERT INTO mission_participants (
+			mission_id, agent_id, node_id, workspace_binding_id, role, status, accepted_at,
+			acceptance_idempotency_key, acceptance_receipt
+		) VALUES
+			(
+				${missionAId}, ${agentAId}, ${nodeAId}, ${bindingAId}, ${"backend"},
+				${"accepted"}, ${new Date()}, ${acceptanceA.idempotency_key},
+				${sql.json(acceptanceA)}
+			),
+			(
+				${missionAId}, ${agentBId}, ${nodeBId}, ${bindingBId}, ${"android"},
+				${"accepted"}, ${new Date()}, ${acceptanceAForB.idempotency_key},
+				${sql.json(acceptanceAForB)}
+			),
+			(
+				${missionBId}, ${agentBId}, ${nodeBId}, ${bindingBId}, ${"android"},
+				${"accepted"}, ${new Date()}, ${acceptanceB.idempotency_key},
+				${sql.json(acceptanceB)}
+			)
+	`;
+	await sql`
+		INSERT INTO mission_events (
+			id, mission_id, sequence_no, type, actor_agent_id, idempotency_key, payload
+		) VALUES
+			(
+				${eventAId}, ${missionAId}, 1, ${"participants_accepted"}, ${agentAId},
+				${"event:a"}, ${sql.json({ participant_agent_ids: [agentAId] })}
+			),
+			(
+				${eventBId}, ${missionBId}, 1, ${"participants_accepted"}, ${agentBId},
+				${"event:b"}, ${sql.json({ participant_agent_ids: [agentBId] })}
+			)
+	`;
+	await sql`
+		INSERT INTO node_deliveries (
+			id, node_id, mission_id, mission_event_id, kind, contract_version, idempotency_key
+		) VALUES
+			(
+				${deliveryAId}, ${nodeAId}, ${missionAId}, ${eventAId}, ${"turn"}, 1,
+				${"delivery:a"}
+			),
+			(
+				${deliveryBId}, ${nodeBId}, ${missionBId}, ${eventBId}, ${"turn"}, 1,
+				${"delivery:b"}
+			)
+	`;
+
+	return {
+		agentAId,
+		agentBId,
+		nodeAId,
+		nodeBId,
+		bindingAId,
+		bindingBId,
+		missionAId,
+		missionBId,
+		eventAId,
+		eventBId,
+		deliveryAId,
+		deliveryBId,
+		acceptanceA,
+		acceptanceB,
+	};
+}
+
+function acceptanceReceipt(idempotencyKey: string, hashCharacter: string): AcceptanceReceipt {
+	return {
+		idempotency_key: idempotencyKey,
+		contract: {
+			artifact_id: randomUUID(),
+			type: "api_contract",
+			version: 1,
+			sha256: hashCharacter.repeat(64),
+			media_type: "application/json",
+			byte_size: 128,
+		},
+		local_policy_grant: {
+			profile_name: "bounded-code",
+			grant_sha256: hashCharacter.repeat(64),
+		},
+	};
+}

--- a/relay/src/db/schema.ts
+++ b/relay/src/db/schema.ts
@@ -3,6 +3,7 @@ import {
 	bigserial,
 	check,
 	customType,
+	foreignKey,
 	index,
 	integer,
 	jsonb,
@@ -235,6 +236,302 @@ export const invites = pgTable(
 	}),
 );
 
+// ─── Durable Mission ledger ─────────────────────────────────────────────────
+
+export const nodes = pgTable(
+	"nodes",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		agentId: uuid("agent_id")
+			.notNull()
+			.references(() => agents.id, { onDelete: "restrict" }),
+		name: text("name").notNull(),
+		status: text("status").notNull().default("active"),
+		capabilities: jsonb("capabilities").notNull().default(sql`'[]'::jsonb`),
+		lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
+		revokedAt: timestamp("revoked_at", { withTimezone: true }),
+		createdAt,
+		updatedAt,
+	},
+	(t) => ({
+		agentIdx: index("idx_nodes_agent").on(t.agentId),
+		identityOwnerIdx: uniqueIndex("idx_nodes_identity_owner").on(t.id, t.agentId),
+		activeNameIdx: uniqueIndex("idx_nodes_active_name")
+			.on(t.agentId, t.name)
+			.where(sql`${t.status} = 'active'`),
+		statusCheck: check("nodes_status_chk", sql`${t.status} IN ('active','revoked')`),
+		revokedAtCheck: check(
+			"nodes_revoked_at_chk",
+			sql`(${t.status} = 'revoked') = (${t.revokedAt} IS NOT NULL)`,
+		),
+	}),
+);
+
+export const workspaceBindings = pgTable(
+	"workspace_bindings",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		nodeId: uuid("node_id")
+			.notNull()
+			.references(() => nodes.id, { onDelete: "restrict" }),
+		alias: text("alias").notNull(),
+		repositoryUrl: text("repository_url").notNull(),
+		allowedBaseRefs: textArray("allowed_base_refs").notNull().default(sql`'{}'::text[]`),
+		status: text("status").notNull().default("active"),
+		revokedAt: timestamp("revoked_at", { withTimezone: true }),
+		createdAt,
+		updatedAt,
+	},
+	(t) => ({
+		nodeIdx: index("idx_workspace_bindings_node").on(t.nodeId),
+		identityNodeIdx: uniqueIndex("idx_workspace_bindings_identity_node").on(t.id, t.nodeId),
+		activeAliasIdx: uniqueIndex("idx_workspace_bindings_active_alias")
+			.on(t.nodeId, t.alias)
+			.where(sql`${t.status} = 'active'`),
+		statusCheck: check("workspace_bindings_status_chk", sql`${t.status} IN ('active','revoked')`),
+		revokedAtCheck: check(
+			"workspace_bindings_revoked_at_chk",
+			sql`(${t.status} = 'revoked') = (${t.revokedAt} IS NOT NULL)`,
+		),
+	}),
+);
+
+export const missions = pgTable(
+	"missions",
+	{
+		id: uuid("id").primaryKey(),
+		createdByAgentId: uuid("created_by_agent_id")
+			.notNull()
+			.references(() => agents.id, { onDelete: "restrict" }),
+		coordinatorConfig: jsonb("coordinator_config").notNull(),
+		state: jsonb("state").notNull(),
+		status: text("status").notNull().default("awaiting_acceptance"),
+		lastEventSequence: integer("last_event_sequence").notNull().default(0),
+		contractVersion: integer("contract_version").notNull().default(1),
+		expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+		createdAt,
+		updatedAt,
+	},
+	(t) => ({
+		creatorIdx: index("idx_missions_creator").on(t.createdByAgentId, t.createdAt.desc()),
+		statusIdx: index("idx_missions_status").on(t.status, t.updatedAt.desc()),
+		statusCheck: check(
+			"missions_status_chk",
+			sql`${t.status} IN ('awaiting_acceptance','active','verifying','blocked','completed','cancelled','expired','failed')`,
+		),
+		sequenceCheck: check("missions_sequence_chk", sql`${t.lastEventSequence} >= 0`),
+		contractVersionCheck: check("missions_contract_version_chk", sql`${t.contractVersion} > 0`),
+	}),
+);
+
+export const missionParticipants = pgTable(
+	"mission_participants",
+	{
+		missionId: uuid("mission_id")
+			.notNull()
+			.references(() => missions.id, { onDelete: "restrict" }),
+		agentId: uuid("agent_id")
+			.notNull()
+			.references(() => agents.id, { onDelete: "restrict" }),
+		nodeId: uuid("node_id")
+			.notNull()
+			.references(() => nodes.id, { onDelete: "restrict" }),
+		workspaceBindingId: uuid("workspace_binding_id")
+			.notNull()
+			.references(() => workspaceBindings.id, { onDelete: "restrict" }),
+		role: text("role").notNull(),
+		status: text("status").notNull().default("pending"),
+		acceptedAt: timestamp("accepted_at", { withTimezone: true }),
+		acceptanceIdempotencyKey: text("acceptance_idempotency_key"),
+		acceptanceReceipt: jsonb("acceptance_receipt"),
+		createdAt,
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.missionId, t.agentId] }),
+		nodeIdx: index("idx_mission_participants_node").on(t.nodeId, t.missionId),
+		missionNodeIdx: uniqueIndex("idx_mission_participants_mission_node").on(t.missionId, t.nodeId),
+		acceptanceIdempotencyIdx: uniqueIndex("idx_mission_participants_acceptance_idempotency")
+			.on(t.missionId, t.acceptanceIdempotencyKey)
+			.where(sql`${t.acceptanceIdempotencyKey} IS NOT NULL`),
+		nodeOwnerFk: foreignKey({
+			columns: [t.nodeId, t.agentId],
+			foreignColumns: [nodes.id, nodes.agentId],
+			name: "mission_participants_node_owner_fk",
+		}),
+		bindingNodeFk: foreignKey({
+			columns: [t.workspaceBindingId, t.nodeId],
+			foreignColumns: [workspaceBindings.id, workspaceBindings.nodeId],
+			name: "mission_participants_binding_node_fk",
+		}),
+		statusCheck: check(
+			"mission_participants_status_chk",
+			sql`${t.status} IN ('pending','accepted')`,
+		),
+		acceptedAtCheck: check(
+			"mission_participants_accepted_at_chk",
+			sql`(${t.status} = 'accepted') = (${t.acceptedAt} IS NOT NULL)
+				AND (${t.status} = 'accepted') = (${t.acceptanceIdempotencyKey} IS NOT NULL)
+				AND (${t.status} = 'accepted') = (${t.acceptanceReceipt} IS NOT NULL)`,
+		),
+	}),
+);
+
+export const missionEvents = pgTable(
+	"mission_events",
+	{
+		id: uuid("id").primaryKey(),
+		missionId: uuid("mission_id")
+			.notNull()
+			.references(() => missions.id, { onDelete: "restrict" }),
+		sequenceNo: integer("sequence_no").notNull(),
+		type: text("type").notNull(),
+		actorAgentId: uuid("actor_agent_id")
+			.notNull()
+			.references(() => agents.id, { onDelete: "restrict" }),
+		idempotencyKey: text("idempotency_key").notNull(),
+		sourceDeliveryId: uuid("source_delivery_id"),
+		causalParentEventId: uuid("causal_parent_event_id"),
+		payload: jsonb("payload").notNull(),
+		createdAt,
+	},
+	(t) => ({
+		missionSequenceIdx: uniqueIndex("idx_mission_events_sequence").on(t.missionId, t.sequenceNo),
+		idempotencyIdx: uniqueIndex("idx_mission_events_idempotency").on(t.missionId, t.idempotencyKey),
+		missionIdentityIdx: uniqueIndex("idx_mission_events_mission_identity").on(t.missionId, t.id),
+		missionCreatedIdx: index("idx_mission_events_created").on(t.missionId, t.createdAt),
+		causalParentFk: foreignKey({
+			columns: [t.missionId, t.causalParentEventId],
+			foreignColumns: [t.missionId, t.id],
+			name: "mission_events_causal_parent_fk",
+		}),
+		actorParticipantFk: foreignKey({
+			columns: [t.missionId, t.actorAgentId],
+			foreignColumns: [missionParticipants.missionId, missionParticipants.agentId],
+			name: "mission_events_actor_participant_fk",
+		}),
+		typeCheck: check(
+			"mission_events_type_chk",
+			sql`${t.type} IN ('participants_accepted','turn_completed','contract_acknowledged','verification_recorded')`,
+		),
+		sequenceCheck: check("mission_events_sequence_chk", sql`${t.sequenceNo} > 0`),
+	}),
+);
+
+export const nodeDeliveries = pgTable(
+	"node_deliveries",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		nodeId: uuid("node_id")
+			.notNull()
+			.references(() => nodes.id, { onDelete: "restrict" }),
+		missionId: uuid("mission_id")
+			.notNull()
+			.references(() => missions.id, { onDelete: "restrict" }),
+		missionEventId: uuid("mission_event_id")
+			.notNull()
+			.references(() => missionEvents.id, { onDelete: "restrict" }),
+		kind: text("kind").notNull(),
+		cursor: bigserial("cursor", { mode: "bigint" }).notNull(),
+		status: text("status").notNull().default("stored"),
+		attemptCount: integer("attempt_count").notNull().default(0),
+		maxAttempts: integer("max_attempts").notNull().default(5),
+		lastFencingToken: text("last_fencing_token").notNull().default("0"),
+		activeLeaseId: uuid("active_lease_id"),
+		leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
+		contractVersion: integer("contract_version").notNull(),
+		verificationRound: integer("verification_round"),
+		idempotencyKey: text("idempotency_key").notNull(),
+		causalParentDeliveryId: uuid("causal_parent_delivery_id"),
+		settledByEventId: uuid("settled_by_event_id"),
+		settledAt: timestamp("settled_at", { withTimezone: true }),
+		availableAt: timestamp("available_at", { withTimezone: true }).notNull().default(sql`now()`),
+		acknowledgedAt: timestamp("acknowledged_at", { withTimezone: true }),
+		deadLetteredAt: timestamp("dead_lettered_at", { withTimezone: true }),
+		createdAt,
+		updatedAt,
+	},
+	(t) => ({
+		cursorIdx: uniqueIndex("idx_node_deliveries_cursor").on(t.cursor),
+		nodeCursorIdx: index("idx_node_deliveries_node_cursor").on(t.nodeId, t.cursor),
+		identityScopeIdx: uniqueIndex("idx_node_deliveries_identity_scope").on(
+			t.nodeId,
+			t.missionId,
+			t.id,
+		),
+		missionIdentityIdx: uniqueIndex("idx_node_deliveries_mission_identity").on(t.missionId, t.id),
+		eventKindIdx: uniqueIndex("idx_node_deliveries_event_kind").on(
+			t.nodeId,
+			t.missionEventId,
+			t.kind,
+		),
+		idempotencyIdx: uniqueIndex("idx_node_deliveries_idempotency").on(t.nodeId, t.idempotencyKey),
+		causalParentFk: foreignKey({
+			columns: [t.nodeId, t.missionId, t.causalParentDeliveryId],
+			foreignColumns: [t.nodeId, t.missionId, t.id],
+			name: "node_deliveries_causal_parent_fk",
+		}),
+		eventMissionFk: foreignKey({
+			columns: [t.missionId, t.missionEventId],
+			foreignColumns: [missionEvents.missionId, missionEvents.id],
+			name: "node_deliveries_event_mission_fk",
+		}),
+		participantNodeFk: foreignKey({
+			columns: [t.missionId, t.nodeId],
+			foreignColumns: [missionParticipants.missionId, missionParticipants.nodeId],
+			name: "node_deliveries_participant_node_fk",
+		}),
+		settlementEventMissionFk: foreignKey({
+			columns: [t.missionId, t.settledByEventId],
+			foreignColumns: [missionEvents.missionId, missionEvents.id],
+			name: "node_deliveries_settlement_event_mission_fk",
+		}),
+		kindCheck: check(
+			"node_deliveries_kind_chk",
+			sql`${t.kind} IN ('turn','verification','contract_acknowledgement')`,
+		),
+		statusCheck: check(
+			"node_deliveries_status_chk",
+			sql`${t.status} IN ('stored','leased','executing','acknowledged','dead_lettered')`,
+		),
+		verificationRoundCheck: check(
+			"node_deliveries_verification_round_chk",
+			sql`(${t.kind} = 'verification') = (${t.verificationRound} IS NOT NULL)
+				AND (${t.verificationRound} IS NULL OR ${t.verificationRound} > 0)`,
+		),
+		attemptCheck: check(
+			"node_deliveries_attempt_chk",
+			sql`${t.attemptCount} >= 0 AND ${t.maxAttempts} > 0 AND ${t.attemptCount} <= ${t.maxAttempts}`,
+		),
+		fencingTokenCheck: check(
+			"node_deliveries_fencing_token_chk",
+			sql`${t.lastFencingToken} ~ '^(0|[1-9][0-9]*)$'`,
+		),
+		initialFenceCheck: check(
+			"node_deliveries_initial_fence_chk",
+			sql`(${t.attemptCount} = 0) = (${t.lastFencingToken} = '0')`,
+		),
+		leaseCheck: check(
+			"node_deliveries_lease_chk",
+			sql`(${t.status} IN ('leased','executing')) = (${t.activeLeaseId} IS NOT NULL)
+				AND (${t.status} IN ('leased','executing')) = (${t.leaseExpiresAt} IS NOT NULL)
+				AND (${t.status} NOT IN ('leased','executing') OR ${t.attemptCount} > 0)`,
+		),
+		acknowledgedAtCheck: check(
+			"node_deliveries_acknowledged_at_chk",
+			sql`(${t.status} = 'acknowledged') = (${t.acknowledgedAt} IS NOT NULL)
+				AND (${t.status} != 'acknowledged' OR ${t.attemptCount} > 0)`,
+		),
+		deadLetteredAtCheck: check(
+			"node_deliveries_dead_lettered_at_chk",
+			sql`(${t.status} = 'dead_lettered') = (${t.deadLetteredAt} IS NOT NULL)`,
+		),
+		settlementCheck: check(
+			"node_deliveries_settlement_chk",
+			sql`(${t.settledByEventId} IS NOT NULL) = (${t.settledAt} IS NOT NULL)`,
+		),
+	}),
+);
+
 export type Agent = typeof agents.$inferSelect;
 export type NewAgent = typeof agents.$inferInsert;
 export type AgentCard = typeof agentCards.$inferSelect;
@@ -242,3 +539,9 @@ export type ApiKey = typeof apiKeys.$inferSelect;
 export type Handoff = typeof handoffs.$inferSelect;
 export type Message = typeof messages.$inferSelect;
 export type AuditLogRow = typeof auditLog.$inferSelect;
+export type Node = typeof nodes.$inferSelect;
+export type WorkspaceBinding = typeof workspaceBindings.$inferSelect;
+export type Mission = typeof missions.$inferSelect;
+export type MissionParticipant = typeof missionParticipants.$inferSelect;
+export type MissionEvent = typeof missionEvents.$inferSelect;
+export type NodeDelivery = typeof nodeDeliveries.$inferSelect;

--- a/relay/src/db/test-utils.ts
+++ b/relay/src/db/test-utils.ts
@@ -48,6 +48,6 @@ export async function truncateAll(sql: Sql): Promise<void> {
 	// with CASCADE would clear the dependents — but explicit listing makes intent
 	// obvious and survives future schema additions that aren't FK-rooted at agents.
 	await sql.unsafe(
-		"TRUNCATE TABLE messages, handoffs, agent_cards, api_keys, audit_log, agent_blocks, invites, agents RESTART IDENTITY CASCADE",
+		"TRUNCATE TABLE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, nodes, messages, handoffs, agent_cards, api_keys, audit_log, agent_blocks, invites, agents RESTART IDENTITY CASCADE",
 	);
 }

--- a/relay/src/services/mission-ledger.test.ts
+++ b/relay/src/services/mission-ledger.test.ts
@@ -1,0 +1,1127 @@
+import { randomUUID } from "node:crypto";
+import type { MissionCoordinatorConfig } from "@agentrelay/protocol";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createDb } from "../db/client.js";
+import {
+	agents,
+	auditLog,
+	missionEvents,
+	missionParticipants,
+	missions,
+	nodeDeliveries,
+	nodes,
+	workspaceBindings,
+} from "../db/schema.js";
+import { type TestDb, truncateAll, tryConnect } from "../db/test-utils.js";
+import {
+	acceptMissionParticipant,
+	appendMissionEvent,
+	createMissionLedger,
+	listStoredDeliveryEvents,
+} from "./mission-ledger.js";
+
+const TEST_URL = process.env.RELAY_TEST_DATABASE_URL ?? process.env.RELAY_DATABASE_URL;
+const conn = await tryConnect();
+const d = conn.available ? describe : describe.skip;
+
+if (!conn.available) {
+	console.warn(`[mission-ledger.test] skipping: ${conn.reason}`);
+}
+
+d("durable Mission ledger", () => {
+	let handle: TestDb;
+
+	beforeAll(() => {
+		if (!conn.handle) throw new Error("expected database handle");
+		handle = conn.handle;
+	});
+
+	beforeEach(async () => {
+		await truncateAll(handle.sql);
+	});
+
+	afterAll(async () => {
+		if (handle) await handle.close();
+	});
+
+	it("creates an immutable Mission with exact Node/workspace routing and replays by Mission ID", async () => {
+		const fixture = await seedFixture(handle);
+		const first = await createMissionLedger(handle.db, {
+			createdByAgentId: fixture.backendAgentId,
+			coordinatorConfig: fixture.config,
+		});
+		expect(first.replayed).toBe(false);
+		expect(first.state.status).toBe("awaiting_acceptance");
+		expect(first.participantBindings).toEqual([
+			{
+				agentId: fixture.backendAgentId,
+				nodeId: fixture.backendNodeId,
+				workspaceBindingId: fixture.backendBindingId,
+			},
+			{
+				agentId: fixture.androidAgentId,
+				nodeId: fixture.androidNodeId,
+				workspaceBindingId: fixture.androidBindingId,
+			},
+		]);
+
+		const replay = await createMissionLedger(handle.db, {
+			createdByAgentId: fixture.backendAgentId,
+			coordinatorConfig: structuredClone(fixture.config),
+		});
+		expect(replay).toEqual({ ...first, replayed: true });
+
+		const changed = structuredClone(fixture.config);
+		changed.mission_context.manifest.objective = "Different objective";
+		await expect(
+			createMissionLedger(handle.db, {
+				createdByAgentId: fixture.backendAgentId,
+				coordinatorConfig: changed,
+			}),
+		).rejects.toMatchObject({ code: "duplicate_idempotency_key" });
+
+		expect(await handle.db.select().from(missions)).toHaveLength(1);
+		expect(await handle.db.select().from(missionParticipants)).toHaveLength(2);
+	});
+
+	it("derives activation from two exact acceptance receipts and replays a concurrent receipt", async () => {
+		const fixture = await createFixtureMission(handle);
+
+		await expect(
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event: aggregateAcceptanceInput(fixture, "accept:spoofed-aggregate"),
+			}),
+		).rejects.toMatchObject({ code: "not_authorized_transition" });
+
+		const wrongContract = participantAcceptanceInput(
+			fixture,
+			fixture.backendAgentId,
+			"accept:wrong-contract",
+		);
+		wrongContract.contract = { ...fixture.contractV1, sha256: "f".repeat(64) };
+		await expect(
+			acceptMissionParticipant(handle.db, {
+				missionId: fixture.missionId,
+				participantAgentId: fixture.backendAgentId,
+				acceptance: wrongContract,
+			}),
+		).rejects.toMatchObject({ code: "invalid_params" });
+
+		const wrongProfile = participantAcceptanceInput(
+			fixture,
+			fixture.backendAgentId,
+			"accept:wrong-profile",
+		);
+		wrongProfile.local_policy_grant = {
+			...wrongProfile.local_policy_grant,
+			profile_name: "read-only",
+		};
+		await expect(
+			acceptMissionParticipant(handle.db, {
+				missionId: fixture.missionId,
+				participantAgentId: fixture.backendAgentId,
+				acceptance: wrongProfile,
+			}),
+		).rejects.toMatchObject({ code: "invalid_params" });
+
+		const backendAcceptance = participantAcceptanceInput(
+			fixture,
+			fixture.backendAgentId,
+			"accept:backend",
+		);
+		const [backendFirst, backendReplay] = await Promise.all([
+			acceptMissionParticipant(handle.db, {
+				missionId: fixture.missionId,
+				participantAgentId: fixture.backendAgentId,
+				acceptance: backendAcceptance,
+			}),
+			acceptMissionParticipant(handle.db, {
+				missionId: fixture.missionId,
+				participantAgentId: fixture.backendAgentId,
+				acceptance: structuredClone(backendAcceptance),
+			}),
+		]);
+		expect([backendFirst, backendReplay].filter((result) => result.replayed)).toHaveLength(1);
+		expect(backendFirst.receipt).toEqual(backendReplay.receipt);
+		expect(backendFirst.receipt).toMatchObject({
+			participant_agent_id: fixture.backendAgentId,
+			contract: fixture.contractV1,
+			local_policy_grant: backendAcceptance.local_policy_grant,
+		});
+		expect(await handle.db.select().from(missionEvents)).toEqual([]);
+		expect(await handle.db.select().from(nodeDeliveries)).toEqual([]);
+
+		const changedReplay = structuredClone(backendAcceptance);
+		changedReplay.local_policy_grant.grant_sha256 = "9".repeat(64);
+		await expect(
+			acceptMissionParticipant(handle.db, {
+				missionId: fixture.missionId,
+				participantAgentId: fixture.backendAgentId,
+				acceptance: changedReplay,
+			}),
+		).rejects.toMatchObject({ code: "duplicate_idempotency_key" });
+
+		const androidAcceptance = participantAcceptanceInput(
+			fixture,
+			fixture.androidAgentId,
+			"accept:android",
+		);
+		await acceptMissionParticipant(handle.db, {
+			missionId: fixture.missionId,
+			participantAgentId: fixture.androidAgentId,
+			acceptance: androidAcceptance,
+		});
+
+		const [mission] = await handle.db.select().from(missions);
+		expect(mission).toMatchObject({ status: "active", lastEventSequence: 1 });
+		const participants = await handle.db
+			.select()
+			.from(missionParticipants)
+			.where(eq(missionParticipants.missionId, fixture.missionId));
+		expect(participants).toHaveLength(2);
+		expect(participants.every((participant) => participant.status === "accepted")).toBe(true);
+		expect(participants.map((participant) => participant.acceptanceReceipt)).toEqual(
+			expect.arrayContaining([backendAcceptance, androidAcceptance]),
+		);
+		expect(await handle.db.select().from(missionEvents)).toHaveLength(1);
+		expect(await handle.db.select().from(nodeDeliveries)).toHaveLength(1);
+	});
+
+	it("serializes concurrent exact event retries with stable event and delivery identities", async () => {
+		const fixture = await createFixtureMission(handle);
+		const activated = await activateMission(handle, fixture);
+		const event = replyInput({
+			fixture,
+			participantAgentId: fixture.backendAgentId,
+			deliveryId: activated.backendTurnDeliveryId,
+			idempotencyKey: "turn:concurrent",
+			messageId: randomUUID(),
+			messageIdempotencyKey: "message:concurrent",
+			message: "Should avatar_url be nullable?",
+			sequenceNo: 1,
+			causalParentMessageId: null,
+		});
+		const [first, replay] = await Promise.all([
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event,
+			}),
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event: structuredClone(event),
+			}),
+		]);
+		expect([first, replay].filter((result) => result.replayed)).toHaveLength(1);
+		expect(first.event.event_id).toBe(replay.event.event_id);
+		expect(first.deliveryIds).toEqual(replay.deliveryIds);
+		expect(first.deliveryIds).toHaveLength(1);
+		expect(await handle.db.select().from(missionEvents)).toHaveLength(2);
+		expect(await handle.db.select().from(nodeDeliveries)).toHaveLength(2);
+		expect(
+			await handle.db.select().from(auditLog).where(eq(auditLog.action, "mission.event.append")),
+		).toHaveLength(2);
+
+		const changed = structuredClone(event);
+		changed.disposition.message = "A different question";
+		changed.message.body = "A different question";
+		await expect(
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event: changed,
+			}),
+		).rejects.toMatchObject({ code: "duplicate_idempotency_key" });
+
+		await expect(
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.androidAgentId,
+				event: { ...event, event_id: randomUUID() },
+			}),
+		).rejects.toThrow(/Unrecognized key/);
+	});
+
+	it("rolls back the second acceptance, derived event, delivery, projection, and audit together", async () => {
+		const fixture = await createFixtureMission(handle);
+		await acceptMissionParticipant(handle.db, {
+			missionId: fixture.missionId,
+			participantAgentId: fixture.backendAgentId,
+			acceptance: participantAcceptanceInput(
+				fixture,
+				fixture.backendAgentId,
+				"accept:rollback:backend",
+			),
+		});
+		await handle.sql.unsafe(`
+			CREATE OR REPLACE FUNCTION reject_node_delivery_test() RETURNS TRIGGER AS $$
+			BEGIN
+				RAISE EXCEPTION 'forced delivery failure';
+			END;
+			$$ LANGUAGE plpgsql;
+			CREATE TRIGGER reject_node_delivery_test
+				BEFORE INSERT ON node_deliveries
+				FOR EACH ROW EXECUTE FUNCTION reject_node_delivery_test();
+		`);
+
+		try {
+			await expect(
+				acceptMissionParticipant(handle.db, {
+					missionId: fixture.missionId,
+					participantAgentId: fixture.androidAgentId,
+					acceptance: participantAcceptanceInput(
+						fixture,
+						fixture.androidAgentId,
+						"accept:rollback:android",
+					),
+				}),
+			).rejects.toThrow(/forced delivery failure/);
+		} finally {
+			await handle.sql.unsafe(`
+				DROP TRIGGER IF EXISTS reject_node_delivery_test ON node_deliveries;
+				DROP FUNCTION IF EXISTS reject_node_delivery_test();
+			`);
+		}
+
+		expect(await handle.db.select().from(missionEvents)).toEqual([]);
+		expect(await handle.db.select().from(nodeDeliveries)).toEqual([]);
+		const [mission] = await handle.db.select().from(missions);
+		expect(mission).toMatchObject({ status: "awaiting_acceptance", lastEventSequence: 0 });
+		const participants = await handle.db
+			.select()
+			.from(missionParticipants)
+			.where(eq(missionParticipants.missionId, fixture.missionId));
+		expect(
+			Object.fromEntries(
+				participants.map((participant) => [participant.agentId, participant.status]),
+			),
+		).toEqual({
+			[fixture.backendAgentId]: "accepted",
+			[fixture.androidAgentId]: "pending",
+		});
+		expect(
+			await handle.db
+				.select()
+				.from(auditLog)
+				.where(eq(auditLog.action, "mission.participant.accept")),
+		).toHaveLength(1);
+		expect(
+			await handle.db.select().from(auditLog).where(eq(auditLog.action, "mission.event.append")),
+		).toEqual([]);
+	});
+
+	it("stamps pending contract acknowledgement deliveries with v2 and serializes both acknowledgements", async () => {
+		const fixture = await createFixtureMission(handle);
+		const activated = await activateMission(handle, fixture);
+		const proposed = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: proposalInput(fixture, activated.backendTurnDeliveryId),
+		});
+		expect(proposed.deliveryIds).toHaveLength(2);
+
+		const acknowledgementDeliveries = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(inArray(nodeDeliveries.id, [...proposed.deliveryIds]));
+		expect(acknowledgementDeliveries).toHaveLength(2);
+		expect(
+			acknowledgementDeliveries.map((delivery) => ({
+				kind: delivery.kind,
+				contractVersion: delivery.contractVersion,
+			})),
+		).toEqual([
+			{ kind: "contract_acknowledgement", contractVersion: 2 },
+			{ kind: "contract_acknowledgement", contractVersion: 2 },
+		]);
+		const backendAckDelivery = acknowledgementDeliveries.find(
+			(delivery) => delivery.nodeId === fixture.backendNodeId,
+		);
+		const androidAckDelivery = acknowledgementDeliveries.find(
+			(delivery) => delivery.nodeId === fixture.androidNodeId,
+		);
+		if (!backendAckDelivery || !androidAckDelivery) {
+			throw new Error("expected one contract acknowledgement delivery per participant Node");
+		}
+
+		const results = await Promise.all([
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event: acknowledgementInput(
+					fixture,
+					fixture.backendAgentId,
+					backendAckDelivery.id,
+					"ack:backend",
+				),
+			}),
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.androidAgentId,
+				event: acknowledgementInput(
+					fixture,
+					fixture.androidAgentId,
+					androidAckDelivery.id,
+					"ack:android",
+				),
+			}),
+		]);
+		expect(results.map((result) => result.event.sequence_no).sort((a, b) => a - b)).toEqual([3, 4]);
+		expect(results.flatMap((result) => result.deliveryIds)).toHaveLength(1);
+		const [mission] = await handle.db.select().from(missions);
+		expect(mission).toMatchObject({
+			status: "active",
+			lastEventSequence: 4,
+			contractVersion: 2,
+		});
+	});
+
+	it("rejects fabricated, cross-Mission, wrong-Node, wrong-kind, and consumed source deliveries", async () => {
+		const fixture = await createFixtureMission(handle);
+		const activated = await activateMission(handle, fixture);
+		const other = await createFixtureMission(handle);
+		const otherActivated = await activateMission(handle, other);
+
+		const expectNoAdvance = async (operation: () => Promise<unknown>) => {
+			const [before] = await handle.db
+				.select({ sequence: missions.lastEventSequence })
+				.from(missions)
+				.where(eq(missions.id, fixture.missionId));
+			const eventCount = (
+				await handle.db
+					.select()
+					.from(missionEvents)
+					.where(eq(missionEvents.missionId, fixture.missionId))
+			).length;
+			await expect(operation()).rejects.toMatchObject({
+				code: expect.stringMatching(/^(invalid_transition|not_authorized_transition)$/),
+			});
+			const [after] = await handle.db
+				.select({ sequence: missions.lastEventSequence })
+				.from(missions)
+				.where(eq(missions.id, fixture.missionId));
+			expect(after?.sequence).toBe(before?.sequence);
+			expect(
+				await handle.db
+					.select()
+					.from(missionEvents)
+					.where(eq(missionEvents.missionId, fixture.missionId)),
+			).toHaveLength(eventCount);
+		};
+
+		await expectNoAdvance(() =>
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event: readyInput(fixture.backendAgentId, randomUUID(), "turn:fabricated-source"),
+			}),
+		);
+		await expectNoAdvance(() =>
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event: readyInput(
+					fixture.backendAgentId,
+					otherActivated.backendTurnDeliveryId,
+					"turn:cross-mission-source",
+				),
+			}),
+		);
+
+		const proposed = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: proposalInput(fixture, activated.backendTurnDeliveryId),
+		});
+		const ackDeliveries = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(inArray(nodeDeliveries.id, [...proposed.deliveryIds]));
+		const backendAckDelivery = ackDeliveries.find(
+			(delivery) => delivery.nodeId === fixture.backendNodeId,
+		);
+		const androidAckDelivery = ackDeliveries.find(
+			(delivery) => delivery.nodeId === fixture.androidNodeId,
+		);
+		if (!backendAckDelivery || !androidAckDelivery) {
+			throw new Error("expected both acknowledgement delivery rows");
+		}
+
+		await expectNoAdvance(() =>
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.androidAgentId,
+				event: acknowledgementInput(
+					fixture,
+					fixture.androidAgentId,
+					backendAckDelivery.id,
+					"ack:wrong-node",
+				),
+			}),
+		);
+		await expectNoAdvance(() =>
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.androidAgentId,
+				event: readyInput(fixture.androidAgentId, androidAckDelivery.id, "turn:wrong-kind", 2),
+			}),
+		);
+
+		await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: acknowledgementInput(
+				fixture,
+				fixture.backendAgentId,
+				backendAckDelivery.id,
+				"ack:consume-source",
+			),
+		});
+		const [consumed] = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.id, backendAckDelivery.id));
+		expect(consumed).toMatchObject({
+			status: "stored",
+			settledByEventId: expect.any(String),
+			settledAt: expect.any(Date),
+		});
+		await expectNoAdvance(() =>
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event: acknowledgementInput(
+					fixture,
+					fixture.backendAgentId,
+					backendAckDelivery.id,
+					"ack:reuse-consumed-source",
+				),
+			}),
+		);
+	});
+
+	it("settles every failed verification delivery in its round and rejects stale-round output", async () => {
+		const fixture = await createFixtureMission(handle);
+		const activated = await activateMission(handle, fixture);
+		const backendReady = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: readyInput(
+				fixture.backendAgentId,
+				activated.backendTurnDeliveryId,
+				"ready:round-1:backend",
+			),
+		});
+		const androidReady = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.androidAgentId,
+			event: readyInput(
+				fixture.androidAgentId,
+				only(backendReady.deliveryIds, "round-one Android turn delivery"),
+				"ready:round-1:android",
+			),
+		});
+		const roundOneDeliveries = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(inArray(nodeDeliveries.id, [...androidReady.deliveryIds]));
+		const backendRoundOne = roundOneDeliveries.find(
+			(delivery) => delivery.nodeId === fixture.backendNodeId,
+		);
+		const androidRoundOne = roundOneDeliveries.find(
+			(delivery) => delivery.nodeId === fixture.androidNodeId,
+		);
+		if (!backendRoundOne || !androidRoundOne) {
+			throw new Error("expected both round-one verification deliveries");
+		}
+		expect(roundOneDeliveries.every((delivery) => delivery.verificationRound === 1)).toBe(true);
+
+		const failed = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: verificationInput(
+				fixture.backendAgentId,
+				backendRoundOne.id,
+				"backend-test",
+				"verify:round-1:failed",
+				{ outcome: "failed" },
+			),
+		});
+		expect(failed.state).toMatchObject({ status: "active", verification_round: 1 });
+		expect(failed.deliveryIds).toHaveLength(1);
+		const settledRoundOne = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(inArray(nodeDeliveries.id, [...androidReady.deliveryIds]));
+		expect(
+			settledRoundOne.map((delivery) => ({
+				status: delivery.status,
+				verificationRound: delivery.verificationRound,
+				settledByEventId: delivery.settledByEventId,
+				settledAt: delivery.settledAt,
+			})),
+		).toEqual([
+			{
+				status: "stored",
+				verificationRound: 1,
+				settledByEventId: failed.event.event_id,
+				settledAt: expect.any(Date),
+			},
+			{
+				status: "stored",
+				verificationRound: 1,
+				settledByEventId: failed.event.event_id,
+				settledAt: expect.any(Date),
+			},
+		]);
+
+		await expect(
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.androidAgentId,
+				event: verificationInput(
+					fixture.androidAgentId,
+					androidRoundOne.id,
+					"android-test",
+					"verify:round-1:stale",
+				),
+			}),
+		).rejects.toMatchObject({ code: "invalid_transition" });
+
+		const retryBackendReady = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: readyInput(
+				fixture.backendAgentId,
+				only(failed.deliveryIds, "retry backend turn delivery"),
+				"ready:round-2:backend",
+			),
+		});
+		const retryAndroidReady = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.androidAgentId,
+			event: readyInput(
+				fixture.androidAgentId,
+				only(retryBackendReady.deliveryIds, "retry Android turn delivery"),
+				"ready:round-2:android",
+			),
+		});
+		expect(retryAndroidReady.state).toMatchObject({ status: "verifying", verification_round: 2 });
+		const roundTwoDeliveries = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(inArray(nodeDeliveries.id, [...retryAndroidReady.deliveryIds]));
+		expect(roundTwoDeliveries).toHaveLength(2);
+		expect(
+			roundTwoDeliveries.every(
+				(delivery) =>
+					delivery.verificationRound === 2 &&
+					delivery.settledByEventId === null &&
+					delivery.settledAt === null,
+			),
+		).toBe(true);
+	});
+
+	it("replays ordered Node-isolated cursor pages without mutating delivery state", async () => {
+		const fixture = await createFixtureMission(handle);
+		const activated = await activateMission(handle, fixture);
+		await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: proposalInput(fixture, activated.backendTurnDeliveryId),
+		});
+
+		const backendPage = await listStoredDeliveryEvents(handle.db, {
+			nodeId: fixture.backendNodeId,
+			page: { after_cursor: null, limit: 50 },
+		});
+		const androidPage = await listStoredDeliveryEvents(handle.db, {
+			nodeId: fixture.androidNodeId,
+			page: { after_cursor: null, limit: 50 },
+		});
+		expect(backendPage.items).toHaveLength(1);
+		expect(backendPage.items[0]?.event.type).toBe("turn_completed");
+		expect(backendPage.items[0]?.event.participant_agent_id).toBe(fixture.backendAgentId);
+		expect(backendPage.items[0]?.delivery.kind).toBe("contract_acknowledgement");
+		expect(androidPage.items).toHaveLength(1);
+		expect(androidPage.items[0]?.event.type).toBe("turn_completed");
+		expect(androidPage.items[0]?.event.participant_agent_id).toBe(fixture.backendAgentId);
+		expect(androidPage.items[0]?.delivery.kind).toBe("contract_acknowledgement");
+		expect(BigInt(backendPage.next_cursor ?? "0")).toBeLessThan(
+			BigInt(androidPage.next_cursor ?? "0"),
+		);
+
+		const replay = await listStoredDeliveryEvents(handle.db, {
+			nodeId: fixture.backendNodeId,
+			page: { after_cursor: null, limit: 50 },
+		});
+		expect(replay).toEqual(backendPage);
+		const exhausted = await listStoredDeliveryEvents(handle.db, {
+			nodeId: fixture.backendNodeId,
+			page: { after_cursor: backendPage.next_cursor, limit: 50 },
+		});
+		expect(exhausted).toEqual({ items: [], next_cursor: backendPage.next_cursor });
+
+		if (!TEST_URL) throw new Error("expected test database URL");
+		const reopened = createDb({ RELAY_DATABASE_URL: TEST_URL, RELAY_DB_POOL_SIZE: 2 });
+		try {
+			expect(
+				await listStoredDeliveryEvents(reopened.db, {
+					nodeId: fixture.androidNodeId,
+					page: { after_cursor: null, limit: 50 },
+				}),
+			).toEqual(androidPage);
+		} finally {
+			await reopened.close();
+		}
+
+		const stored = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.status, "stored"));
+		expect(stored).toHaveLength(3);
+		expect(stored.filter((delivery) => delivery.settledByEventId === null)).toHaveLength(2);
+	});
+
+	it("rejects delayed output after terminal completion without changing ledger rows", async () => {
+		const fixture = await createFixtureMission(handle);
+		const activated = await activateMission(handle, fixture);
+		const backendReady = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: readyInput(fixture.backendAgentId, activated.backendTurnDeliveryId, "ready:backend"),
+		});
+		const androidReady = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.androidAgentId,
+			event: readyInput(
+				fixture.androidAgentId,
+				only(backendReady.deliveryIds, "Android turn delivery"),
+				"ready:android",
+			),
+		});
+		expect(androidReady.state.status).toBe("verifying");
+		const verificationDeliveries = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(inArray(nodeDeliveries.id, [...androidReady.deliveryIds]));
+		const backendVerificationDelivery = verificationDeliveries.find(
+			(delivery) => delivery.nodeId === fixture.backendNodeId,
+		);
+		const androidVerificationDelivery = verificationDeliveries.find(
+			(delivery) => delivery.nodeId === fixture.androidNodeId,
+		);
+		if (!backendVerificationDelivery || !androidVerificationDelivery) {
+			throw new Error("expected one verification delivery per participant Node");
+		}
+
+		await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.backendAgentId,
+			event: verificationInput(
+				fixture.backendAgentId,
+				backendVerificationDelivery.id,
+				"backend-test",
+				"verify:backend",
+			),
+		});
+		const completed = await appendMissionEvent(handle.db, {
+			missionId: fixture.missionId,
+			actorAgentId: fixture.androidAgentId,
+			event: verificationInput(
+				fixture.androidAgentId,
+				androidVerificationDelivery.id,
+				"android-test",
+				"verify:android",
+			),
+		});
+		expect(completed.state.status).toBe("completed");
+		const eventsBefore = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(eq(missionEvents.missionId, fixture.missionId))
+			.orderBy(asc(missionEvents.sequenceNo));
+		const deliveriesBefore = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.missionId, fixture.missionId))
+			.orderBy(asc(nodeDeliveries.cursor));
+		const [missionBefore] = await handle.db
+			.select()
+			.from(missions)
+			.where(eq(missions.id, fixture.missionId));
+
+		await expect(
+			appendMissionEvent(handle.db, {
+				missionId: fixture.missionId,
+				actorAgentId: fixture.backendAgentId,
+				event: verificationInput(
+					fixture.backendAgentId,
+					backendVerificationDelivery.id,
+					"backend-test",
+					"verify:late",
+				),
+			}),
+		).rejects.toMatchObject({ code: "invalid_transition" });
+		expect(
+			await handle.db
+				.select()
+				.from(missionEvents)
+				.where(eq(missionEvents.missionId, fixture.missionId))
+				.orderBy(asc(missionEvents.sequenceNo)),
+		).toEqual(eventsBefore);
+		expect(
+			await handle.db
+				.select()
+				.from(nodeDeliveries)
+				.where(eq(nodeDeliveries.missionId, fixture.missionId))
+				.orderBy(asc(nodeDeliveries.cursor)),
+		).toEqual(deliveriesBefore);
+		expect(
+			await handle.db.select().from(missions).where(eq(missions.id, fixture.missionId)),
+		).toEqual([missionBefore]);
+	});
+});
+
+interface Fixture {
+	readonly missionId: string;
+	readonly backendAgentId: string;
+	readonly androidAgentId: string;
+	readonly backendNodeId: string;
+	readonly androidNodeId: string;
+	readonly backendBindingId: string;
+	readonly androidBindingId: string;
+	readonly contractV1: ContractRef;
+	readonly contractV2: ContractRef;
+	readonly revisionId: string;
+	readonly config: MissionCoordinatorConfig;
+}
+
+interface ContractRef {
+	readonly artifact_id: string;
+	readonly type: "api_contract";
+	readonly version: number;
+	readonly sha256: string;
+	readonly media_type: "application/json";
+	readonly byte_size: number;
+}
+
+interface ActivatedMission {
+	readonly backendTurnDeliveryId: string;
+}
+
+async function seedFixture(handle: TestDb): Promise<Fixture> {
+	const missionId = randomUUID();
+	const backendAgentId = randomUUID();
+	const androidAgentId = randomUUID();
+	const backendNodeId = randomUUID();
+	const androidNodeId = randomUUID();
+	const backendBindingId = randomUUID();
+	const androidBindingId = randomUUID();
+	const artifactId = randomUUID();
+	const contractV1: ContractRef = {
+		artifact_id: artifactId,
+		type: "api_contract",
+		version: 1,
+		sha256: "a".repeat(64),
+		media_type: "application/json",
+		byte_size: 128,
+	};
+	const contractV2: ContractRef = { ...contractV1, version: 2, sha256: "b".repeat(64) };
+	const createdAt = new Date(Date.now() - 1_000).toISOString();
+	const config: MissionCoordinatorConfig = {
+		mission_context: {
+			manifest: {
+				schema_version: 1,
+				mission_id: missionId,
+				objective: "Ship one compatible profile contract across backend and Android",
+				public_acceptance_criteria: ["Both repository checks pass"],
+				participants: [
+					{
+						agent_id: backendAgentId,
+						role: "backend",
+						workspace_alias: "backend-api",
+						repository_url: "https://github.com/acme/backend.git",
+						expected_base_commit: "1".repeat(40),
+						initial_assignment: "Implement the response contract",
+						requested_local_policy_profile: "bounded-code",
+					},
+					{
+						agent_id: androidAgentId,
+						role: "android",
+						workspace_alias: "android-app",
+						repository_url: "https://github.com/acme/android.git",
+						expected_base_commit: "2".repeat(40),
+						initial_assignment: "Consume the response contract",
+						requested_local_policy_profile: "bounded-code",
+					},
+				],
+				shared_contract: contractV1 as ContractRef & { version: 1 },
+				max_turns: 20,
+				max_wall_time_seconds: 3_600,
+				token_budget: 100_000,
+				expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+				allowed_artifact_types: ["api_contract"],
+				created_at: createdAt,
+			},
+			created_by: { principal_id: backendAgentId, kind: "agent" },
+		},
+		required_verification_commands: {
+			[backendAgentId]: ["backend-test"],
+			[androidAgentId]: ["android-test"],
+		},
+	};
+
+	await handle.db.insert(agents).values([
+		{
+			id: backendAgentId,
+			handle: `backend-${backendAgentId}@acme`,
+			email: `backend-${backendAgentId}@example.com`,
+			displayName: "Backend",
+			role: "backend",
+		},
+		{
+			id: androidAgentId,
+			handle: `android-${androidAgentId}@acme`,
+			email: `android-${androidAgentId}@example.com`,
+			displayName: "Android",
+			role: "android",
+		},
+	]);
+	await handle.db.insert(nodes).values([
+		{ id: backendNodeId, agentId: backendAgentId, name: "backend-mac" },
+		{ id: androidNodeId, agentId: androidAgentId, name: "android-mac" },
+	]);
+	await handle.db.insert(workspaceBindings).values([
+		{
+			id: backendBindingId,
+			nodeId: backendNodeId,
+			alias: "backend-api",
+			repositoryUrl: "https://github.com/acme/backend.git",
+			allowedBaseRefs: ["refs/heads/main"],
+		},
+		{
+			id: androidBindingId,
+			nodeId: androidNodeId,
+			alias: "android-app",
+			repositoryUrl: "https://github.com/acme/android.git",
+			allowedBaseRefs: ["refs/heads/main"],
+		},
+	]);
+
+	return {
+		missionId,
+		backendAgentId,
+		androidAgentId,
+		backendNodeId,
+		androidNodeId,
+		backendBindingId,
+		androidBindingId,
+		contractV1,
+		contractV2,
+		revisionId: randomUUID(),
+		config,
+	};
+}
+
+async function createFixtureMission(handle: TestDb): Promise<Fixture> {
+	const fixture = await seedFixture(handle);
+	await createMissionLedger(handle.db, {
+		createdByAgentId: fixture.backendAgentId,
+		coordinatorConfig: fixture.config,
+	});
+	return fixture;
+}
+
+async function activateMission(handle: TestDb, fixture: Fixture): Promise<ActivatedMission> {
+	await acceptMissionParticipant(handle.db, {
+		missionId: fixture.missionId,
+		participantAgentId: fixture.backendAgentId,
+		acceptance: participantAcceptanceInput(
+			fixture,
+			fixture.backendAgentId,
+			`accept:${fixture.missionId}:backend`,
+		),
+	});
+	await acceptMissionParticipant(handle.db, {
+		missionId: fixture.missionId,
+		participantAgentId: fixture.androidAgentId,
+		acceptance: participantAcceptanceInput(
+			fixture,
+			fixture.androidAgentId,
+			`accept:${fixture.missionId}:android`,
+		),
+	});
+	const [delivery] = await handle.db
+		.select({ id: nodeDeliveries.id })
+		.from(nodeDeliveries)
+		.where(
+			and(
+				eq(nodeDeliveries.missionId, fixture.missionId),
+				eq(nodeDeliveries.nodeId, fixture.backendNodeId),
+				eq(nodeDeliveries.kind, "turn"),
+				eq(nodeDeliveries.status, "stored"),
+			),
+		);
+	if (!delivery) throw new Error("expected activation to schedule the backend turn");
+	return { backendTurnDeliveryId: delivery.id };
+}
+
+function participantAcceptanceInput(
+	fixture: Fixture,
+	participantAgentId: string,
+	idempotencyKey: string,
+) {
+	return {
+		idempotency_key: idempotencyKey,
+		contract: { ...fixture.contractV1 },
+		local_policy_grant: {
+			profile_name: "bounded-code",
+			grant_sha256: participantAgentId === fixture.backendAgentId ? "d".repeat(64) : "e".repeat(64),
+		},
+	};
+}
+
+function aggregateAcceptanceInput(fixture: Fixture, idempotencyKey: string) {
+	return {
+		idempotency_key: idempotencyKey,
+		type: "participants_accepted" as const,
+		participant_agent_ids: [fixture.backendAgentId, fixture.androidAgentId],
+		contract: fixture.contractV1,
+	};
+}
+
+function replyInput(input: {
+	fixture: Fixture;
+	participantAgentId: string;
+	deliveryId: string;
+	idempotencyKey: string;
+	messageId: string;
+	messageIdempotencyKey: string;
+	message: string;
+	sequenceNo: number;
+	causalParentMessageId: string | null;
+}) {
+	return {
+		idempotency_key: input.idempotencyKey,
+		type: "turn_completed" as const,
+		participant_agent_id: input.participantAgentId,
+		delivery_id: input.deliveryId,
+		contract_version: 1,
+		disposition: {
+			kind: "reply" as const,
+			message_type: "question" as const,
+			message: input.message,
+		},
+		message: {
+			message_id: input.messageId,
+			mission_id: input.fixture.missionId,
+			sequence_no: input.sequenceNo,
+			author_agent_id: input.participantAgentId,
+			type: "question" as const,
+			body: input.message,
+			artifacts: [],
+			contract_version: 1,
+			idempotency_key: input.messageIdempotencyKey,
+			causal_parent_message_id: input.causalParentMessageId,
+			created_at: new Date().toISOString(),
+		},
+		revision: null,
+	};
+}
+
+function proposalInput(fixture: Fixture, deliveryId: string) {
+	return {
+		idempotency_key: "turn:backend:proposal",
+		type: "turn_completed" as const,
+		participant_agent_id: fixture.backendAgentId,
+		delivery_id: deliveryId,
+		contract_version: 1,
+		disposition: { kind: "propose_contract" as const, artifact: fixture.contractV2 },
+		message: null,
+		revision: {
+			revision_id: fixture.revisionId,
+			mission_id: fixture.missionId,
+			previous_version: 1,
+			version: 2,
+			artifact: fixture.contractV2,
+			proposed_by_agent_id: fixture.backendAgentId,
+			acknowledged_by_agent_ids: [],
+			idempotency_key: "revision:2",
+			created_at: new Date().toISOString(),
+		},
+	};
+}
+
+function acknowledgementInput(
+	fixture: Fixture,
+	participantAgentId: string,
+	deliveryId: string,
+	idempotencyKey: string,
+) {
+	return {
+		idempotency_key: idempotencyKey,
+		type: "contract_acknowledged" as const,
+		participant_agent_id: participantAgentId,
+		delivery_id: deliveryId,
+		revision_id: fixture.revisionId,
+		contract_version: 2,
+		artifact: fixture.contractV2,
+	};
+}
+
+function readyInput(
+	participantAgentId: string,
+	deliveryId: string,
+	idempotencyKey: string,
+	contractVersion = 1,
+) {
+	return {
+		idempotency_key: idempotencyKey,
+		type: "turn_completed" as const,
+		participant_agent_id: participantAgentId,
+		delivery_id: deliveryId,
+		contract_version: contractVersion,
+		disposition: { kind: "ready" as const, evidence: [] },
+		message: null,
+		revision: null,
+	};
+}
+
+function verificationInput(
+	participantAgentId: string,
+	deliveryId: string,
+	commandId: string,
+	idempotencyKey: string,
+	options: { verificationRound?: number; outcome?: "passed" | "failed" } = {},
+) {
+	const outcome = options.outcome ?? "passed";
+	return {
+		idempotency_key: idempotencyKey,
+		type: "verification_recorded" as const,
+		participant_agent_id: participantAgentId,
+		delivery_id: deliveryId,
+		contract_version: 1,
+		verification_round: options.verificationRound ?? 1,
+		evidence: {
+			verification_id: randomUUID(),
+			command_id: commandId,
+			outcome,
+			exit_code: outcome === "passed" ? 0 : 1,
+			duration_ms: 25,
+			summary: `${commandId} ${outcome}`,
+			output_sha256: "c".repeat(64),
+			artifacts: [],
+			recorded_at: new Date().toISOString(),
+		},
+	};
+}
+
+function only(values: readonly string[], label: string): string {
+	if (values.length !== 1) throw new Error(`expected exactly one ${label}`);
+	return values[0]!;
+}

--- a/relay/src/services/mission-ledger.ts
+++ b/relay/src/services/mission-ledger.ts
@@ -1,0 +1,952 @@
+import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import {
+	type Delivery,
+	type DeliveryKind,
+	InvalidMissionCoordinatorEventError,
+	type MissionCoordinatorAppendInput,
+	type MissionCoordinatorEvent,
+	type MissionCoordinatorState,
+	type MissionParticipantAcceptanceInput,
+	type StoredMissionDeliveryCursorPage,
+	createMissionCoordinatorState,
+	deliverySchema,
+	missionCoordinatorAppendInputSchema,
+	missionCoordinatorConfigSchema,
+	missionCoordinatorEventSchema,
+	missionParticipantAcceptanceInputSchema,
+	reduceMissionCoordinatorEvent,
+	replayMissionCoordinatorEvents,
+	storedDeliveryCursorPageRequestSchema,
+	storedMissionDeliveryCursorPageSchema,
+} from "@agentrelay/protocol";
+import { and, asc, desc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
+import type { Database } from "../db/client.js";
+import {
+	type Mission,
+	type MissionParticipant,
+	agents,
+	missionEvents,
+	missionParticipants,
+	missions,
+	nodeDeliveries,
+	nodes,
+	workspaceBindings,
+} from "../db/schema.js";
+import { RelayError } from "../errors.js";
+import { writeAudit } from "./audit.js";
+
+export interface MissionParticipantBinding {
+	readonly agentId: string;
+	readonly nodeId: string;
+	readonly workspaceBindingId: string;
+}
+
+export interface CreateMissionLedgerResult {
+	readonly missionId: string;
+	readonly state: MissionCoordinatorState;
+	readonly participantBindings: readonly MissionParticipantBinding[];
+	readonly replayed: boolean;
+}
+
+export interface AppendMissionEventResult {
+	readonly event: MissionCoordinatorEvent;
+	readonly deliveryIds: readonly string[];
+	readonly state: MissionCoordinatorState;
+	readonly replayed: boolean;
+}
+
+export interface MissionParticipantAcceptanceReceipt {
+	readonly mission_id: string;
+	readonly participant_agent_id: string;
+	readonly idempotency_key: string;
+	readonly contract: MissionParticipantAcceptanceInput["contract"];
+	readonly local_policy_grant: MissionParticipantAcceptanceInput["local_policy_grant"];
+	readonly accepted_at: string;
+}
+
+export interface AcceptMissionParticipantResult {
+	readonly receipt: MissionParticipantAcceptanceReceipt;
+	readonly replayed: boolean;
+}
+
+export type StoredDeliveryLedgerPage = StoredMissionDeliveryCursorPage;
+
+type LedgerTransaction = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+export async function createMissionLedger(
+	db: Database,
+	input: {
+		createdByAgentId: string;
+		coordinatorConfig: unknown;
+		requestId?: string;
+	},
+): Promise<CreateMissionLedgerResult> {
+	const config = missionCoordinatorConfigSchema.parse(input.coordinatorConfig);
+	const context = config.mission_context;
+	const missionId = context.manifest.mission_id;
+	if (
+		context.created_by.kind !== "agent" ||
+		context.created_by.principal_id !== input.createdByAgentId
+	) {
+		throw new RelayError(
+			"not_authorized_transition",
+			"Authenticated Mission creator does not match mission_context.created_by",
+		);
+	}
+
+	return db.transaction(async (tx) => {
+		await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${missionId}, 0))`);
+
+		const [existing] = await tx.select().from(missions).where(eq(missions.id, missionId));
+		if (existing) {
+			const existingConfig = missionCoordinatorConfigSchema.parse(existing.coordinatorConfig);
+			if (
+				existing.createdByAgentId !== input.createdByAgentId ||
+				!isDeepStrictEqual(existingConfig, config)
+			) {
+				throw new RelayError(
+					"duplicate_idempotency_key",
+					"Mission ID is already bound to different creation input",
+				);
+			}
+			return {
+				missionId,
+				state: createMissionCoordinatorState(existingConfig),
+				participantBindings: await loadParticipantBindings(
+					tx,
+					missionId,
+					existingConfig.mission_context.manifest.participants.map(
+						(participant) => participant.agent_id,
+					),
+				),
+				replayed: true,
+			};
+		}
+
+		const participantIds = context.manifest.participants.map((participant) => participant.agent_id);
+		const requiredAgentIds = [...new Set([...participantIds, input.createdByAgentId])];
+		const activeAgents = await tx
+			.select({ id: agents.id })
+			.from(agents)
+			.where(and(inArray(agents.id, requiredAgentIds), eq(agents.status, "active")));
+		if (activeAgents.length !== requiredAgentIds.length) {
+			throw new RelayError(
+				"invalid_params",
+				"Mission creator and every participant must be active agents",
+			);
+		}
+
+		const participantBindings: MissionParticipantBinding[] = [];
+		for (const participant of context.manifest.participants) {
+			const matches = await tx
+				.select({
+					workspaceBindingId: workspaceBindings.id,
+					nodeId: nodes.id,
+				})
+				.from(workspaceBindings)
+				.innerJoin(nodes, eq(nodes.id, workspaceBindings.nodeId))
+				.where(
+					and(
+						eq(nodes.agentId, participant.agent_id),
+						eq(nodes.status, "active"),
+						eq(workspaceBindings.status, "active"),
+						eq(workspaceBindings.alias, participant.workspace_alias),
+						eq(workspaceBindings.repositoryUrl, participant.repository_url),
+					),
+				);
+			if (matches.length !== 1) {
+				throw new RelayError(
+					"invalid_params",
+					"Mission participant must resolve to exactly one active Node workspace",
+					{
+						participant_agent_id: participant.agent_id,
+						workspace_alias: participant.workspace_alias,
+						eligible_nodes: matches.length,
+					},
+				);
+			}
+			participantBindings.push({
+				agentId: participant.agent_id,
+				nodeId: matches[0]!.nodeId,
+				workspaceBindingId: matches[0]!.workspaceBindingId,
+			});
+		}
+
+		const state = createMissionCoordinatorState(config);
+		await tx.insert(missions).values({
+			id: missionId,
+			createdByAgentId: input.createdByAgentId,
+			coordinatorConfig: config,
+			state,
+			status: state.status,
+			lastEventSequence: state.sequence_no,
+			contractVersion: state.contract_version,
+			expiresAt: new Date(context.manifest.expires_at),
+		});
+		await tx.insert(missionParticipants).values(
+			context.manifest.participants.map((participant) => {
+				const binding = participantBindings.find(
+					(candidate) => candidate.agentId === participant.agent_id,
+				)!;
+				return {
+					missionId,
+					agentId: participant.agent_id,
+					nodeId: binding.nodeId,
+					workspaceBindingId: binding.workspaceBindingId,
+					role: participant.role,
+				};
+			}),
+		);
+		await writeAudit(tx, {
+			actorId: input.createdByAgentId,
+			action: "mission.create",
+			resourceType: "mission",
+			resourceId: missionId,
+			requestId: input.requestId,
+			metadata: { participant_agent_ids: participantIds },
+		});
+
+		return { missionId, state, participantBindings, replayed: false };
+	});
+}
+
+export async function acceptMissionParticipant(
+	db: Database,
+	input: {
+		missionId: string;
+		participantAgentId: string;
+		acceptance: unknown;
+		requestId?: string;
+	},
+): Promise<AcceptMissionParticipantResult> {
+	const acceptance = missionParticipantAcceptanceInputSchema.parse(input.acceptance);
+
+	return db.transaction(async (tx) => {
+		await lockMission(tx, input.missionId);
+		const [mission] = await tx.select().from(missions).where(eq(missions.id, input.missionId));
+		if (!mission) throw new RelayError("invalid_params", "Mission not found");
+
+		const [participant] = await tx
+			.select()
+			.from(missionParticipants)
+			.where(
+				and(
+					eq(missionParticipants.missionId, input.missionId),
+					eq(missionParticipants.agentId, input.participantAgentId),
+				),
+			);
+		if (!participant) {
+			throw new RelayError(
+				"not_authorized_transition",
+				"Authenticated actor is not a Mission participant",
+			);
+		}
+
+		if (participant.status === "accepted") {
+			const storedAcceptance = acceptanceInputFromParticipant(participant);
+			if (
+				participant.acceptanceIdempotencyKey !== acceptance.idempotency_key ||
+				!isDeepStrictEqual(storedAcceptance, acceptance)
+			) {
+				throw new RelayError(
+					"duplicate_idempotency_key",
+					"Mission participant already accepted with a different receipt",
+				);
+			}
+			return {
+				receipt: acceptanceReceiptFromParticipant(participant, storedAcceptance),
+				replayed: true,
+			};
+		}
+
+		if (Date.now() >= mission.expiresAt.getTime()) {
+			throw new RelayError("invalid_transition", "Mission has expired");
+		}
+		const config = missionCoordinatorConfigSchema.parse(mission.coordinatorConfig);
+		const manifest = config.mission_context.manifest;
+		const manifestParticipant = manifest.participants.find(
+			(candidate) => candidate.agent_id === input.participantAgentId,
+		);
+		if (!manifestParticipant) {
+			throw new RelayError("internal", "Stored participant is absent from the Mission manifest");
+		}
+		if (!isDeepStrictEqual(acceptance.contract, manifest.shared_contract)) {
+			throw new RelayError("invalid_params", "Acceptance must bind the exact Mission contract");
+		}
+		if (
+			acceptance.local_policy_grant.profile_name !==
+			manifestParticipant.requested_local_policy_profile
+		) {
+			throw new RelayError(
+				"invalid_params",
+				"Acceptance policy grant must match the participant's requested local profile",
+			);
+		}
+
+		const [keyOwner] = await tx
+			.select({ agentId: missionParticipants.agentId })
+			.from(missionParticipants)
+			.where(
+				and(
+					eq(missionParticipants.missionId, input.missionId),
+					eq(missionParticipants.acceptanceIdempotencyKey, acceptance.idempotency_key),
+				),
+			);
+		if (keyOwner) {
+			throw new RelayError(
+				"duplicate_idempotency_key",
+				"Acceptance idempotency key is already bound to another participant",
+			);
+		}
+
+		const acceptedAt = new Date();
+		const [acceptedParticipant] = await tx
+			.update(missionParticipants)
+			.set({
+				status: "accepted",
+				acceptedAt,
+				acceptanceIdempotencyKey: acceptance.idempotency_key,
+				acceptanceReceipt: acceptance,
+			})
+			.where(
+				and(
+					eq(missionParticipants.missionId, input.missionId),
+					eq(missionParticipants.agentId, input.participantAgentId),
+					eq(missionParticipants.status, "pending"),
+				),
+			)
+			.returning();
+		if (!acceptedParticipant) {
+			throw new RelayError("invalid_transition", "Mission participant is not pending acceptance");
+		}
+
+		await writeAudit(tx, {
+			actorId: input.participantAgentId,
+			action: "mission.participant.accept",
+			resourceType: "mission",
+			resourceId: input.missionId,
+			requestId: input.requestId,
+			metadata: {
+				contract_version: acceptance.contract.version,
+				contract_sha256: acceptance.contract.sha256,
+				policy_profile: acceptance.local_policy_grant.profile_name,
+				policy_grant_sha256: acceptance.local_policy_grant.grant_sha256,
+			},
+		});
+
+		const participants = await tx
+			.select()
+			.from(missionParticipants)
+			.where(eq(missionParticipants.missionId, input.missionId));
+		if (participants.length === manifest.participants.length && participants.every(isAccepted)) {
+			const aggregate = missionCoordinatorAppendInputSchema.parse({
+				idempotency_key: `mission:${input.missionId}:participants-accepted`,
+				type: "participants_accepted",
+				participant_agent_ids: manifest.participants.map((candidate) => candidate.agent_id),
+				contract: manifest.shared_contract,
+			});
+			await appendMissionEventInTransaction(tx, mission, {
+				actorAgentId: input.participantAgentId,
+				appendInput: aggregate,
+				requestId: input.requestId,
+				allowDerivedAcceptance: true,
+			});
+		}
+
+		return {
+			receipt: acceptanceReceiptFromParticipant(acceptedParticipant, acceptance),
+			replayed: false,
+		};
+	});
+}
+
+export async function appendMissionEvent(
+	db: Database,
+	input: {
+		missionId: string;
+		actorAgentId: string;
+		event: unknown;
+		requestId?: string;
+	},
+): Promise<AppendMissionEventResult> {
+	const appendInput = missionCoordinatorAppendInputSchema.parse(input.event);
+	if (appendInput.type === "participants_accepted") {
+		throw new RelayError(
+			"not_authorized_transition",
+			"Participant acceptance is derived only from two independent receipts",
+		);
+	}
+
+	return db.transaction(async (tx) => {
+		await lockMission(tx, input.missionId);
+		const [mission] = await tx.select().from(missions).where(eq(missions.id, input.missionId));
+		if (!mission) throw new RelayError("invalid_params", "Mission not found");
+		return appendMissionEventInTransaction(tx, mission, {
+			actorAgentId: input.actorAgentId,
+			appendInput,
+			requestId: input.requestId,
+			allowDerivedAcceptance: false,
+		});
+	});
+}
+
+async function appendMissionEventInTransaction(
+	tx: LedgerTransaction,
+	mission: Mission,
+	input: {
+		actorAgentId: string;
+		appendInput: MissionCoordinatorAppendInput;
+		requestId?: string;
+		allowDerivedAcceptance: boolean;
+	},
+): Promise<AppendMissionEventResult> {
+	const sourceDeliveryId =
+		input.appendInput.type === "participants_accepted" ? null : input.appendInput.delivery_id;
+	const [replayRow] = await tx
+		.select()
+		.from(missionEvents)
+		.where(
+			and(
+				eq(missionEvents.missionId, mission.id),
+				eq(missionEvents.idempotencyKey, input.appendInput.idempotency_key),
+			),
+		);
+	if (replayRow) {
+		const replayEvent = eventFromRow(replayRow);
+		if (
+			replayRow.actorAgentId !== input.actorAgentId ||
+			replayRow.sourceDeliveryId !== sourceDeliveryId ||
+			!isDeepStrictEqual(appendInputFromEvent(replayEvent), input.appendInput)
+		) {
+			throw new RelayError(
+				"duplicate_idempotency_key",
+				"Idempotency key is already bound to a different Mission event",
+			);
+		}
+		const replayDeliveries = await tx
+			.select({ id: nodeDeliveries.id })
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.missionEventId, replayRow.id))
+			.orderBy(asc(nodeDeliveries.cursor));
+		const replayConfig = missionCoordinatorConfigSchema.parse(mission.coordinatorConfig);
+		const replayEventRows = await tx
+			.select()
+			.from(missionEvents)
+			.where(eq(missionEvents.missionId, mission.id))
+			.orderBy(asc(missionEvents.sequenceNo));
+		return {
+			event: replayEvent,
+			deliveryIds: replayDeliveries.map((delivery) => delivery.id),
+			state: replayMissionCoordinatorEvents(
+				replayConfig,
+				replayEventRows.filter((row) => row.sequenceNo <= replayRow.sequenceNo).map(eventFromRow),
+			),
+			replayed: true,
+		};
+	}
+
+	if (Date.now() >= mission.expiresAt.getTime()) {
+		throw new RelayError("invalid_transition", "Mission has expired");
+	}
+	if (input.appendInput.type === "participants_accepted") {
+		if (!input.allowDerivedAcceptance) {
+			throw new RelayError(
+				"not_authorized_transition",
+				"Participant acceptance must be derived from stored receipts",
+			);
+		}
+		await assertExactParticipantAcceptances(tx, mission, input.appendInput);
+	} else {
+		assertAuthorizedActor(input.actorAgentId, input.appendInput);
+	}
+
+	const config = missionCoordinatorConfigSchema.parse(mission.coordinatorConfig);
+	const storedRows = await tx
+		.select()
+		.from(missionEvents)
+		.where(eq(missionEvents.missionId, mission.id))
+		.orderBy(asc(missionEvents.sequenceNo));
+	const currentState = replayMissionCoordinatorEvents(config, storedRows.map(eventFromRow));
+	if (
+		currentState.sequence_no !== mission.lastEventSequence ||
+		!isDeepStrictEqual(currentState, missionStateFromRow(mission))
+	) {
+		throw new RelayError("internal", "Stored Mission projection does not match its event ledger");
+	}
+
+	if (input.appendInput.type !== "participants_accepted") {
+		await assertSourceDelivery(tx, mission.id, input.actorAgentId, input.appendInput);
+	}
+
+	const event = missionCoordinatorEventSchema.parse({
+		...input.appendInput,
+		event_id: randomUUID(),
+		mission_id: mission.id,
+		sequence_no: currentState.sequence_no + 1,
+		created_at: new Date().toISOString(),
+	});
+	let nextState: MissionCoordinatorState;
+	try {
+		nextState = reduceMissionCoordinatorEvent(currentState, event);
+	} catch (error) {
+		if (error instanceof InvalidMissionCoordinatorEventError) {
+			throw new RelayError("invalid_transition", error.message, { reason: error.reason });
+		}
+		throw error;
+	}
+
+	const previousEvent = storedRows.at(-1);
+	await tx.insert(missionEvents).values({
+		id: event.event_id,
+		missionId: mission.id,
+		sequenceNo: event.sequence_no,
+		type: event.type,
+		actorAgentId: input.actorAgentId,
+		idempotencyKey: event.idempotency_key,
+		sourceDeliveryId,
+		causalParentEventId: previousEvent?.id ?? null,
+		payload: eventPayload(event),
+		createdAt: new Date(event.created_at),
+	});
+
+	if (sourceDeliveryId !== null && shouldSettleSourceDelivery(nextState, event)) {
+		const settledAt = new Date(event.created_at);
+		const settlementConditions =
+			event.type === "verification_recorded" && event.evidence.outcome === "failed"
+				? and(
+						eq(nodeDeliveries.missionId, mission.id),
+						eq(nodeDeliveries.kind, "verification"),
+						eq(nodeDeliveries.contractVersion, event.contract_version),
+						eq(nodeDeliveries.verificationRound, event.verification_round),
+						isNull(nodeDeliveries.settledByEventId),
+					)
+				: and(
+						eq(nodeDeliveries.id, sourceDeliveryId),
+						eq(nodeDeliveries.missionId, mission.id),
+						isNull(nodeDeliveries.settledByEventId),
+					);
+		const settled = await tx
+			.update(nodeDeliveries)
+			.set({ settledByEventId: event.event_id, settledAt })
+			.where(settlementConditions)
+			.returning({ id: nodeDeliveries.id });
+		if (!settled.some((delivery) => delivery.id === sourceDeliveryId)) {
+			throw new RelayError("invalid_transition", "Source delivery is no longer available");
+		}
+	}
+
+	const participantRows = await tx
+		.select()
+		.from(missionParticipants)
+		.where(eq(missionParticipants.missionId, mission.id));
+	const deliveryTargets = deriveDeliveryTargets(currentState, nextState, event);
+	const createdDeliveryIds: string[] = [];
+	for (const target of deliveryTargets) {
+		const participant = participantRows.find((row) => row.agentId === target.agentId);
+		if (!participant) {
+			throw new RelayError("internal", "Derived delivery target is not a Mission participant");
+		}
+		const [causalParent] = await tx
+			.select({ id: nodeDeliveries.id })
+			.from(nodeDeliveries)
+			.where(
+				and(
+					eq(nodeDeliveries.missionId, mission.id),
+					eq(nodeDeliveries.nodeId, participant.nodeId),
+				),
+			)
+			.orderBy(desc(nodeDeliveries.cursor))
+			.limit(1);
+		const [created] = await tx
+			.insert(nodeDeliveries)
+			.values({
+				nodeId: participant.nodeId,
+				missionId: mission.id,
+				missionEventId: event.event_id,
+				kind: target.kind,
+				contractVersion: target.contractVersion,
+				verificationRound: target.verificationRound,
+				idempotencyKey: `event:${event.event_id}:${target.kind}:${participant.nodeId}`,
+				causalParentDeliveryId: causalParent?.id ?? null,
+			})
+			.returning({ id: nodeDeliveries.id });
+		if (!created) throw new RelayError("internal", "Failed to persist derived delivery");
+		createdDeliveryIds.push(created.id);
+	}
+
+	await tx
+		.update(missions)
+		.set({
+			state: nextState,
+			status: nextState.status,
+			lastEventSequence: nextState.sequence_no,
+			contractVersion: nextState.contract_version,
+		})
+		.where(eq(missions.id, mission.id));
+	await writeAudit(tx, {
+		actorId: input.actorAgentId,
+		action: "mission.event.append",
+		resourceType: "mission_event",
+		resourceId: event.event_id,
+		requestId: input.requestId,
+		metadata: {
+			mission_id: mission.id,
+			sequence_no: event.sequence_no,
+			type: event.type,
+			source_delivery_id: sourceDeliveryId,
+			delivery_ids: createdDeliveryIds,
+			derived: event.type === "participants_accepted",
+		},
+	});
+
+	return {
+		event,
+		deliveryIds: createdDeliveryIds,
+		state: nextState,
+		replayed: false,
+	};
+}
+
+export async function listStoredDeliveryEvents(
+	db: Database,
+	input: { nodeId: string; page: unknown },
+): Promise<StoredDeliveryLedgerPage> {
+	const page = storedDeliveryCursorPageRequestSchema.parse(input.page);
+	const conditions = [
+		eq(nodeDeliveries.nodeId, input.nodeId),
+		eq(nodeDeliveries.status, "stored"),
+		isNull(nodeDeliveries.settledByEventId),
+	];
+	if (page.after_cursor !== null) {
+		conditions.push(gt(nodeDeliveries.cursor, BigInt(page.after_cursor)));
+	}
+	const rows = await db
+		.select({ delivery: nodeDeliveries, event: missionEvents })
+		.from(nodeDeliveries)
+		.innerJoin(missionEvents, eq(missionEvents.id, nodeDeliveries.missionEventId))
+		.where(and(...conditions))
+		.orderBy(asc(nodeDeliveries.cursor))
+		.limit(page.limit);
+	const items = rows.map((row) => ({
+		delivery: deliveryFromRow(row.delivery),
+		event: eventFromRow(row.event),
+		actor_agent_id: row.event.actorAgentId,
+		source_delivery_id: row.event.sourceDeliveryId,
+		causal_parent_event_id: row.event.causalParentEventId,
+	}));
+	return storedMissionDeliveryCursorPageSchema.parse({
+		items,
+		next_cursor: items.at(-1)?.delivery.cursor ?? page.after_cursor,
+	});
+}
+
+async function lockMission(tx: LedgerTransaction, missionId: string): Promise<void> {
+	await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${missionId}, 0))`);
+}
+
+function acceptanceInputFromParticipant(
+	participant: MissionParticipant,
+): MissionParticipantAcceptanceInput {
+	if (participant.acceptanceReceipt === null) {
+		throw new RelayError("internal", "Accepted participant is missing its durable receipt");
+	}
+	return missionParticipantAcceptanceInputSchema.parse(participant.acceptanceReceipt);
+}
+
+function acceptanceReceiptFromParticipant(
+	participant: MissionParticipant,
+	acceptance: MissionParticipantAcceptanceInput,
+): MissionParticipantAcceptanceReceipt {
+	if (participant.acceptedAt === null) {
+		throw new RelayError("internal", "Accepted participant is missing its acceptance time");
+	}
+	return {
+		mission_id: participant.missionId,
+		participant_agent_id: participant.agentId,
+		idempotency_key: acceptance.idempotency_key,
+		contract: acceptance.contract,
+		local_policy_grant: acceptance.local_policy_grant,
+		accepted_at: participant.acceptedAt.toISOString(),
+	};
+}
+
+function isAccepted(participant: MissionParticipant): boolean {
+	return (
+		participant.status === "accepted" &&
+		participant.acceptedAt !== null &&
+		participant.acceptanceIdempotencyKey !== null &&
+		participant.acceptanceReceipt !== null
+	);
+}
+
+async function assertExactParticipantAcceptances(
+	tx: LedgerTransaction,
+	mission: Mission,
+	event: Extract<MissionCoordinatorAppendInput, { readonly type: "participants_accepted" }>,
+): Promise<void> {
+	const config = missionCoordinatorConfigSchema.parse(mission.coordinatorConfig);
+	const manifest = config.mission_context.manifest;
+	const participants = await tx
+		.select()
+		.from(missionParticipants)
+		.where(eq(missionParticipants.missionId, mission.id));
+	if (participants.length !== manifest.participants.length || !participants.every(isAccepted)) {
+		throw new RelayError(
+			"not_authorized_transition",
+			"Both Mission participants must have durable acceptance receipts",
+		);
+	}
+	if (!isDeepStrictEqual(event.contract, manifest.shared_contract)) {
+		throw new RelayError("internal", "Derived acceptance contract does not match the manifest");
+	}
+
+	for (const manifestParticipant of manifest.participants) {
+		const participant = participants.find(
+			(candidate) => candidate.agentId === manifestParticipant.agent_id,
+		);
+		if (!participant) {
+			throw new RelayError("internal", "Mission manifest and participant rows disagree");
+		}
+		const acceptance = acceptanceInputFromParticipant(participant);
+		if (
+			!isDeepStrictEqual(acceptance.contract, manifest.shared_contract) ||
+			acceptance.local_policy_grant.profile_name !==
+				manifestParticipant.requested_local_policy_profile
+		) {
+			throw new RelayError(
+				"internal",
+				"Stored participant acceptance no longer matches the immutable Mission",
+			);
+		}
+	}
+}
+
+async function assertSourceDelivery(
+	tx: LedgerTransaction,
+	missionId: string,
+	actorAgentId: string,
+	event: Exclude<MissionCoordinatorAppendInput, { readonly type: "participants_accepted" }>,
+): Promise<void> {
+	const [source] = await tx
+		.select({
+			delivery: nodeDeliveries,
+			participantStatus: missionParticipants.status,
+		})
+		.from(nodeDeliveries)
+		.innerJoin(
+			missionParticipants,
+			and(
+				eq(missionParticipants.missionId, nodeDeliveries.missionId),
+				eq(missionParticipants.nodeId, nodeDeliveries.nodeId),
+			),
+		)
+		.where(
+			and(
+				eq(nodeDeliveries.id, event.delivery_id),
+				eq(nodeDeliveries.missionId, missionId),
+				eq(missionParticipants.agentId, actorAgentId),
+			),
+		);
+	if (!source || source.participantStatus !== "accepted") {
+		throw new RelayError(
+			"not_authorized_transition",
+			"Source delivery is not assigned to the authenticated Mission participant",
+		);
+	}
+
+	const expectedKind: DeliveryKind =
+		event.type === "turn_completed"
+			? "turn"
+			: event.type === "contract_acknowledged"
+				? "contract_acknowledgement"
+				: "verification";
+	if (
+		source.delivery.status !== "stored" ||
+		source.delivery.settledByEventId !== null ||
+		source.delivery.kind !== expectedKind ||
+		source.delivery.contractVersion !== event.contract_version ||
+		(event.type === "verification_recorded" &&
+			source.delivery.verificationRound !== event.verification_round)
+	) {
+		throw new RelayError(
+			"invalid_transition",
+			"Source delivery is unavailable or does not match the event kind and contract",
+		);
+	}
+}
+
+function shouldSettleSourceDelivery(
+	next: MissionCoordinatorState,
+	event: MissionCoordinatorEvent,
+): boolean {
+	if (event.type !== "verification_recorded") return event.type !== "participants_accepted";
+	if (event.evidence.outcome === "failed") return true;
+	const required = next.required_verification_commands[event.participant_agent_id] ?? [];
+	return required.every((commandId) =>
+		next.verification_records.some(
+			(record) =>
+				record.participant_agent_id === event.participant_agent_id &&
+				record.contract_version === event.contract_version &&
+				record.verification_round === event.verification_round &&
+				record.evidence.command_id === commandId &&
+				record.evidence.outcome === "passed",
+		),
+	);
+}
+
+function assertAuthorizedActor(actorAgentId: string, event: MissionCoordinatorAppendInput): void {
+	if (event.type === "participants_accepted") return;
+	if (event.participant_agent_id !== actorAgentId) {
+		throw new RelayError(
+			"not_authorized_transition",
+			"Mission event participant does not match the authenticated actor",
+		);
+	}
+}
+
+function deriveDeliveryTargets(
+	previous: MissionCoordinatorState,
+	next: MissionCoordinatorState,
+	event: MissionCoordinatorEvent,
+): Array<{
+	agentId: string;
+	kind: DeliveryKind;
+	contractVersion: number;
+	verificationRound: number | null;
+}> {
+	if (event.type === "turn_completed" && event.disposition.kind === "propose_contract") {
+		const pendingVersion = next.pending_revision?.version;
+		if (pendingVersion === undefined) {
+			throw new RelayError("internal", "Contract proposal did not produce a pending revision");
+		}
+		return next.mission_context.manifest.participants.map((participant) => ({
+			agentId: participant.agent_id,
+			kind: "contract_acknowledgement",
+			contractVersion: pendingVersion,
+			verificationRound: null,
+		}));
+	}
+	if (previous.status !== "verifying" && next.status === "verifying") {
+		return next.mission_context.manifest.participants.map((participant) => ({
+			agentId: participant.agent_id,
+			kind: "verification",
+			contractVersion: next.contract_version,
+			verificationRound: next.verification_round,
+		}));
+	}
+	if (next.status === "active" && next.current_participant_agent_id !== null) {
+		return [
+			{
+				agentId: next.current_participant_agent_id,
+				kind: "turn",
+				contractVersion: next.contract_version,
+				verificationRound: null,
+			},
+		];
+	}
+	return [];
+}
+
+function eventPayload(event: MissionCoordinatorEvent): Record<string, unknown> {
+	const payload = { ...event } as Record<string, unknown>;
+	for (const field of [
+		"event_id",
+		"idempotency_key",
+		"mission_id",
+		"sequence_no",
+		"created_at",
+		"type",
+	]) {
+		delete payload[field];
+	}
+	return payload;
+}
+
+function appendInputFromEvent(event: MissionCoordinatorEvent): MissionCoordinatorAppendInput {
+	const input = { ...event } as Record<string, unknown>;
+	for (const field of ["event_id", "mission_id", "sequence_no", "created_at"]) {
+		delete input[field];
+	}
+	return missionCoordinatorAppendInputSchema.parse(input);
+}
+
+function eventFromRow(row: typeof missionEvents.$inferSelect): MissionCoordinatorEvent {
+	if (row.payload === null || typeof row.payload !== "object" || Array.isArray(row.payload)) {
+		throw new RelayError("internal", "Stored Mission event payload is not an object");
+	}
+	return missionCoordinatorEventSchema.parse({
+		...(row.payload as Record<string, unknown>),
+		event_id: row.id,
+		idempotency_key: row.idempotencyKey,
+		mission_id: row.missionId,
+		sequence_no: row.sequenceNo,
+		created_at: row.createdAt.toISOString(),
+		type: row.type,
+	});
+}
+
+function deliveryFromRow(row: typeof nodeDeliveries.$inferSelect): Delivery {
+	return deliverySchema.parse({
+		delivery_id: row.id,
+		node_id: row.nodeId,
+		mission_id: row.missionId,
+		mission_event_id: row.missionEventId,
+		kind: row.kind,
+		cursor: row.cursor.toString(),
+		status: row.status,
+		attempt_count: row.attemptCount,
+		max_attempts: row.maxAttempts,
+		last_fencing_token: row.lastFencingToken,
+		contract_version: row.contractVersion,
+		verification_round: row.verificationRound,
+		lease:
+			row.activeLeaseId === null || row.leaseExpiresAt === null
+				? null
+				: {
+						lease_id: row.activeLeaseId,
+						fencing_token: row.lastFencingToken,
+						expires_at: row.leaseExpiresAt.toISOString(),
+					},
+		idempotency_key: row.idempotencyKey,
+		causal_parent_delivery_id: row.causalParentDeliveryId,
+		available_at: row.availableAt.toISOString(),
+		created_at: row.createdAt.toISOString(),
+		updated_at: row.updatedAt.toISOString(),
+		acknowledged_at: row.acknowledgedAt?.toISOString() ?? null,
+		dead_lettered_at: row.deadLetteredAt?.toISOString() ?? null,
+	});
+}
+
+function missionStateFromRow(row: typeof missions.$inferSelect): MissionCoordinatorState {
+	const config = missionCoordinatorConfigSchema.parse(row.coordinatorConfig);
+	const eventState = row.state as MissionCoordinatorState;
+	if (
+		eventState === null ||
+		typeof eventState !== "object" ||
+		eventState.mission_context?.manifest.mission_id !== config.mission_context.manifest.mission_id
+	) {
+		throw new RelayError("internal", "Stored Mission projection is invalid");
+	}
+	return structuredClone(eventState);
+}
+
+async function loadParticipantBindings(
+	db: Pick<Database, "select">,
+	missionId: string,
+	participantAgentIds: readonly string[],
+): Promise<MissionParticipantBinding[]> {
+	const rows = await db
+		.select({
+			agentId: missionParticipants.agentId,
+			nodeId: missionParticipants.nodeId,
+			workspaceBindingId: missionParticipants.workspaceBindingId,
+		})
+		.from(missionParticipants)
+		.where(eq(missionParticipants.missionId, missionId));
+	return participantAgentIds.map((agentId) => {
+		const row = rows.find((candidate) => candidate.agentId === agentId);
+		if (!row) throw new RelayError("internal", "Stored Mission participant binding is missing");
+		return row;
+	});
+}


### PR DESCRIPTION
## Summary

- persist relay-visible Nodes, workspace bindings, Missions, participant receipts, ordered events, and per-Node deliveries
- derive activation only from two exact participant receipts and bind every result to assigned source work, contract version, and verification round
- add logical work settlement, joined cursor replay with provenance, composite database integrity constraints, and Docker workspace packaging
- keep Node authentication, fenced leases, runtime execution, and transport acknowledgement explicitly deferred

## Validation

- 90 protocol tests
- 94 relay Postgres integration tests
- workspace lint, typecheck, build, and tests
- protocol export smoke
- relay Docker build and runtime protocol import

## Stack

Base: #54. This PR should be reviewed after the mailbox-integrity checkpoint.