### PR TITLE
feat(relay): add Node enrollment and workspace registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,11 @@ tool-neutral repository instruction file.
 AgentRelay is intended to let independently owned agents discover, communicate, and
 collaborate across devices, repositories, and runtimes.
 
-The code on `main` currently implements a durable manual handoff mailbox through a
-relay and stdio MCP server. The next target adds a long-running local AgentRelay Node,
-durable delivery processing, runtime adapters, and bounded Missions. Do not present
-planned Node behavior as shipped.
+The repository currently implements a durable manual handoff mailbox, the internal
+Mission ledger, and relay APIs for Node enrollment, Node credential revocation, and
+logical workspace registration. The next target adds authenticated delivery claims,
+a long-running local AgentRelay Node, and real runtime activation. Do not present
+planned execution behavior as shipped.
 
 Read the relevant source before making a non-trivial change:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,8 @@ Peer messages and artifacts are untrusted input.
 
 - Preserve bearer authentication, participant authorization, block checks, and
   lifecycle-transition ownership.
+- Keep agent and Node bearer credentials type-separated. A Node credential must not
+  authenticate `/agents` or `/a2a`, and an agent key must not authenticate `/node/v1`.
 - State-changing operations need an idempotency strategy and transactionally
   consistent audit behavior.
 - Provenance-wrap every teammate-originated text-bearing field, including fields

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ repositories is the first proof, not the final product boundary.
 
 ## Honest status
 
-The repository currently ships an **authenticated asynchronous mailbox plus an
-internal durable Mission-ledger kernel**, not the full autonomous runtime described
-above. The ledger has no public Node API or runtime activation path yet.
+The repository currently ships an **authenticated asynchronous mailbox, a durable
+Mission-ledger kernel, and the first Node identity API**, not the full autonomous
+runtime described above. Nodes can be enrolled and bind logical workspaces, but no
+public route can claim Mission work or start a coding-agent runtime yet.
 
 ### Implemented today
 
@@ -38,6 +39,11 @@ above. The ledger has no public Node API or runtime activation path yet.
   deliveries. The internal ledger service records one exact acceptance receipt per
   participant, derives activation only after both receipts exist, binds every result
   to its source work, and supports provenance-preserving cursor replay.
+- Separately revocable Node credentials plus authenticated enrollment, credential
+  rotation, Node revocation, and logical workspace registration routes. Agent and
+  Node credentials are different key types; rotation is generation-fenced, and
+  revoking a Node also revokes its active credential and workspace bindings without
+  deleting Mission history.
 - CLI setup, invite/join, install, doctor/fix, key rotation, audit, relay-synchronized
   block/unblock, and local trust management.
 - An in-process Slack dispatcher with encrypted-at-rest webhook configuration.
@@ -45,7 +51,7 @@ above. The ledger has no public Node API or runtime activation path yet.
 ### Next architecture, not shipped yet
 
 - A persistent AgentRelay Node on every participating machine.
-- Node-scoped credentials plus public enrollment and cursor-polling routes.
+- Authenticated Mission and cursor-polling routes for enrolled Nodes.
 - Fenced delivery claims, lease renewal/expiry, acknowledgements, retries,
   dead-letter handling, and durable transport-operation receipts. The current kernel
   can settle logical work, but it does not pretend that unclaimed work was executed.
@@ -200,7 +206,7 @@ Cross-agent messages and artifacts are untrusted input. Current safeguards inclu
 bearer authentication, participant authorization, block checks on new and existing
 handoff messages and content-bearing transitions, a shared transaction lock that makes
 a successful block response a commit fence for those mutations, audit for
-invite/handoff/message/block mutations, provenance
+invite/handoff/message/block and Node/workspace mutations, provenance
 wrappers or markers on every teammate-originated mailbox field returned by MCP,
 recommended host settings, and local trust parsing.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,10 +18,12 @@ application on top of it.
 
 ## Current implementation
 
-The repository currently ships an authenticated asynchronous mailbox:
+The repository currently ships an authenticated asynchronous mailbox plus its first
+durable coordination foundations:
 
 - Postgres-backed developer identities, cards, API keys, invites, blocks, handoffs,
-  and messages, with audit records for invite and handoff/message mutations.
+  and messages, with audit records for invite, handoff/message, block, and
+  Node/workspace mutations.
 - A Hono relay with REST onboarding and an A2A-shaped JSON-RPC endpoint.
 - Seven stdio MCP tools for sending, receiving, replying to, inspecting, and
   completing handoff threads.
@@ -30,8 +32,12 @@ The repository currently ships an authenticated asynchronous mailbox:
 - An internal Postgres Mission-ledger kernel with relay-visible Node and workspace
   identity, immutable Mission context, current reducer projection, append-only
   coordinator events, independent participant acceptance receipts, transactionally
-  derived stored deliveries, and per-Node cursor replay. It is not exposed as a Node
-  API yet.
+  derived stored deliveries, and per-Node cursor replay. The Mission and delivery
+  service remains internal.
+- A public identity surface that lets an authenticated agent enroll and revoke its
+  Nodes, rotate separately scoped Node credentials, and lets an authenticated Node
+  register or revoke relay-visible logical workspace bindings. It never accepts a
+  local checkout path.
 - Typed engineering artifacts plus provenance wrapping or structural markers on all
   teammate-originated mailbox content.
 - An in-process Slack notification dispatcher with encrypted-at-rest webhook setup.
@@ -41,8 +47,8 @@ This is useful groundwork, but it is not yet an autonomous agent network. The cu
 system does not contain:
 
 - A persistent local daemon that consumes work and starts or resumes agent turns.
-- Node-scoped credentials, enrollment/polling routes, processing claims, leases,
-  acknowledgements, retry, or dead-letter operations.
+- Authenticated Node delivery polling, processing claims, leases, acknowledgements,
+  retry, or dead-letter operations.
 - Runtime-session or Mission-lease identity; persisted Node/workspace records are an
   internal routing foundation only.
 - Enforcement of the returned per-teammate trust overlay inside a runtime.
@@ -177,7 +183,8 @@ Remote agent content is untrusted data. The receiving owner controls local autho
 
 ### Implemented safeguards
 
-- Hashed and revocable API keys.
+- Hashed and revocable agent and Node credentials with disjoint bearer formats and
+  route scopes.
 - Participant-only handoff access and role-specific state transitions.
 - Relay-side block checks when creating, accepting, appending to, or completing a
   content-bearing handoff. A shared directed-pair transaction lock makes a committed
@@ -194,8 +201,9 @@ Remote agent content is untrusted data. The receiving owner controls local autho
 
 ### Gaps before autonomous execution
 
-- Registration, card updates, key rotation, and agent disable are not written to the
-  current relay audit log.
+- Agent registration, card updates, agent-key rotation, and agent disable are not
+  written to the current relay audit log. Node enrollment, credential rotation,
+  Node revocation, and workspace registration/revocation are audited.
 - `trust_overlay` is returned as JSON but is not dynamically applied to the host.
 - Relay audit does not record local commands, edits, tests, or policy decisions.
 - The notification queue is process-local and can drop work on overflow or restart.
@@ -221,8 +229,8 @@ push, merge, publish, deploy, arbitrary network effects, and production credenti
 - TLS protects data in transit; Postgres stores relay-visible content.
 - Relay-blind end-to-end encryption is not decided. It would change search,
   notifications, policy inspection, and recovery.
-- Local filesystem paths do not travel in peer messages. Nodes resolve logical
-  workspace aliases locally.
+- Local filesystem paths do not enter relay-visible workspace registrations or peer
+  messages. Nodes resolve logical workspace aliases locally.
 - Agents exchange bounded text, structured contracts, hashes, patches, immutable git
   references, and approved links, not assumed shared filesystem state.
 - Store decisions and observable execution evidence, not hidden chain-of-thought.

--- a/docs/deploy-fly.md
+++ b/docs/deploy-fly.md
@@ -85,7 +85,9 @@ fly secrets set \
   -a <your-app-name>
 ```
 
-Save these values somewhere safe (1Password, age-encrypted file). `RELAY_PEPPER` and `RELAY_ENCRYPTION_KEY` are sticky - rotating them invalidates every issued API key and every encrypted Slack webhook respectively.
+Save these values somewhere safe (1Password, age-encrypted file). `RELAY_PEPPER` and
+`RELAY_ENCRYPTION_KEY` are sticky - rotating them invalidates every issued agent or
+Node credential and every encrypted Slack webhook respectively.
 
 ### 5. Deploy
 

--- a/docs/hld.md
+++ b/docs/hld.md
@@ -1,8 +1,8 @@
 # High-level design: current relay implementation
 
 > **Scope:** Current repository implementation as of 2026-08-02.
-> This document describes the existing handoff plane and internal durable-ledger
-> kernel, not the autonomous Node target.
+> This document describes the existing handoff plane, durable-ledger kernel, and
+> Node identity/workspace API, not the autonomous Node runtime target.
 > See [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md) for the next system.
 
 ## Purpose
@@ -13,8 +13,8 @@ the conversation and enforces participant access. A local stdio MCP server expos
 the mailbox as tools to Claude Code or Codex.
 
 Humans or active agent sessions still initiate inbox checks and every subsequent
-tool call. There is no daemon, Node credential/API, durable processing claim, or
-runtime activation loop.
+tool call. The relay can enroll a Node and issue its separate credential, but there
+is no daemon, authenticated delivery claim, or runtime activation loop.
 
 ## Components
 
@@ -42,11 +42,15 @@ The relay is a Node/TypeScript Hono service backed by Postgres and Drizzle. It o
 - API-key rotation and block records.
 - Handoff and ordered-message persistence.
 - Participant authorization and lifecycle transitions.
-- Audit records for invite, handoff/message, and block mutations.
+- Audit records for invite, handoff/message, block, Node/workspace, and internal
+  Mission mutations.
 - An in-process Slack dispatcher with encrypted-at-rest webhook configuration.
 - An internal Mission-ledger service that persists Mission projections and append-only
   events, derives stored per-Node deliveries in the same transaction, and reads them
   through an opaque cursor. No HTTP route invokes this service yet.
+- Agent-authenticated Node enrollment, credential rotation, and revocation routes,
+  plus Node-authenticated logical workspace registration and revocation. These
+  operations are audited in the same transaction as their state changes.
 
 The HTTP application is stateless with respect to durable domain rows, but the
 notification queue is process-local and not durable.
@@ -84,7 +88,8 @@ Agent 1---1 AgentCard
              |
              +----- mutation AuditLog rows
 
-Agent 1---N Node ---N WorkspaceBinding
+Agent 1---N Node ---N NodeCredential
+                 \---N WorkspaceBinding
                  \---N MissionParticipant ---1 Mission ---N MissionEvent
                                                     |
                                                     +---N NodeDelivery
@@ -98,13 +103,15 @@ Agent 1---N Node ---N WorkspaceBinding
   proposed action, and lifecycle timestamps.
 - `Message` is append-only, stores payload and typed artifacts separately, and
   receives a per-handoff sequence number.
-- `AuditLog` records invite, handoff/message, and block mutations, not every relay
-  mutation or any local host action.
+- `AuditLog` records invite, handoff/message, block, Node/workspace, and internal
+  Mission mutations, not every relay mutation or any local host action.
 - `AgentBlock` prevents a blocked sender from creating a new handoff for the blocker
   or appending another message to an existing thread whose receiver blocked them.
 - `Invite` records signed-token identity, expiry, and one-time redemption.
 - `Node` and `WorkspaceBinding` are relay-visible routing identities without a local
   checkout path or executable command authority.
+- `NodeCredential` stores only the hashed, separately revocable credential used by
+  one active Node. Its raw token is returned only when enrolled or rotated.
 - `Mission` stores the immutable coordinator config plus a reducer projection;
   `MissionEvent` is append-only and ordered within that Mission.
 - `NodeDelivery` points one Node cursor to work derived from a committed Mission
@@ -174,7 +181,8 @@ and the relay-owned idempotency key is not exposed to the model.
 ### Durable today
 
 - Handoffs, messages, lifecycle state, identities, invites, and blocks, plus audit
-  rows for invite, handoff/message, and block mutations.
+  rows for invite, handoff/message, block, Node/workspace, and internal Mission
+  mutations.
 - Participant access checks and most state transitions.
 - Idempotent replay for handoff creation and message append.
 - Through the internal ledger service: Mission creation, ordered event append,
@@ -182,6 +190,8 @@ and the relay-owned idempotency key is not exposed to the model.
   source-delivery and causal links, derived stored deliveries, logical settlement,
   audit, stable event/delivery-ID replay, and joined cursor replay. Each mutation and
   its consequences share one Postgres transaction.
+- Node enrollment, credential rotation/revocation, logical workspace registration,
+  exact workspace replay, and atomic Node-to-credential/workspace revocation.
 
 ### Best effort today
 
@@ -191,8 +201,7 @@ and the relay-owned idempotency key is not exposed to the model.
 
 ### Not implemented today
 
-- Node enrollment/credentials or an authenticated polling route over the internal
-  Node/workspace and delivery records.
+- An authenticated polling route over the internal Mission and delivery records.
 - Delivery claim, transport acknowledgement, retry lease, dead-letter transition, or
   general transport-operation receipt.
 - Runtime-session start/resume/cancel.
@@ -202,12 +211,12 @@ and the relay-owned idempotency key is not exposed to the model.
 
 ## Security boundaries
 
-Implemented protections include hashed keys, participant authorization, block checks
-on new handoffs, pending acceptance, active-thread appends, and content-bearing
-completion, a shared directed-pair lock between those checks and block-list writes,
-scoped relay audit, provenance wrappers or markers on
-teammate-originated mailbox fields, static host permission recommendations, and
-per-acceptance local trust loading.
+Implemented protections include type-separated hashed agent and Node credentials,
+participant authorization, block checks on new handoffs, pending acceptance,
+active-thread appends, and content-bearing completion, a shared directed-pair lock
+between those checks and block-list writes, scoped relay audit, provenance wrappers
+or markers on teammate-originated mailbox fields, static host permission
+recommendations, and per-acceptance local trust loading.
 
 They are not yet one end-to-end enforcement system:
 
@@ -242,11 +251,17 @@ model. See the security section of [`architecture.md`](architecture.md).
   acceptance is its own exact receipt; the second receipt atomically derives the
   aggregate activation event and first turn. A failed delivery insert rolls back that
   entire mutation. Cursor reads do not imply claim, execution, or acknowledgement.
+- Node credential rotation is a compare-and-swap against the owner-visible active
+  credential ID and serializes with workspace mutations. Concurrent rotations from
+  one credential generation cannot both succeed. Node revocation atomically disables
+  its credential and active workspace bindings; immutable Mission rows remain for
+  audit and recovery analysis.
 
 ## Relationship to the next design
 
 The current APIs remain a compatibility and inspection surface while Missions are
-proved. The internal kernel now stores Nodes, workspace bindings, Missions, events,
-and unclaimed deliveries without stretching the handoff row into a scheduler. The
-next checkpoint adds separately revocable Node credentials and fenced lease/claim/
-completion APIs before any local runtime is allowed to consume that work.
+proved. The relay now enrolls separately authenticated Nodes and their logical
+workspace bindings, while the internal kernel stores Missions, events, and unclaimed
+deliveries without stretching the handoff row into a scheduler. The next checkpoint
+adds authenticated polling and fenced lease/claim/completion APIs before any local
+runtime is allowed to consume that work.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -50,7 +50,8 @@ Whichever platform you pick, the relay needs:
 
 ## Migration / rotation notes
 
-- `RELAY_PEPPER` is **sticky** — rotating it invalidates every existing API key (every teammate has to re-register). Pick a stable value at launch and keep it.
+- `RELAY_PEPPER` is **sticky** — rotating it invalidates every existing agent and
+  Node bearer credential. Pick a stable value at launch and keep it.
 - `RELAY_ENCRYPTION_KEY` is sticky for any encrypted-at-rest fields (Slack webhook URLs today). Rotate only with a re-encrypt step.
 - `RELAY_ADMIN_TOKEN` is rotatable freely; existing teammates aren't affected.
 - `RELAY_INVITE_SECRET` is rotatable but invalidates any minted-but-unredeemed invite URLs.

--- a/docs/lld.md
+++ b/docs/lld.md
@@ -2,8 +2,8 @@
 
 > **Scope:** Current repository implementation as of 2026-08-02.
 > This is a compact source-oriented reference, not a promise that planned fields or
-> routes exist. Future Node and Mission contracts belong to
-> [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md) until implemented.
+> routes exist. Unimplemented Node runtime and Mission HTTP behavior remains in
+> [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md) until it lands.
 
 ## Repository layout
 
@@ -19,10 +19,11 @@
 └── package.json         pnpm workspace scripts
 ```
 
-There is currently no `node/` daemon, persistent event consumer, Node HTTP surface,
-or real runtime adapter. The executable Mission contracts, deterministic coordinator,
-fake adapter, and backend-Android proof fixture live in `protocol/`; the relay now
-contains an internal durable-ledger service that no route calls yet.
+There is currently no `node/` daemon, persistent event consumer, authenticated
+delivery route, or real runtime adapter. The relay does expose Node enrollment,
+credential, identity, and logical workspace routes. The executable Mission contracts,
+deterministic coordinator, fake adapter, and backend-Android proof fixture live in
+`protocol/`; the durable Mission-ledger service itself remains internal.
 
 ## Protocol workspace
 
@@ -63,19 +64,21 @@ the committed Drizzle migrations.
 | `api_keys` | Hashed bearer keys with label, last-used timestamp, and revocation timestamp. |
 | `handoffs` | Sender, recipient, summary, intent, four-state lifecycle, initial and completion artifacts, proposed action, metadata, timestamps, idempotency key. |
 | `messages` | Append-only handoff messages with separate generic payload and typed artifacts, per-thread sequence, and idempotency key. |
-| `audit_log` | Invite, handoff/message, block, and internal Mission create/participant-accept/event mutation records: actor, action, resource, metadata, request ID, timestamp. |
+| `audit_log` | Invite, handoff/message, block, Node/workspace, and internal Mission create/participant-accept/event mutation records: actor, action, resource, metadata, request ID, timestamp. |
 | `agent_blocks` | Blocker/blocked pairs enforced for new handoffs and each existing-thread append. |
 | `invites` | Signed-token hash, target handle/role, inviter, expiry, use timestamp, and redeemed agent. |
-| `nodes` | Internal device identity owned by one agent, with relay-visible capabilities, presence timestamp, and revocation state. No credential is issued yet. |
+| `nodes` | Device identity owned by one agent, with relay-visible capabilities, best-effort presence timestamp, and revocation state. |
+| `node_credentials` | Hashed Node-only bearer credentials with label, last-used timestamp, and independent revocation timestamp. A partial unique index permits at most one active credential per Node; raw tokens are never stored. |
 | `workspace_bindings` | A Node-local logical alias represented at the relay by repository URL and allowed base refs. It deliberately has no checkout path. |
 | `missions` | Immutable coordinator config, current reducer projection/status/contract version, sequence, creator, and expiry. |
 | `mission_participants` | The exact agent, Node, and workspace binding selected for each two-party Mission, plus that participant's idempotent contract and opaque local-policy-grant acceptance receipt. |
 | `mission_events` | Append-only type-specific coordinator payload with relay-generated event ID, Mission sequence/time, service-supplied actor, source delivery, idempotency key, and causal parent. |
 | `node_deliveries` | Per-Node opaque cursor pointing to one Mission event, with contract/verification generation, logical settlement, and future lease/fencing state. |
 
-Public mailbox authentication still represents a logical developer/agent. Internal
-Node and workspace identities now exist for deterministic Mission routing, but there
-is no Node credential, local checkout identity, runtime session, or Mission lease.
+Public mailbox authentication still represents a logical developer/agent. Until a
+separate owner/organization identity exists, that agent credential is the enrollment
+authority for its own Nodes. Node credentials now exist for the identity/workspace
+surface, but there is no local checkout identity, runtime session, or Mission lease.
 
 ## Authentication
 
@@ -86,8 +89,18 @@ is no Node credential, local checkout identity, runtime session, or Mission leas
   in a mode-0600 file.
 - Self-rotation revokes all active keys for the caller, writes a replacement, and
   updates local config after the response.
-
-Node-scoped credentials do not exist yet.
+- Node routes accept only `ar_node_live_*` or `ar_node_test_*` credentials; agent
+  credentials cannot authenticate them, and Node credentials cannot authenticate
+  agent or A2A routes.
+- Enrollment and credential rotation return a raw Node token once. The relay stores
+  only its peppered hash and salt. The owner-only Node summary exposes the current
+  credential ID, never its token or hash. Rotation must compare-and-swap that exact
+  ID; stale or concurrent requests return `state_changed` without mutation. A lost
+  response is recovered by listing the current ID and rotating that generation once
+  more.
+- Node authentication requires an active credential, active Node, and active owning
+  agent. Successful requests update credential last-used and Node presence on a
+  best-effort, debounced path.
 
 ## Internal Mission ledger
 
@@ -127,8 +140,9 @@ Node-scoped credentials do not exist yet.
   rolled-back transactions are valid. The future claim operation must also scan
   recoverable expired leases independently of this new-work cursor.
 
-This internal surface is intentionally not mounted under `/agents`, `/a2a`, or a
-temporary agent-authenticated Node route.
+The Mission/event/delivery service remains intentionally unmounted. The public Node
+routes expose only identity and logical workspace registration; they cannot list,
+claim, execute, or acknowledge a Mission delivery.
 
 ## HTTP surface
 
@@ -167,9 +181,27 @@ There is no `/metrics`, `/inbox/:id`, or
 | `GET` | `/agents/me/block` | List caller's server-side blocks. |
 | `POST` | `/agents/me/block` | Add a server-side block by handle. |
 | `DELETE` | `/agents/me/block/:handle` | Remove a server-side block. |
+| `POST` | `/agents/me/nodes` | Enroll a Node and return its raw Node credential once. Duplicate active names return `state_changed`; they never replay a secret. |
+| `GET` | `/agents/me/nodes` | List owner-only summaries for every owned Node, including revoked history and the current active credential ID or `null`. No token or hash is exposed. |
+| `POST` | `/agents/me/nodes/:nodeId/credentials/rotate` | Require `{expected_credential_id}`, atomically replace only that active generation, and return the new raw credential once. A stale generation returns `state_changed`. |
+| `DELETE` | `/agents/me/nodes/:nodeId` | Idempotently revoke an owned Node, its active credentials, and active workspace bindings while retaining Mission history. |
 
 `/agents` is authenticated. The stored card JSON is not currently exposed through an
 A2A well-known discovery URL.
+
+### Authenticated Node routes
+
+| Method | Path | Behavior |
+|---|---|---|
+| `GET` | `/node/v1/me` | Return the active Node's relay-visible descriptor. |
+| `POST` | `/node/v1/workspaces` | Register one logical alias, repository URL, and allowed base-ref set. An exact active replay returns the existing binding; changed input conflicts, and a revoked alias stays retired. |
+| `GET` | `/node/v1/workspaces` | List the Node's active and revoked relay-visible bindings. |
+| `DELETE` | `/node/v1/workspaces/:alias` | Idempotently revoke an existing binding; a never-registered alias returns `workspace_not_found`. |
+
+Workspace registration accepts no checkout path, command, credential-bearing URL,
+or local policy. Node-authenticated workspace mutations re-check the credential under
+the same Node transaction lock used by rotation and revocation, so a completed
+revocation fences later mutations.
 
 ## JSON-RPC surface
 
@@ -347,8 +379,9 @@ Important limits:
 ## Audit and revocation
 
 Relay audit rows cover invite mint/redeem, handoff create/accept/complete/cancel,
-message append, block/unblock, and internal Mission create/participant accept/event
-append. Registration, card updates, key rotation, and agent disable still write no
+message append, block/unblock, Node enroll/credential-rotate/revoke, workspace
+register/revoke, and internal Mission create/participant accept/event append. Agent
+registration, card updates, agent-key rotation, and agent disable still write no
 audit row. Audit also does not record commands, tool
 arguments/results, file edits, tests, or permission decisions performed by a local
 coding-agent host.
@@ -415,7 +448,8 @@ command.
 ## Boundary with the next design
 
 Do not extend `accepted_by_session` or the four-state handoff table into a distributed
-runtime scheduler. Nodes, workspace bindings, Missions, events, and stored deliveries
-now have a separate internal ledger. The next slice adds Node credentials and a
-fenced claim/renew/complete API with immutable attempt evidence and durable operation
-receipts, while keeping the mailbox API as a compatibility and inspection surface.
+runtime scheduler. Nodes, credentials, workspace bindings, Missions, events, and
+stored deliveries have a separate model. The next slice exposes authenticated
+delivery polling plus fenced claim/renew/complete operations with immutable attempt
+evidence and durable operation receipts, while keeping the mailbox API as a
+compatibility and inspection surface.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -60,18 +60,21 @@ in-memory scripted proof, not durable relay or real-runtime evidence.
   replay over joined immutable events.
 - [x] Persist two independent exact acceptance receipts, bind results to source work,
   and prevent settled or stale verification-round work from advancing a Mission.
-- [ ] Add independently revocable Node credentials and authenticated enrollment,
-  Mission, and polling routes.
+- [x] Add independently revocable Node credentials plus authenticated enrollment,
+  credential rotation/revocation, and logical workspace registration routes.
+- [ ] Add authenticated Mission creation/acceptance/result and Node delivery-polling
+  routes.
 - [ ] Add claim leases, renewal, expiry, retry, cancellation, and dead-letter policy.
 - [ ] Persist claim/attempt history, runs, acknowledgements, and exact operation
   receipts for the Mission retention period.
 - [ ] Prove reconnect and recovery through cursor polling; leave SSE out of this slice.
 
-The completed kernel is deliberately internal: no agent credential can impersonate a
-Node, and no runtime can consume an unfenced delivery. Event append replays immutable
-event and derived-delivery IDs; logical settlement is distinct from transport
-acknowledgement. The next state-changing Node operations need fenced, durable
-operation receipts.
+Agent and Node credentials are type-separated, and Node revocation atomically revokes
+its active credentials and workspace bindings without deleting Mission history. The
+Mission ledger is still internal: no runtime can poll or consume an unfenced delivery.
+Event append replays immutable event and derived-delivery IDs; logical settlement is
+distinct from transport acknowledgement. The next delivery operations need fenced,
+durable operation receipts.
 
 Required tests: disconnect before claim, after claim, and after host acceptance;
 duplicate signal; relay restart; late output after terminal Mission.
@@ -115,7 +118,8 @@ as the activation foundation.
 
 - Relay-readable versus relay-blind payloads.
 - Inline patches versus signed artifact storage versus immutable git references.
-- Exact owner/agent/node/workspace credential and revocation UX.
+- Separate owner/organization identity and operator-facing enrollment/recovery UX
+  beyond the current agent-authorized compare-and-swap API.
 - Claude adapter choice.
 - Hosted service and federation.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -35,7 +35,8 @@ curl http://localhost:8080/readyz
 
 Replace every development secret before exposing the relay. Keep `RELAY_PEPPER`,
 `RELAY_ENCRYPTION_KEY`, and `RELAY_INVITE_SECRET` stable in a secret manager; casual
-rotation invalidates existing credentials, encrypted fields, or outstanding invites.
+rotation invalidates existing agent and Node credentials, encrypted fields, or
+outstanding invites.
 
 ### Team deployment
 
@@ -174,8 +175,9 @@ runtime activation.
   the settings are not a substitute for an operating-system sandbox.
 - `trust.yaml` influences the decision returned by `accept_handoff`; the result is
   not dynamically applied to an active runtime.
-- Relay audit covers invite and handoff/message mutations. It omits several other
-  relay mutations and all local commands, edits, and tests.
+- Relay audit covers invite, handoff/message, block, and Node/workspace mutations. It
+  still omits several agent-management mutations and all local commands, edits, and
+  tests.
 
 For this mailbox release, keep writes and external actions behind the host's normal
 human approval flow. Do not treat a teammate's message as permission to push, deploy,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,9 +10,10 @@ AgentRelay is a cross-device communication and collaboration network for indepen
 owned agents. Coding across separate repositories is the first proving vertical, not
 the product's final boundary.
 
-The current repository is an authenticated asynchronous mailbox. The next milestone
-is not another notification mode. It is a durable delivery ledger plus a persistent
-local Node that can start or resume a bounded agent turn.
+The current repository combines an authenticated asynchronous mailbox with the
+durable Mission-ledger kernel and a Node enrollment/workspace identity surface. The
+next milestone is authenticated, fenced delivery processing plus a persistent local
+Node that can start or resume a bounded agent turn.
 
 We progress through evidence gates, not calendar promises or version hype.
 
@@ -52,8 +53,9 @@ including one contract revision, without a real coding-agent runtime.
 
 **Status:** internal ledger kernel implemented with independent acceptance receipts,
 source-bound result settlement, verification generations, and joined cursor replay.
-Node credentials, public polling, fenced leases, transport acknowledgements,
-recovery, and the Stage 2 exit gate remain open.
+Separately revocable Node credentials and enrollment/workspace routes are implemented.
+Public delivery polling, fenced leases, transport acknowledgements, recovery, and the
+Stage 2 exit gate remain open.
 
 - Add node identity, workspace-binding, Mission, event, delivery, claim, run, and
   acknowledgement persistence.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -69,22 +69,23 @@ must call `check_inbox` or `view_thread`.
 Peer content is untrusted data.
 
 Current protections include bearer authentication, participant authorization,
-relay-side blocks for new handoffs, audit records for invite and handoff/message
-mutations, provenance markers on summary/message text returned by `accept_handoff`
-and `view_thread`, recommended host settings, and local trust parsing.
+relay-side blocks for new handoffs and later content-bearing thread mutations, audit
+records for invite, handoff/message, and block mutations, provenance wrappers or
+structural markers on teammate-authored mailbox data, recommended host settings, and
+local trust parsing.
 
 Known limits:
 
-- `check_inbox` summary previews and some artifact fields are returned without
-  provenance wrapping.
-- Existing-thread appends do not re-check relay block state.
+- Pickup is explicit; this stdio process does not listen in the background or start a
+  host turn.
 - `accept_handoff` returns `trust_overlay`, but this package does not dynamically
   apply it to an active Claude or Codex session.
 - Host permission semantics are provider-specific; generated config is a
   recommendation, not a universal enforcement guarantee.
 - Relay audit omits several relay mutations and does not record local commands,
   edits, tests, or permission decisions.
-- Local block state and relay-side block state can diverge.
+- Relay and local block writes cannot commit atomically across HTTP and the local
+  filesystem. The CLI uses a fail-safe order and reports partial failures for retry.
 
 Keep writes and external effects behind the host's ordinary human approval boundary.
 Do not grant remote content authority to push, publish, deploy, access credentials, or

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -4,9 +4,10 @@ Executable contracts for AgentRelay's bounded two-participant Mission loop.
 
 The package contains:
 
-- strict Zod schemas for relay-visible Nodes/workspaces, Mission manifests,
-  participant acceptance receipts, contract revisions, typed messages, artifact
-  references, delivery/cursor envelopes, runs, and evidence;
+- strict Zod schemas for Node enrollment, workspace registration, relay-visible
+  Node/workspace descriptors, Mission manifests, participant acceptance receipts,
+  contract revisions, typed messages, artifact references, delivery/cursor
+  envelopes, runs, and evidence;
 - pure Mission, fenced-delivery, and deterministic coordinator reducers that reject
   invalid transitions;
 - a runtime-neutral host adapter contract, with a deterministic fake under
@@ -49,6 +50,11 @@ its immutable Mission event and trusted actor/source/causal provenance. Empty pa
 may retain the caller's cursor checkpoint. `missionParticipantAcceptanceInputSchema`
 records the exact shared contract and an opaque hash for the matching local-policy
 grant without putting local policy details on the relay wire.
+
+Node credential rotation is a generation compare-and-swap: owners read
+`active_credential_id` from `ownedNodeSummarySchema` and submit that exact value with
+`nodeCredentialRotationInputSchema`. Credential identity is deliberately absent from
+the relay-visible `nodeDescriptorSchema`.
 
 The adapter contract makes replay semantics explicit: every event has a stable
 turn-local sequence, available usage is a monotonic cumulative turn snapshot, and

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -24,7 +24,7 @@
 		"build": "tsc -p tsconfig.json",
 		"prepack": "pnpm run build",
 		"test": "vitest run",
-		"test:exports": "node --input-type=module -e \"const p = await import('@agentrelay/protocol'); const t = await import('@agentrelay/protocol/testing'); if (!p.missionManifestSchema || !p.transitionDeliveryState || !p.acceptHostEvent || !p.missionCoordinatorEventSchema || !p.missionCoordinatorAppendInputSchema || !p.missionParticipantAcceptanceInputSchema || !p.storedMissionDeliveryItemSchema || !p.storedMissionDeliveryCursorPageSchema || !p.nodeDescriptorSchema || !p.workspaceBindingDescriptorSchema || !p.storedDeliveryCursorPageSchema || !t.FakeAgentHostAdapter || !t.runMissionFixture || !t.backendAndroidMissionFixture) throw new Error('protocol exports missing')\"",
+		"test:exports": "node --input-type=module -e \"const p = await import('@agentrelay/protocol'); const t = await import('@agentrelay/protocol/testing'); if (!p.missionManifestSchema || !p.transitionDeliveryState || !p.acceptHostEvent || !p.missionCoordinatorEventSchema || !p.missionCoordinatorAppendInputSchema || !p.missionParticipantAcceptanceInputSchema || !p.storedMissionDeliveryItemSchema || !p.storedMissionDeliveryCursorPageSchema || !p.nodeEnrollmentInputSchema || !p.nodeCredentialRotationInputSchema || !p.nodeDescriptorSchema || !p.ownedNodeSummarySchema || !p.workspaceRegistrationInputSchema || !p.workspaceBindingDescriptorSchema || !p.storedDeliveryCursorPageSchema || !t.FakeAgentHostAdapter || !t.runMissionFixture || !t.backendAndroidMissionFixture) throw new Error('protocol exports missing')\"",
 		"test:watch": "vitest",
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},

--- a/protocol/src/schemas.test.ts
+++ b/protocol/src/schemas.test.ts
@@ -8,7 +8,10 @@ import {
 	missionContextSchema,
 	missionEventEnvelopeSchema,
 	missionManifestSchema,
+	nodeCredentialRotationInputSchema,
 	nodeDescriptorSchema,
+	nodeEnrollmentInputSchema,
+	ownedNodeSummarySchema,
 	policyRequestSchema,
 	runSchema,
 	storedDeliveryCursorPageRequestSchema,
@@ -16,6 +19,7 @@ import {
 	turnDispositionSchema,
 	verificationEvidenceSchema,
 	workspaceBindingDescriptorSchema,
+	workspaceRegistrationInputSchema,
 } from "./schemas.js";
 
 const ids = {
@@ -33,6 +37,7 @@ const ids = {
 	revision: "00000000-0000-4000-8000-000000000012",
 	workspaceBinding: "00000000-0000-4000-8000-000000000013",
 	otherNode: "00000000-0000-4000-8000-000000000014",
+	nodeCredential: "00000000-0000-4000-8000-000000000015",
 } as const;
 
 const artifact = {
@@ -160,6 +165,101 @@ describe("relay-visible Node contracts", () => {
 			workspaceBindingDescriptorSchema.safeParse({
 				...binding,
 				allowed_base_refs: ["../outside"],
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe("Node enrollment inputs", () => {
+	it("accepts only a logical Node name and unique capabilities", () => {
+		const input = {
+			name: "backend-mac",
+			capabilities: ["runtime.codex", "runtime.fake"],
+		};
+
+		expect(nodeEnrollmentInputSchema.parse(input)).toEqual(input);
+		expect(
+			nodeEnrollmentInputSchema.safeParse({
+				...input,
+				capabilities: ["runtime.fake", "runtime.fake"],
+			}).success,
+		).toBe(false);
+		expect(
+			nodeEnrollmentInputSchema.safeParse({
+				...input,
+				local_path: "/Users/alice/backend",
+			}).success,
+		).toBe(false);
+	});
+
+	it("requires an exact credential generation for rotation", () => {
+		const input = { expected_credential_id: ids.nodeCredential };
+
+		expect(nodeCredentialRotationInputSchema.parse(input)).toEqual(input);
+		expect(
+			nodeCredentialRotationInputSchema.safeParse({
+				...input,
+				force: true,
+			}).success,
+		).toBe(false);
+		expect(
+			nodeCredentialRotationInputSchema.safeParse({
+				expected_credential_id: "current",
+			}).success,
+		).toBe(false);
+	});
+
+	it("keeps owner credential identity outside the relay-visible Node descriptor", () => {
+		const node = {
+			node_id: ids.node,
+			agent_id: ids.backendAgent,
+			name: "backend-mac",
+			status: "active" as const,
+			capabilities: ["runtime.fake"],
+			last_seen_at: null,
+			created_at: "2026-08-02T10:00:00.000Z",
+			updated_at: "2026-08-02T10:00:00.000Z",
+			revoked_at: null,
+		};
+		const summary = {
+			node,
+			active_credential_id: ids.nodeCredential,
+		};
+
+		expect(ownedNodeSummarySchema.parse(summary)).toEqual(summary);
+		expect(nodeDescriptorSchema.safeParse(summary).success).toBe(false);
+		expect(
+			ownedNodeSummarySchema.safeParse({
+				...summary,
+				credential_token: "secret",
+			}).success,
+		).toBe(false);
+	});
+
+	it("accepts only safe logical workspace registration data", () => {
+		const input = {
+			alias: "backend-api",
+			repository_url: "https://github.com/acme/backend.git",
+			allowed_base_refs: ["refs/heads/main", "refs/heads/release"],
+		};
+
+		expect(workspaceRegistrationInputSchema.parse(input)).toEqual(input);
+		expect(
+			workspaceRegistrationInputSchema.safeParse({
+				...input,
+				allowed_base_refs: ["refs/heads/main", "refs/heads/main"],
+			}).success,
+		).toBe(false);
+		expect(
+			workspaceRegistrationInputSchema.safeParse({
+				...input,
+				repository_url: "file:///Users/alice/backend",
+			}).success,
+		).toBe(false);
+		expect(
+			workspaceRegistrationInputSchema.safeParse({
+				...input,
+				checkout_path: "/Users/alice/backend",
 			}).success,
 		).toBe(false);
 	});

--- a/protocol/src/schemas.ts
+++ b/protocol/src/schemas.ts
@@ -142,6 +142,23 @@ export const actorRefSchema = z
 
 export const nodeStatusSchema = z.enum(["active", "revoked"]);
 
+export const nodeEnrollmentInputSchema = z
+	.object({
+		name: aliasSchema,
+		capabilities: z.array(identifierSchema).max(32),
+	})
+	.strict()
+	.refine((input) => hasUniqueValues(input.capabilities), {
+		message: "Node capabilities must be unique",
+		path: ["capabilities"],
+	});
+
+export const nodeCredentialRotationInputSchema = z
+	.object({
+		expected_credential_id: uuidSchema,
+	})
+	.strict();
+
 export const nodeDescriptorSchema = z
 	.object({
 		node_id: uuidSchema,
@@ -201,6 +218,13 @@ export const nodeDescriptorSchema = z
 		}
 	});
 
+export const ownedNodeSummarySchema = z
+	.object({
+		node: nodeDescriptorSchema,
+		active_credential_id: uuidSchema.nullable(),
+	})
+	.strict();
+
 export const workspaceBindingStatusSchema = z.enum(["active", "revoked"]);
 
 export const repositoryUrlSchema = z
@@ -246,6 +270,18 @@ export const repositoryUrlSchema = z
 				message: "Repository URL must not contain query parameters or fragments",
 			});
 		}
+	});
+
+export const workspaceRegistrationInputSchema = z
+	.object({
+		alias: aliasSchema,
+		repository_url: repositoryUrlSchema,
+		allowed_base_refs: z.array(repositoryRefSchema).max(32),
+	})
+	.strict()
+	.refine((input) => hasUniqueValues(input.allowed_base_refs), {
+		message: "Allowed base refs must be unique",
+		path: ["allowed_base_refs"],
 	});
 
 export const workspaceBindingDescriptorSchema = z
@@ -886,8 +922,12 @@ export type PolicyProfileName = z.infer<typeof policyProfileNameSchema>;
 export type PolicyRequest = z.infer<typeof policyRequestSchema>;
 export type ActorRef = z.infer<typeof actorRefSchema>;
 export type NodeStatus = z.infer<typeof nodeStatusSchema>;
+export type NodeEnrollmentInput = z.infer<typeof nodeEnrollmentInputSchema>;
+export type NodeCredentialRotationInput = z.infer<typeof nodeCredentialRotationInputSchema>;
 export type NodeDescriptor = z.infer<typeof nodeDescriptorSchema>;
+export type OwnedNodeSummary = z.infer<typeof ownedNodeSummarySchema>;
 export type WorkspaceBindingStatus = z.infer<typeof workspaceBindingStatusSchema>;
+export type WorkspaceRegistrationInput = z.infer<typeof workspaceRegistrationInputSchema>;
 export type WorkspaceBindingDescriptor = z.infer<typeof workspaceBindingDescriptorSchema>;
 export type Participant = z.infer<typeof participantSchema>;
 export type ArtifactRef = z.infer<typeof artifactRefSchema>;

--- a/relay/drizzle/0006_node_credentials.sql
+++ b/relay/drizzle/0006_node_credentials.sql
@@ -1,0 +1,33 @@
+-- Drizzle reads its journal before opening the migration transaction. Serialize
+-- concurrent relay startup so two runners can safely observe this file as pending.
+SELECT pg_advisory_xact_lock(
+  hashtextextended('agentrelay:migration:0006_node_credentials', 0)
+);
+--> statement-breakpoint
+-- `now()` is fixed at transaction start and can regress updated_at after a
+-- concurrent write. Use wall-clock time when each update trigger actually runs.
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = clock_timestamp();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "node_credentials" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "node_id" uuid NOT NULL REFERENCES "nodes"("id") ON DELETE restrict,
+  "key_hash" bytea NOT NULL,
+  "salt" bytea NOT NULL,
+  "label" text,
+  "last_used_at" timestamp with time zone,
+  "revoked_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_node_credentials_active_node";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_node_credentials_active_node"
+  ON "node_credentials" ("node_id") WHERE "revoked_at" IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_node_credentials_active_hash"
+  ON "node_credentials" ("key_hash") WHERE "revoked_at" IS NULL;

--- a/relay/drizzle/meta/_journal.json
+++ b/relay/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
 			"when": 1785762000000,
 			"tag": "0005_durable_delivery_ledger",
 			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1785848400000,
+			"tag": "0006_node_credentials",
+			"breakpoints": true
 		}
 	]
 }

--- a/relay/scripts/test-integration.sh
+++ b/relay/scripts/test-integration.sh
@@ -37,13 +37,13 @@ truncate_all() {
   if [[ -n "${RELAY_TEST_TRUNCATE_VIA_PSQL:-}" ]]; then
     command -v psql >/dev/null || { echo "psql not on PATH" >&2; exit 1; }
     psql "$RELAY_TEST_DATABASE_URL" -q -c \
-      "TRUNCATE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, nodes, agents, agent_cards, api_keys, handoffs, messages, audit_log, agent_blocks, invites RESTART IDENTITY CASCADE;" \
+      "TRUNCATE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, node_credentials, nodes, agents, agent_cards, api_keys, handoffs, messages, audit_log, agent_blocks, invites RESTART IDENTITY CASCADE;" \
       >/dev/null 2>&1
     return
   fi
 
   docker exec "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -q -c \
-    "TRUNCATE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, nodes, agents, agent_cards, api_keys, handoffs, messages, audit_log, agent_blocks, invites RESTART IDENTITY CASCADE;" \
+    "TRUNCATE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, node_credentials, nodes, agents, agent_cards, api_keys, handoffs, messages, audit_log, agent_blocks, invites RESTART IDENTITY CASCADE;" \
     >/dev/null 2>&1
 }
 
@@ -53,6 +53,7 @@ truncate_all() {
 INTEGRATION_FILES=(
   src/db/migration-0004.test.ts
   src/db/migration-0005.test.ts
+  src/db/migration-0006.test.ts
   src/db/schema.test.ts
   src/services/mission-ledger.test.ts
   src/routes/admin.test.ts
@@ -61,6 +62,7 @@ INTEGRATION_FILES=(
   src/routes/a2a.test.ts
   src/routes/blocks.test.ts
   src/routes/me.test.ts
+  src/routes/nodes.test.ts
   src/notifications/dispatcher.test.ts
 )
 

--- a/relay/src/auth/keys.test.ts
+++ b/relay/src/auth/keys.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { constantTimeEqual, generateKey, hashKey, isWellFormedKey } from "./keys.js";
+import {
+	constantTimeEqual,
+	generateKey,
+	generateNodeKey,
+	hashKey,
+	isWellFormedKey,
+	isWellFormedNodeKey,
+} from "./keys.js";
 
 describe("auth/keys", () => {
 	const pepper = "p".repeat(32);
@@ -19,6 +26,25 @@ describe("auth/keys", () => {
 		expect(isWellFormedKey(k.raw)).toBe(true);
 	});
 
+	it("generates well-formed Node keys", () => {
+		for (const env of ["live", "test"] as const) {
+			const k = generateNodeKey(env, pepper);
+			expect(k.raw.startsWith(`ar_node_${env}_`)).toBe(true);
+			expect(k.raw.length).toBe(`ar_node_${env}_`.length + 32);
+			expect(isWellFormedNodeKey(k.raw)).toBe(true);
+			expect(k.hash.length).toBe(32);
+			expect(k.salt.length).toBe(16);
+		}
+	});
+
+	it("keeps agent and Node key types separate", () => {
+		const agentKey = generateKey("test", pepper);
+		const nodeKey = generateNodeKey("test", pepper);
+
+		expect(isWellFormedNodeKey(agentKey.raw)).toBe(false);
+		expect(isWellFormedKey(nodeKey.raw)).toBe(false);
+	});
+
 	it("hash is deterministic for (pepper, key)", () => {
 		const k = generateKey("live", pepper);
 		expect(hashKey(k.raw, pepper).equals(k.hash)).toBe(true);
@@ -34,6 +60,8 @@ describe("auth/keys", () => {
 		expect(isWellFormedKey("garbage")).toBe(false);
 		expect(isWellFormedKey("ah_prod_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).toBe(false);
 		expect(isWellFormedKey("ah_live_AAAA")).toBe(false); // wrong length + uppercase
+		expect(isWellFormedNodeKey("ar_node_prod_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).toBe(false);
+		expect(isWellFormedNodeKey("ar_node_live_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")).toBe(false);
 	});
 
 	it("constantTimeEqual handles equal/unequal/different-length", () => {

--- a/relay/src/auth/keys.ts
+++ b/relay/src/auth/keys.ts
@@ -33,18 +33,35 @@ function base32(bytes: Buffer): string {
 }
 
 const KEY_REGEX = /^ah_(live|test)_[a-z2-7]{32}$/;
+const NODE_KEY_REGEX = /^ar_node_(live|test)_[a-z2-7]{32}$/;
 
 export function isWellFormedKey(key: string): boolean {
 	return KEY_REGEX.test(key);
 }
 
-export function generateKey(env: KeyEnvironment, pepper: string): GeneratedKey {
-	const raw = `ah_${env}_${base32(randomBytes(KEY_BYTES))}`;
+export function isWellFormedNodeKey(key: string): boolean {
+	return NODE_KEY_REGEX.test(key);
+}
+
+function generatePrefixedKey(
+	prefix: "ah" | "ar_node",
+	env: KeyEnvironment,
+	pepper: string,
+): GeneratedKey {
+	const raw = `${prefix}_${env}_${base32(randomBytes(KEY_BYTES))}`;
 	return {
 		raw,
 		hash: hashKey(raw, pepper),
 		salt: randomBytes(16),
 	};
+}
+
+export function generateKey(env: KeyEnvironment, pepper: string): GeneratedKey {
+	return generatePrefixedKey("ah", env, pepper);
+}
+
+export function generateNodeKey(env: KeyEnvironment, pepper: string): GeneratedKey {
+	return generatePrefixedKey("ar_node", env, pepper);
 }
 
 export function hashKey(rawKey: string, pepper: string): Buffer {

--- a/relay/src/auth/middleware.ts
+++ b/relay/src/auth/middleware.ts
@@ -1,10 +1,10 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import type { MiddlewareHandler } from "hono";
 import type { Database } from "../db/client.js";
-import { agents, apiKeys } from "../db/schema.js";
+import { agents, apiKeys, nodeCredentials, nodes } from "../db/schema.js";
 import { RelayError } from "../errors.js";
 import type { AppEnv } from "../types.js";
-import { hashKey, isWellFormedKey } from "./keys.js";
+import { hashKey, isWellFormedKey, isWellFormedNodeKey } from "./keys.js";
 
 export interface AuthenticatedAgent {
 	id: string;
@@ -15,7 +15,16 @@ export interface AuthenticatedAgent {
 	apiKeyId: string;
 }
 
+export interface AuthenticatedNode {
+	id: string;
+	agentId: string;
+	name: string;
+	status: string;
+	credentialId: string;
+}
+
 const lastUsedDebounce = new Map<string, number>();
+const nodeLastUsedDebounce = new Map<string, number>();
 const LAST_USED_DEBOUNCE_MS = 60_000;
 
 function shouldUpdateLastUsed(keyId: string): boolean {
@@ -28,6 +37,18 @@ function shouldUpdateLastUsed(keyId: string): boolean {
 
 export function clearLastUsedDebounce(): void {
 	lastUsedDebounce.clear();
+}
+
+function shouldUpdateNodeLastUsed(credentialId: string): boolean {
+	const now = Date.now();
+	const prev = nodeLastUsedDebounce.get(credentialId);
+	if (prev && now - prev < LAST_USED_DEBOUNCE_MS) return false;
+	nodeLastUsedDebounce.set(credentialId, now);
+	return true;
+}
+
+export function clearNodeLastUsedDebounce(): void {
+	nodeLastUsedDebounce.clear();
 }
 
 export interface BearerAuthOptions {
@@ -90,6 +111,70 @@ export function bearerAuth(opts: BearerAuthOptions): MiddlewareHandler<AppEnv> {
 				.catch((err: unknown) => {
 					c.get("logger")?.warn({ err, keyId: row.keyId }, "last_used_at update failed");
 				});
+		}
+
+		await next();
+	};
+}
+
+/** Resolves a Node-scoped bearer credential without accepting agent API keys. */
+export function nodeBearerAuth(opts: BearerAuthOptions): MiddlewareHandler<AppEnv> {
+	const { db, pepper } = opts;
+	return async (c, next) => {
+		const raw = extractBearer(c.req.header("authorization"));
+		if (!raw || !isWellFormedNodeKey(raw)) {
+			throw new RelayError("unauthenticated", "Missing or malformed Node bearer token");
+		}
+
+		const hash = hashKey(raw, pepper);
+		const rows = await db
+			.select({
+				credentialId: nodeCredentials.id,
+				nodeId: nodes.id,
+				agentId: nodes.agentId,
+				name: nodes.name,
+				status: nodes.status,
+			})
+			.from(nodeCredentials)
+			.innerJoin(nodes, eq(nodes.id, nodeCredentials.nodeId))
+			.innerJoin(agents, eq(agents.id, nodes.agentId))
+			.where(
+				and(
+					eq(nodeCredentials.keyHash, hash),
+					isNull(nodeCredentials.revokedAt),
+					eq(nodes.status, "active"),
+					eq(agents.status, "active"),
+				),
+			)
+			.limit(1);
+		const row = rows[0];
+		if (!row) throw new RelayError("unauthenticated", "Invalid or revoked Node credential");
+
+		const node: AuthenticatedNode = {
+			id: row.nodeId,
+			agentId: row.agentId,
+			name: row.name,
+			status: row.status,
+			credentialId: row.credentialId,
+		};
+		c.set("node", node);
+
+		if (shouldUpdateNodeLastUsed(row.credentialId)) {
+			Promise.all([
+				db
+					.update(nodeCredentials)
+					.set({ lastUsedAt: sql`now()` })
+					.where(and(eq(nodeCredentials.id, row.credentialId), isNull(nodeCredentials.revokedAt))),
+				db
+					.update(nodes)
+					.set({ lastSeenAt: sql`now()`, updatedAt: sql`now()` })
+					.where(and(eq(nodes.id, row.nodeId), eq(nodes.status, "active"))),
+			]).catch((err: unknown) => {
+				c.get("logger")?.warn(
+					{ err, nodeId: row.nodeId, credentialId: row.credentialId },
+					"Node presence update failed",
+				);
+			});
 		}
 
 		await next();

--- a/relay/src/db/migration-0006.test.ts
+++ b/relay/src/db/migration-0006.test.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import postgres, { type Sql } from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { tryConnect } from "./test-utils.js";
+
+const TEST_URL = process.env.RELAY_TEST_DATABASE_URL ?? process.env.RELAY_DATABASE_URL;
+const conn = await tryConnect();
+const d = conn.available && TEST_URL ? describe : describe.skip;
+
+if (!conn.available || !TEST_URL) {
+	console.warn(`[migration-0006.test] skipping: ${conn.reason ?? "database URL unset"}`);
+}
+
+d("0006 Node credentials migration", () => {
+	let sql: Sql;
+	let migration: string;
+	const schemaName = `migration_0006_${randomUUID().replaceAll("-", "")}`;
+
+	beforeAll(async () => {
+		sql = postgres(TEST_URL as string, { max: 1, onnotice: () => undefined });
+		await sql.unsafe(`CREATE SCHEMA "${schemaName}"`);
+		await sql.unsafe(`SET search_path TO "${schemaName}", public`);
+		await sql.unsafe(
+			"CREATE TABLE nodes (id uuid PRIMARY KEY, updated_at timestamp with time zone DEFAULT now() NOT NULL)",
+		);
+		await sql.unsafe(`
+			CREATE FUNCTION set_updated_at() RETURNS TRIGGER AS $$
+			BEGIN
+				NEW.updated_at = now();
+				RETURN NEW;
+			END;
+			$$ LANGUAGE plpgsql
+		`);
+		await sql.unsafe(`
+			CREATE TRIGGER nodes_set_updated_at
+			BEFORE UPDATE ON nodes FOR EACH ROW EXECUTE FUNCTION set_updated_at()
+		`);
+		migration = await readFile(
+			new URL("../../drizzle/0006_node_credentials.sql", import.meta.url),
+			"utf8",
+		);
+		await applyMigration(sql, migration);
+	});
+
+	afterAll(async () => {
+		if (sql) {
+			await sql.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+			await sql.end({ timeout: 2 });
+		}
+		if (conn.handle) await conn.handle.close();
+	});
+
+	it("replays safely and preserves issued credentials", async () => {
+		const nodeId = randomUUID();
+		const credentialId = randomUUID();
+		const keyHash = Buffer.from("a".repeat(32));
+		const salt = Buffer.from("s".repeat(16));
+		await sql`INSERT INTO nodes (id) VALUES (${nodeId})`;
+		await sql`
+			INSERT INTO node_credentials (id, node_id, key_hash, salt, label)
+			VALUES (${credentialId}, ${nodeId}, ${keyHash}, ${salt}, ${"enrollment"})
+		`;
+
+		await applyMigration(sql, migration);
+
+		const [stored] = await sql<
+			Array<{ id: string; node_id: string; label: string; revoked_at: Date | null }>
+		>`
+			SELECT id, node_id, label, revoked_at
+			FROM node_credentials
+			WHERE id = ${credentialId}
+		`;
+		expect(stored).toEqual({
+			id: credentialId,
+			node_id: nodeId,
+			label: "enrollment",
+			revoked_at: null,
+		});
+	});
+
+	it("enforces Node ownership and active-hash uniqueness without storing raw tokens", async () => {
+		const firstNodeId = randomUUID();
+		const secondNodeId = randomUUID();
+		const keyHash = Buffer.from("b".repeat(32));
+		const salt = Buffer.from("t".repeat(16));
+		await sql`INSERT INTO nodes (id) VALUES (${firstNodeId}), (${secondNodeId})`;
+		await sql`
+			INSERT INTO node_credentials (node_id, key_hash, salt)
+			VALUES (${firstNodeId}, ${keyHash}, ${salt})
+		`;
+		await expect(sql`
+			INSERT INTO node_credentials (node_id, key_hash, salt)
+			VALUES (${firstNodeId}, ${Buffer.from("c".repeat(32))}, ${salt})
+		`).rejects.toThrow(/idx_node_credentials_active_node/);
+
+		await expect(sql`
+			INSERT INTO node_credentials (node_id, key_hash, salt)
+			VALUES (${secondNodeId}, ${keyHash}, ${salt})
+		`).rejects.toThrow(/idx_node_credentials_active_hash/);
+
+		await sql`
+			UPDATE node_credentials
+			SET revoked_at = now()
+			WHERE node_id = ${firstNodeId}
+		`;
+		await expect(sql`
+			INSERT INTO node_credentials (node_id, key_hash, salt)
+			VALUES (${secondNodeId}, ${keyHash}, ${salt})
+		`).resolves.toBeDefined();
+
+		await expect(sql`
+			INSERT INTO node_credentials (node_id, key_hash, salt)
+			VALUES (${randomUUID()}, ${Buffer.from("d".repeat(32))}, ${salt})
+		`).rejects.toThrow(/node_credentials_node_id_fkey/);
+
+		const secretColumns = await sql<Array<{ column_name: string }>>`
+			SELECT column_name
+			FROM information_schema.columns
+			WHERE table_schema = ${schemaName}
+				AND table_name = 'node_credentials'
+				AND column_name IN ('key', 'token', 'raw_key', 'raw_token')
+		`;
+		expect(secretColumns).toEqual([]);
+	});
+
+	it("replaces transaction-start update timestamps with wall-clock trigger time", async () => {
+		const nodeId = randomUUID();
+		await sql`INSERT INTO nodes (id) VALUES (${nodeId})`;
+
+		const timestamps = await sql.begin(async (tx) => {
+			const [started] = await tx<Array<{ transaction_started_at: Date }>>`
+				SELECT now() AS transaction_started_at
+			`;
+			await tx`SELECT pg_sleep(0.02)`;
+			const [updated] = await tx<Array<{ updated_at: Date }>>`
+				UPDATE nodes
+				SET id = id
+				WHERE id = ${nodeId}
+				RETURNING updated_at
+			`;
+			return { startedAt: started?.transaction_started_at, updatedAt: updated?.updated_at };
+		});
+
+		if (!timestamps.startedAt || !timestamps.updatedAt) {
+			throw new Error("expected transaction and trigger timestamps");
+		}
+		expect(timestamps.updatedAt.getTime()).toBeGreaterThan(timestamps.startedAt.getTime());
+	});
+});
+
+async function applyMigration(sql: Sql, migration: string): Promise<void> {
+	await sql.begin(async (tx) => {
+		for (const statement of migration.split("--> statement-breakpoint")) {
+			if (statement.trim()) await tx.unsafe(statement);
+		}
+	});
+}

--- a/relay/src/db/schema.ts
+++ b/relay/src/db/schema.ts
@@ -19,7 +19,7 @@ import {
 // citext for case-insensitive email uniqueness (extension enabled in 0001 migration).
 const citext = customType<{ data: string }>({ dataType: () => "citext" });
 
-// bytea for hashed API keys + per-row salts.
+// bytea for hashed credentials + per-row salts.
 const bytea = customType<{ data: Buffer; driverData: Buffer }>({ dataType: () => "bytea" });
 
 // text[] arrays for repos_owned / skills (GIN-indexed below).
@@ -264,6 +264,30 @@ export const nodes = pgTable(
 			"nodes_revoked_at_chk",
 			sql`(${t.status} = 'revoked') = (${t.revokedAt} IS NOT NULL)`,
 		),
+	}),
+);
+
+export const nodeCredentials = pgTable(
+	"node_credentials",
+	{
+		id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+		nodeId: uuid("node_id")
+			.notNull()
+			.references(() => nodes.id, { onDelete: "restrict" }),
+		keyHash: bytea("key_hash").notNull(),
+		salt: bytea("salt").notNull(),
+		label: text("label"),
+		lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+		revokedAt: timestamp("revoked_at", { withTimezone: true }),
+		createdAt,
+	},
+	(t) => ({
+		activeNodeIdx: uniqueIndex("idx_node_credentials_active_node")
+			.on(t.nodeId)
+			.where(sql`${t.revokedAt} IS NULL`),
+		activeHashIdx: uniqueIndex("idx_node_credentials_active_hash")
+			.on(t.keyHash)
+			.where(sql`${t.revokedAt} IS NULL`),
 	}),
 );
 
@@ -540,6 +564,7 @@ export type Handoff = typeof handoffs.$inferSelect;
 export type Message = typeof messages.$inferSelect;
 export type AuditLogRow = typeof auditLog.$inferSelect;
 export type Node = typeof nodes.$inferSelect;
+export type NodeCredential = typeof nodeCredentials.$inferSelect;
 export type WorkspaceBinding = typeof workspaceBindings.$inferSelect;
 export type Mission = typeof missions.$inferSelect;
 export type MissionParticipant = typeof missionParticipants.$inferSelect;

--- a/relay/src/db/test-utils.ts
+++ b/relay/src/db/test-utils.ts
@@ -48,6 +48,6 @@ export async function truncateAll(sql: Sql): Promise<void> {
 	// with CASCADE would clear the dependents — but explicit listing makes intent
 	// obvious and survives future schema additions that aren't FK-rooted at agents.
 	await sql.unsafe(
-		"TRUNCATE TABLE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, nodes, messages, handoffs, agent_cards, api_keys, audit_log, agent_blocks, invites, agents RESTART IDENTITY CASCADE",
+		"TRUNCATE TABLE node_deliveries, mission_events, mission_participants, missions, workspace_bindings, node_credentials, nodes, messages, handoffs, agent_cards, api_keys, audit_log, agent_blocks, invites, agents RESTART IDENTITY CASCADE",
 	);
 }

--- a/relay/src/errors.test.ts
+++ b/relay/src/errors.test.ts
@@ -19,6 +19,11 @@ describe("RelayError", () => {
 		});
 	});
 
+	it("maps missing Node resources to precise 404 errors", () => {
+		expect(new RelayError("node_not_found", "missing").httpStatus).toBe(404);
+		expect(new RelayError("workspace_not_found", "missing").httpStatus).toBe(404);
+	});
+
 	it("error map covers all known symbols with consistent shapes", () => {
 		for (const [symbol, mapping] of Object.entries(ERROR_MAP)) {
 			expect(typeof mapping.rpc).toBe("number");

--- a/relay/src/errors.ts
+++ b/relay/src/errors.ts
@@ -18,6 +18,8 @@ export type ErrorSymbol =
 	| "duplicate_idempotency_key"
 	| "invalid_intent_payload"
 	| "teammate_blocked"
+	| "node_not_found"
+	| "workspace_not_found"
 	| "internal";
 
 interface ErrorMapping {
@@ -43,6 +45,8 @@ export const ERROR_MAP: Record<ErrorSymbol, ErrorMapping> = {
 	duplicate_idempotency_key: { rpc: -32011, http: 409 },
 	invalid_intent_payload: { rpc: -32012, http: 400 },
 	teammate_blocked: { rpc: -32013, http: 403 },
+	node_not_found: { rpc: -32014, http: 404 },
+	workspace_not_found: { rpc: -32015, http: 404 },
 	internal: { rpc: -32099, http: 500 },
 };
 

--- a/relay/src/routes/agents.ts
+++ b/relay/src/routes/agents.ts
@@ -11,6 +11,7 @@ import { isSlackWebhookUrl } from "../notifications/slack.js";
 import { lockAgentBlockPair } from "../services/agent-block-lock.js";
 import { writeAudit } from "../services/audit.js";
 import type { AppEnv } from "../types.js";
+import { registerNodeOwnerRoutes } from "./node-owner.js";
 
 const updateCardSchema = z
 	.object({
@@ -37,6 +38,7 @@ export interface AgentsRoutesOptions {
 export function createAgentsRoutes(opts: AgentsRoutesOptions): Hono<AppEnv> {
 	const router = new Hono<AppEnv>();
 	router.use("*", bearerAuth({ db: opts.db, pepper: opts.pepper }));
+	registerNodeOwnerRoutes(router, opts);
 
 	// GET /agents/me — whoami (lld §5.4 / R7)
 	router.get("/me", async (c) => {

--- a/relay/src/routes/node-owner.ts
+++ b/relay/src/routes/node-owner.ts
@@ -1,0 +1,94 @@
+import {
+	nodeCredentialRotationInputSchema,
+	nodeEnrollmentInputSchema,
+	uuidSchema,
+} from "@agentrelay/protocol";
+import type { Hono } from "hono";
+import type { AuthenticatedAgent } from "../auth/middleware.js";
+import type { Database } from "../db/client.js";
+import { RelayError } from "../errors.js";
+import {
+	enrollNode,
+	listNodes,
+	revokeNode,
+	rotateNodeCredential,
+} from "../services/node-enrollment.js";
+import type { AppEnv } from "../types.js";
+
+export interface NodeOwnerRoutesOptions {
+	db: Database;
+	pepper: string;
+	keyEnvironment: "live" | "test";
+}
+
+export function registerNodeOwnerRoutes(router: Hono<AppEnv>, opts: NodeOwnerRoutesOptions): void {
+	router.post("/me/nodes", async (c) => {
+		const agent = requireAgent(c.get("agent"));
+		const body = await c.req.json().catch(() => null);
+		const parsed = nodeEnrollmentInputSchema.safeParse(body);
+		if (!parsed.success) {
+			throw new RelayError("invalid_params", "Invalid Node enrollment payload", {
+				issues: parsed.error.issues,
+			});
+		}
+
+		const result = await enrollNode(
+			opts.db,
+			agent.id,
+			parsed.data,
+			opts.keyEnvironment,
+			opts.pepper,
+			{ requestId: c.get("requestId") },
+		);
+		return c.json(result, 201);
+	});
+
+	router.get("/me/nodes", async (c) => {
+		const agent = requireAgent(c.get("agent"));
+		return c.json({ nodes: await listNodes(opts.db, agent.id) });
+	});
+
+	router.post("/me/nodes/:nodeId/credentials/rotate", async (c) => {
+		const agent = requireAgent(c.get("agent"));
+		const nodeId = parseNodeId(c.req.param("nodeId"));
+		const body = await c.req.json().catch(() => null);
+		const parsed = nodeCredentialRotationInputSchema.safeParse(body);
+		if (!parsed.success) {
+			throw new RelayError("invalid_params", "Invalid Node credential rotation payload", {
+				issues: parsed.error.issues,
+			});
+		}
+		const credential = await rotateNodeCredential(
+			opts.db,
+			agent.id,
+			nodeId,
+			parsed.data,
+			opts.keyEnvironment,
+			opts.pepper,
+			{ requestId: c.get("requestId") },
+		);
+		return c.json({ node_id: nodeId, credential });
+	});
+
+	router.delete("/me/nodes/:nodeId", async (c) => {
+		const agent = requireAgent(c.get("agent"));
+		const nodeId = parseNodeId(c.req.param("nodeId"));
+		await revokeNode(opts.db, agent.id, nodeId, { requestId: c.get("requestId") });
+		return c.body(null, 204);
+	});
+}
+
+function requireAgent(agent: AuthenticatedAgent | undefined): AuthenticatedAgent {
+	if (!agent) throw new RelayError("unauthenticated", "Auth required");
+	return agent;
+}
+
+function parseNodeId(value: string): string {
+	const parsed = uuidSchema.safeParse(value);
+	if (!parsed.success) {
+		throw new RelayError("invalid_params", "Invalid Node ID", {
+			issues: parsed.error.issues,
+		});
+	}
+	return parsed.data;
+}

--- a/relay/src/routes/node.ts
+++ b/relay/src/routes/node.ts
@@ -1,0 +1,96 @@
+import { workspaceRegistrationInputSchema } from "@agentrelay/protocol";
+import { Hono } from "hono";
+import { z } from "zod";
+import { type AuthenticatedNode, nodeBearerAuth } from "../auth/middleware.js";
+import type { Database } from "../db/client.js";
+import { RelayError } from "../errors.js";
+import {
+	getNode,
+	listWorkspaces,
+	registerWorkspace,
+	revokeWorkspace,
+} from "../services/node-enrollment.js";
+import type { AppEnv } from "../types.js";
+
+const workspaceAliasParamSchema = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/)
+	.refine((value) => value !== "." && value !== "..", "Alias cannot be a path segment");
+
+export interface NodeRoutesOptions {
+	db: Database;
+	pepper: string;
+}
+
+export function createNodeRoutes(opts: NodeRoutesOptions): Hono<AppEnv> {
+	const router = new Hono<AppEnv>();
+	router.use("*", nodeBearerAuth({ db: opts.db, pepper: opts.pepper }));
+
+	router.get("/me", async (c) => {
+		const node = requireNode(c.get("node"));
+		return c.json({ node: await getNode(opts.db, node.id, node.agentId) });
+	});
+
+	router.post("/workspaces", async (c) => {
+		const node = requireNode(c.get("node"));
+		const body = await c.req.json().catch(() => null);
+		const parsed = workspaceRegistrationInputSchema.safeParse(body);
+		if (!parsed.success) {
+			throw new RelayError("invalid_params", "Invalid workspace registration payload", {
+				issues: parsed.error.issues,
+			});
+		}
+
+		const result = await registerWorkspace(
+			opts.db,
+			{
+				nodeId: node.id,
+				agentId: node.agentId,
+				credentialId: node.credentialId,
+				requestId: c.get("requestId"),
+			},
+			parsed.data,
+		);
+		return c.json(result, result.replayed ? 200 : 201);
+	});
+
+	router.get("/workspaces", async (c) => {
+		const node = requireNode(c.get("node"));
+		return c.json({ workspaces: await listWorkspaces(opts.db, node.id, node.agentId) });
+	});
+
+	router.delete("/workspaces/:alias", async (c) => {
+		const node = requireNode(c.get("node"));
+		const alias = parseWorkspaceAlias(c.req.param("alias"));
+		await revokeWorkspace(
+			opts.db,
+			{
+				nodeId: node.id,
+				agentId: node.agentId,
+				credentialId: node.credentialId,
+				requestId: c.get("requestId"),
+			},
+			alias,
+		);
+		return c.body(null, 204);
+	});
+
+	return router;
+}
+
+function requireNode(node: AuthenticatedNode | undefined): AuthenticatedNode {
+	if (!node) throw new RelayError("unauthenticated", "Node auth required");
+	return node;
+}
+
+function parseWorkspaceAlias(value: string): string {
+	const parsed = workspaceAliasParamSchema.safeParse(value);
+	if (!parsed.success) {
+		throw new RelayError("invalid_params", "Invalid workspace alias", {
+			issues: parsed.error.issues,
+		});
+	}
+	return parsed.data;
+}

--- a/relay/src/routes/nodes.test.ts
+++ b/relay/src/routes/nodes.test.ts
@@ -1,0 +1,900 @@
+import {
+	type NodeDescriptor,
+	type OwnedNodeSummary,
+	type WorkspaceBindingDescriptor,
+	nodeDescriptorSchema,
+	ownedNodeSummarySchema,
+	workspaceBindingDescriptorSchema,
+} from "@agentrelay/protocol";
+import { and, asc, eq, isNull } from "drizzle-orm";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { hashKey } from "../auth/keys.js";
+import { clearLastUsedDebounce, clearNodeLastUsedDebounce } from "../auth/middleware.js";
+import { loadConfig } from "../config.js";
+import { agents, auditLog, nodeCredentials, nodes, workspaceBindings } from "../db/schema.js";
+import { type TestDb, truncateAll, tryConnect } from "../db/test-utils.js";
+import { createLogger } from "../logger.js";
+import { createServer } from "../server.js";
+
+const conn = await tryConnect();
+const d = conn.available ? describe : describe.skip;
+const TEST_DATABASE_URL = process.env.RELAY_TEST_DATABASE_URL ?? process.env.RELAY_DATABASE_URL;
+
+if (!conn.available) {
+	console.warn(`[nodes.test] skipping: ${conn.reason}`);
+}
+
+const TEST_ENV = {
+	RELAY_DATABASE_URL: process.env.RELAY_TEST_DATABASE_URL ?? "postgres://x:y@localhost/x",
+	RELAY_PEPPER: "p".repeat(32),
+	RELAY_ENCRYPTION_KEY: "e".repeat(16),
+	RELAY_INVITE_SECRET: "i".repeat(32),
+	RELAY_ADMIN_TOKEN: "admin-token-secret",
+	RELAY_METRICS_TOKEN: "metrics-token",
+	RELAY_PUBLIC_URL: "http://localhost:8080",
+	RELAY_ENV: "dev" as const,
+	RELAY_LOG_LEVEL: "fatal" as const,
+};
+
+interface AgentIdentity {
+	id: string;
+	key: string;
+}
+
+interface IssuedCredential {
+	id: string;
+	token: string;
+}
+
+interface EnrollmentResponse {
+	node: NodeDescriptor;
+	credential: IssuedCredential;
+}
+
+interface WorkspaceResponse {
+	workspace: WorkspaceBindingDescriptor;
+	replayed: boolean;
+}
+
+interface ErrorResponse {
+	code: string;
+	message: string;
+	details?: Record<string, unknown>;
+}
+
+d("Node enrollment and workspace registration", () => {
+	let handle: TestDb;
+	let app: ReturnType<typeof createServer>;
+
+	beforeAll(() => {
+		if (!conn.handle) throw new Error("expected db handle");
+		handle = conn.handle;
+		const config = loadConfig({ ...TEST_ENV } as NodeJS.ProcessEnv);
+		app = createServer({ config, logger: createLogger(config), db: handle.db });
+	});
+
+	beforeEach(async () => {
+		await truncateAll(handle.sql);
+		clearLastUsedDebounce();
+		clearNodeLastUsedDebounce();
+	});
+
+	afterAll(async () => {
+		if (handle) await handle.close();
+	});
+
+	function adminHeaders(): Record<string, string> {
+		return {
+			authorization: `Bearer ${TEST_ENV.RELAY_ADMIN_TOKEN}`,
+			"content-type": "application/json",
+		};
+	}
+
+	function bearer(token: string, requestId?: string): Record<string, string> {
+		return {
+			authorization: `Bearer ${token}`,
+			"content-type": "application/json",
+			...(requestId ? { "x-request-id": requestId } : {}),
+		};
+	}
+
+	async function createAgent(localPart: string): Promise<AgentIdentity> {
+		const response = await app.request("/admin/agents", {
+			method: "POST",
+			headers: adminHeaders(),
+			body: JSON.stringify({
+				handle: `${localPart}@acme`,
+				email: `${localPart}@acme.test`,
+				display_name: localPart,
+				role: "engineer",
+			}),
+		});
+		expect(response.status).toBe(201);
+		const body = (await response.json()) as { agent_id: string; api_key: string };
+		return { id: body.agent_id, key: body.api_key };
+	}
+
+	async function enrollNode(
+		agentKey: string,
+		name = "backend-mac",
+		capabilities = ["runtime.codex", "runtime.fake"],
+		requestId?: string,
+	): Promise<EnrollmentResponse> {
+		const response = await app.request("/agents/me/nodes", {
+			method: "POST",
+			headers: bearer(agentKey, requestId),
+			body: JSON.stringify({ name, capabilities }),
+		});
+		expect(response.status).toBe(201);
+		return (await response.json()) as EnrollmentResponse;
+	}
+
+	async function registerWorkspace(
+		nodeToken: string,
+		input: {
+			alias: string;
+			repository_url: string;
+			allowed_base_refs: string[];
+		},
+		requestId?: string,
+	): Promise<{ response: Response; body: WorkspaceResponse }> {
+		const response = await app.request("/node/v1/workspaces", {
+			method: "POST",
+			headers: bearer(nodeToken, requestId),
+			body: JSON.stringify(input),
+		});
+		const body = (await response.json()) as WorkspaceResponse;
+		return { response, body };
+	}
+
+	async function expectError(
+		response: Response,
+		status: number,
+		code: string,
+	): Promise<ErrorResponse> {
+		expect(response.status).toBe(status);
+		const body = (await response.json()) as ErrorResponse;
+		expect(body.code).toBe(code);
+		expect(body.message.length).toBeGreaterThan(0);
+		return body;
+	}
+
+	it("issues a one-time Node credential, stores only its hash, and returns protocol descriptors", async () => {
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(owner.key, "backend-mac", ["runtime.fake", "runtime.codex"]);
+
+		expect(enrolled.credential.token).toMatch(/^ar_node_test_[a-z2-7]{32}$/);
+		expect(enrolled.credential.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(nodeDescriptorSchema.parse(enrolled.node)).toEqual(enrolled.node);
+		expect(enrolled.node).toMatchObject({
+			agent_id: owner.id,
+			name: "backend-mac",
+			status: "active",
+			capabilities: ["runtime.codex", "runtime.fake"],
+			last_seen_at: null,
+			revoked_at: null,
+		});
+
+		const [stored] = await handle.db
+			.select({
+				id: nodeCredentials.id,
+				nodeId: nodeCredentials.nodeId,
+				keyHash: nodeCredentials.keyHash,
+				salt: nodeCredentials.salt,
+				label: nodeCredentials.label,
+			})
+			.from(nodeCredentials)
+			.where(eq(nodeCredentials.id, enrolled.credential.id));
+		expect(stored).toBeDefined();
+		expect(stored?.nodeId).toBe(enrolled.node.node_id);
+		expect(stored?.label).toBe("enrollment");
+		expect(
+			Buffer.from(stored?.keyHash ?? []).equals(
+				hashKey(enrolled.credential.token, TEST_ENV.RELAY_PEPPER),
+			),
+		).toBe(true);
+		expect(Buffer.from(stored?.salt ?? [])).toHaveLength(16);
+		expect(JSON.stringify(stored)).not.toContain(enrolled.credential.token);
+
+		const ownerListResponse = await app.request("/agents/me/nodes", {
+			headers: bearer(owner.key),
+		});
+		expect(ownerListResponse.status).toBe(200);
+		const ownerList = (await ownerListResponse.json()) as { nodes: OwnedNodeSummary[] };
+		expect(ownerList.nodes).toHaveLength(1);
+		expect(ownedNodeSummarySchema.parse(ownerList.nodes[0])).toEqual(ownerList.nodes[0]);
+		expect(ownerList.nodes[0]?.node).toEqual(enrolled.node);
+		expect(ownerList.nodes[0]?.active_credential_id).toBe(enrolled.credential.id);
+		expect(JSON.stringify(ownerList)).not.toContain(enrolled.credential.token);
+		expect(JSON.stringify(ownerList)).not.toContain("key_hash");
+		expect(JSON.stringify(ownerList)).not.toContain("salt");
+
+		const nodeMeResponse = await app.request("/node/v1/me", {
+			headers: bearer(enrolled.credential.token),
+		});
+		expect(nodeMeResponse.status).toBe(200);
+		const nodeMe = (await nodeMeResponse.json()) as { node: NodeDescriptor };
+		expect(nodeDescriptorSchema.parse(nodeMe.node)).toEqual(nodeMe.node);
+		expect(nodeMe.node.node_id).toBe(enrolled.node.node_id);
+		expect(JSON.stringify(nodeMe)).not.toContain(enrolled.credential.token);
+	});
+
+	it("strictly rejects local authority and invalid or duplicate Node capabilities", async () => {
+		const owner = await createAgent("alice");
+		const invalidPayloads = [
+			{
+				name: "backend-mac",
+				capabilities: ["runtime.fake"],
+				local_path: "/Users/alice/backend",
+			},
+			{ name: "backend-mac", capabilities: ["runtime.fake", "runtime.fake"] },
+			{ name: "backend-mac", capabilities: ["../execute"] },
+			{ name: "..", capabilities: ["runtime.fake"] },
+		];
+
+		for (const payload of invalidPayloads) {
+			const response = await app.request("/agents/me/nodes", {
+				method: "POST",
+				headers: bearer(owner.key),
+				body: JSON.stringify(payload),
+			});
+			await expectError(response, 400, "invalid_params");
+		}
+
+		const storedNodes = await handle.db.select({ id: nodes.id }).from(nodes);
+		expect(storedNodes).toEqual([]);
+	});
+
+	it("keeps agent and Node bearer types separate and isolates Node ownership", async () => {
+		const alice = await createAgent("alice");
+		const bob = await createAgent("bob");
+		const aliceNode = await enrollNode(alice.key, "shared-name");
+		const bobNode = await enrollNode(bob.key, "shared-name");
+
+		await expectError(
+			await app.request("/agents/me", { headers: bearer(aliceNode.credential.token) }),
+			401,
+			"unauthenticated",
+		);
+		await expectError(
+			await app.request("/node/v1/me", { headers: bearer(alice.key) }),
+			401,
+			"unauthenticated",
+		);
+
+		const aliceList = (await (
+			await app.request("/agents/me/nodes", { headers: bearer(alice.key) })
+		).json()) as { nodes: OwnedNodeSummary[] };
+		const bobList = (await (
+			await app.request("/agents/me/nodes", { headers: bearer(bob.key) })
+		).json()) as { nodes: OwnedNodeSummary[] };
+		expect(aliceList.nodes.map((summary) => summary.node.node_id)).toEqual([
+			aliceNode.node.node_id,
+		]);
+		expect(bobList.nodes.map((summary) => summary.node.node_id)).toEqual([bobNode.node.node_id]);
+
+		await expectError(
+			await app.request(`/agents/me/nodes/${aliceNode.node.node_id}/credentials/rotate`, {
+				method: "POST",
+				headers: bearer(bob.key),
+				body: JSON.stringify({ expected_credential_id: aliceNode.credential.id }),
+			}),
+			404,
+			"node_not_found",
+		);
+		await expectError(
+			await app.request(`/agents/me/nodes/${aliceNode.node.node_id}`, {
+				method: "DELETE",
+				headers: bearer(bob.key),
+			}),
+			404,
+			"node_not_found",
+		);
+
+		const stillAuthorized = await app.request("/node/v1/me", {
+			headers: bearer(aliceNode.credential.token),
+		});
+		expect(stillAuthorized.status).toBe(200);
+	});
+
+	it("rejects an active duplicate Node name without changing the original", async () => {
+		const owner = await createAgent("alice");
+		const original = await enrollNode(owner.key, "backend-mac");
+
+		const duplicateResponse = await app.request("/agents/me/nodes", {
+			method: "POST",
+			headers: bearer(owner.key),
+			body: JSON.stringify({
+				name: "backend-mac",
+				capabilities: ["runtime.other"],
+			}),
+		});
+		const error = await expectError(duplicateResponse, 409, "state_changed");
+		expect(error.details).toMatchObject({ node_id: original.node.node_id });
+
+		const ownerList = (await (
+			await app.request("/agents/me/nodes", { headers: bearer(owner.key) })
+		).json()) as { nodes: OwnedNodeSummary[] };
+		expect(ownerList.nodes).toHaveLength(1);
+		expect(ownerList.nodes[0]?.node.capabilities).toEqual(["runtime.codex", "runtime.fake"]);
+		const credentials = await handle.db.select().from(nodeCredentials);
+		expect(credentials).toHaveLength(1);
+	});
+
+	it("rotates a Node credential atomically and immediately invalidates the old token", async () => {
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(owner.key);
+		await expectError(
+			await app.request(`/agents/me/nodes/${enrolled.node.node_id}/credentials/rotate`, {
+				method: "POST",
+				headers: bearer(owner.key),
+			}),
+			400,
+			"invalid_params",
+		);
+
+		const rotateResponse = await app.request(
+			`/agents/me/nodes/${enrolled.node.node_id}/credentials/rotate`,
+			{
+				method: "POST",
+				headers: bearer(owner.key, "req_node_rotate"),
+				body: JSON.stringify({ expected_credential_id: enrolled.credential.id }),
+			},
+		);
+		expect(rotateResponse.status).toBe(200);
+		const rotated = (await rotateResponse.json()) as {
+			node_id: string;
+			credential: IssuedCredential;
+		};
+		expect(rotated.node_id).toBe(enrolled.node.node_id);
+		expect(rotated.credential.token).toMatch(/^ar_node_test_[a-z2-7]{32}$/);
+		expect(rotated.credential.token).not.toBe(enrolled.credential.token);
+
+		await expectError(
+			await app.request("/node/v1/me", { headers: bearer(enrolled.credential.token) }),
+			401,
+			"unauthenticated",
+		);
+		const freshResponse = await app.request("/node/v1/me", {
+			headers: bearer(rotated.credential.token),
+		});
+		expect(freshResponse.status).toBe(200);
+		const staleRotation = await app.request(
+			`/agents/me/nodes/${enrolled.node.node_id}/credentials/rotate`,
+			{
+				method: "POST",
+				headers: bearer(owner.key),
+				body: JSON.stringify({ expected_credential_id: enrolled.credential.id }),
+			},
+		);
+		const staleError = await expectError(staleRotation, 409, "state_changed");
+		expect(staleError.details).toMatchObject({
+			active_credential_id: rotated.credential.id,
+		});
+
+		const credentials = await handle.db
+			.select({ id: nodeCredentials.id, revokedAt: nodeCredentials.revokedAt })
+			.from(nodeCredentials)
+			.where(eq(nodeCredentials.nodeId, enrolled.node.node_id))
+			.orderBy(asc(nodeCredentials.createdAt), asc(nodeCredentials.id));
+		expect(credentials).toHaveLength(2);
+		expect(credentials.filter((credential) => credential.revokedAt === null)).toEqual([
+			{ id: rotated.credential.id, revokedAt: null },
+		]);
+		const rotationAudits = await handle.db
+			.select({ id: auditLog.id })
+			.from(auditLog)
+			.where(eq(auditLog.action, "node.credential.rotate"));
+		expect(rotationAudits).toHaveLength(1);
+	});
+
+	it("allows exactly one concurrent credential rotation and supports list-based recovery", async () => {
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(owner.key);
+		const rotationPath = `/agents/me/nodes/${enrolled.node.node_id}/credentials/rotate`;
+		const rotationInit = {
+			method: "POST",
+			headers: bearer(owner.key),
+			body: JSON.stringify({ expected_credential_id: enrolled.credential.id }),
+		};
+
+		const responses = await Promise.all([
+			app.request(rotationPath, rotationInit),
+			app.request(rotationPath, rotationInit),
+		]);
+		expect(responses.map((response) => response.status).sort()).toEqual([200, 409]);
+		const winnerResponse = responses.find((response) => response.status === 200);
+		const staleResponse = responses.find((response) => response.status === 409);
+		if (!winnerResponse || !staleResponse) throw new Error("expected one rotation winner");
+		const winner = (await winnerResponse.json()) as {
+			credential: IssuedCredential;
+		};
+		const staleError = await expectError(staleResponse, 409, "state_changed");
+		expect(staleError.details).toMatchObject({
+			active_credential_id: winner.credential.id,
+		});
+
+		await expectError(
+			await app.request("/node/v1/me", { headers: bearer(enrolled.credential.token) }),
+			401,
+			"unauthenticated",
+		);
+		expect(
+			(await app.request("/node/v1/me", { headers: bearer(winner.credential.token) })).status,
+		).toBe(200);
+
+		const ownerListResponse = await app.request("/agents/me/nodes", {
+			headers: bearer(owner.key),
+		});
+		expect(ownerListResponse.status).toBe(200);
+		const ownerList = (await ownerListResponse.json()) as { nodes: OwnedNodeSummary[] };
+		const current = ownedNodeSummarySchema.parse(ownerList.nodes[0]);
+		expect(current.active_credential_id).toBe(winner.credential.id);
+
+		const recoveryResponse = await app.request(rotationPath, {
+			method: "POST",
+			headers: bearer(owner.key),
+			body: JSON.stringify({ expected_credential_id: current.active_credential_id }),
+		});
+		expect(recoveryResponse.status).toBe(200);
+		const recovered = (await recoveryResponse.json()) as { credential: IssuedCredential };
+		await expectError(
+			await app.request("/node/v1/me", { headers: bearer(winner.credential.token) }),
+			401,
+			"unauthenticated",
+		);
+		expect(
+			(await app.request("/node/v1/me", { headers: bearer(recovered.credential.token) })).status,
+		).toBe(200);
+
+		const activeCredentials = await handle.db
+			.select({ id: nodeCredentials.id })
+			.from(nodeCredentials)
+			.where(
+				and(eq(nodeCredentials.nodeId, enrolled.node.node_id), isNull(nodeCredentials.revokedAt)),
+			);
+		expect(activeCredentials).toEqual([{ id: recovered.credential.id }]);
+		const rotationAudits = await handle.db
+			.select({ id: auditLog.id })
+			.from(auditLog)
+			.where(eq(auditLog.action, "node.credential.rotate"));
+		expect(rotationAudits).toHaveLength(2);
+	});
+
+	it("invalidates Node authentication when the owning agent is disabled", async () => {
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(owner.key);
+
+		const disableResponse = await app.request(`/admin/agents/${owner.id}`, {
+			method: "DELETE",
+			headers: adminHeaders(),
+		});
+		expect(disableResponse.status).toBe(204);
+		await expectError(
+			await app.request("/node/v1/me", { headers: bearer(enrolled.credential.token) }),
+			401,
+			"unauthenticated",
+		);
+
+		const [storedOwner] = await handle.db
+			.select({ status: agents.status })
+			.from(agents)
+			.where(eq(agents.id, owner.id));
+		expect(storedOwner?.status).toBe("disabled");
+	});
+
+	it("rejects local paths, credential-bearing or file URLs, and unsafe or duplicate refs", async () => {
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(owner.key);
+		const base = {
+			alias: "backend-api",
+			repository_url: "https://github.com/acme/backend.git",
+			allowed_base_refs: ["refs/heads/main"],
+		};
+		const invalidPayloads = [
+			{ ...base, local_path: "/Users/alice/backend" },
+			{ ...base, repository_url: "file:///Users/alice/backend" },
+			{ ...base, repository_url: "https://alice:secret@github.com/acme/backend.git" },
+			{ ...base, repository_url: "ssh://alice@github.com/acme/backend.git" },
+			{ ...base, allowed_base_refs: ["../outside"] },
+			{ ...base, allowed_base_refs: ["refs/heads/main", "refs/heads/main"] },
+		];
+
+		for (const payload of invalidPayloads) {
+			const response = await app.request("/node/v1/workspaces", {
+				method: "POST",
+				headers: bearer(enrolled.credential.token),
+				body: JSON.stringify(payload),
+			});
+			await expectError(response, 400, "invalid_params");
+		}
+
+		const storedWorkspaces = await handle.db
+			.select({ id: workspaceBindings.id })
+			.from(workspaceBindings);
+		expect(storedWorkspaces).toEqual([]);
+	});
+
+	it("normalizes workspace refs, replays exact registration, rejects divergence, and retires revoked aliases", async () => {
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(owner.key);
+		const originalInput = {
+			alias: "backend-api",
+			repository_url: "https://github.com/acme/backend.git",
+			allowed_base_refs: ["refs/heads/release", "refs/heads/main"],
+		};
+
+		const created = await registerWorkspace(
+			enrolled.credential.token,
+			originalInput,
+			"req_workspace_register",
+		);
+		expect(created.response.status).toBe(201);
+		expect(created.body.replayed).toBe(false);
+		expect(workspaceBindingDescriptorSchema.parse(created.body.workspace)).toEqual(
+			created.body.workspace,
+		);
+		expect(created.body.workspace).toMatchObject({
+			node_id: enrolled.node.node_id,
+			agent_id: owner.id,
+			alias: "backend-api",
+			allowed_base_refs: ["refs/heads/main", "refs/heads/release"],
+			status: "active",
+			revoked_at: null,
+		});
+
+		const replay = await registerWorkspace(enrolled.credential.token, {
+			...originalInput,
+			allowed_base_refs: ["refs/heads/main", "refs/heads/release"],
+		});
+		expect(replay.response.status).toBe(200);
+		expect(replay.body).toEqual({ ...created.body, replayed: true });
+
+		for (const divergent of [
+			{ ...originalInput, repository_url: "https://github.com/acme/other.git" },
+			{ ...originalInput, allowed_base_refs: ["refs/heads/develop"] },
+		]) {
+			const response = await app.request("/node/v1/workspaces", {
+				method: "POST",
+				headers: bearer(enrolled.credential.token),
+				body: JSON.stringify(divergent),
+			});
+			await expectError(response, 409, "state_changed");
+		}
+
+		const listResponse = await app.request("/node/v1/workspaces", {
+			headers: bearer(enrolled.credential.token),
+		});
+		expect(listResponse.status).toBe(200);
+		const list = (await listResponse.json()) as { workspaces: WorkspaceBindingDescriptor[] };
+		expect(list.workspaces).toHaveLength(1);
+		expect(workspaceBindingDescriptorSchema.parse(list.workspaces[0])).toEqual(list.workspaces[0]);
+		expect(list.workspaces[0]?.workspace_binding_id).toBe(
+			created.body.workspace.workspace_binding_id,
+		);
+		expect(JSON.stringify(list)).not.toContain("local_path");
+
+		const revokeResponse = await app.request("/node/v1/workspaces/backend-api", {
+			method: "DELETE",
+			headers: bearer(enrolled.credential.token, "req_workspace_revoke"),
+		});
+		expect(revokeResponse.status).toBe(204);
+		const repeatedRevoke = await app.request("/node/v1/workspaces/backend-api", {
+			method: "DELETE",
+			headers: bearer(enrolled.credential.token),
+		});
+		expect(repeatedRevoke.status).toBe(204);
+
+		const afterRevokeResponse = await app.request("/node/v1/workspaces", {
+			headers: bearer(enrolled.credential.token),
+		});
+		expect(afterRevokeResponse.status).toBe(200);
+		const afterRevoke = (await afterRevokeResponse.json()) as {
+			workspaces: WorkspaceBindingDescriptor[];
+		};
+		expect(afterRevoke.workspaces).toHaveLength(1);
+		expect(afterRevoke.workspaces[0]?.status).toBe("revoked");
+		expect(afterRevoke.workspaces[0]?.revoked_at).not.toBeNull();
+		expect(workspaceBindingDescriptorSchema.parse(afterRevoke.workspaces[0])).toEqual(
+			afterRevoke.workspaces[0],
+		);
+
+		const reuseResponse = await app.request("/node/v1/workspaces", {
+			method: "POST",
+			headers: bearer(enrolled.credential.token),
+			body: JSON.stringify(originalInput),
+		});
+		await expectError(reuseResponse, 409, "invalid_transition");
+
+		const workspaceAudit = await handle.db
+			.select({ action: auditLog.action, requestId: auditLog.requestId })
+			.from(auditLog)
+			.where(eq(auditLog.resourceType, "workspace_binding"))
+			.orderBy(asc(auditLog.id));
+		expect(workspaceAudit).toEqual([
+			{ action: "workspace.register", requestId: "req_workspace_register" },
+			{ action: "workspace.revoke", requestId: "req_workspace_revoke" },
+		]);
+	});
+
+	it("audits Node mutations and cascades Node revocation to every credential and workspace", async () => {
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(
+			owner.key,
+			"backend-mac",
+			["runtime.fake"],
+			"req_node_enroll",
+		);
+		const registered = await registerWorkspace(
+			enrolled.credential.token,
+			{
+				alias: "backend-api",
+				repository_url: "https://github.com/acme/backend.git",
+				allowed_base_refs: ["refs/heads/main"],
+			},
+			"req_workspace_register",
+		);
+		expect(registered.response.status).toBe(201);
+
+		const rotateResponse = await app.request(
+			`/agents/me/nodes/${enrolled.node.node_id}/credentials/rotate`,
+			{
+				method: "POST",
+				headers: bearer(owner.key, "req_node_rotate"),
+				body: JSON.stringify({ expected_credential_id: enrolled.credential.id }),
+			},
+		);
+		expect(rotateResponse.status).toBe(200);
+		const rotated = (await rotateResponse.json()) as { credential: IssuedCredential };
+
+		const revokeResponse = await app.request(`/agents/me/nodes/${enrolled.node.node_id}`, {
+			method: "DELETE",
+			headers: bearer(owner.key, "req_node_revoke"),
+		});
+		expect(revokeResponse.status).toBe(204);
+		const repeatedRevoke = await app.request(`/agents/me/nodes/${enrolled.node.node_id}`, {
+			method: "DELETE",
+			headers: bearer(owner.key),
+		});
+		expect(repeatedRevoke.status).toBe(204);
+
+		for (const token of [enrolled.credential.token, rotated.credential.token]) {
+			await expectError(
+				await app.request("/node/v1/me", { headers: bearer(token) }),
+				401,
+				"unauthenticated",
+			);
+		}
+
+		const credentialRows = await handle.db
+			.select({ revokedAt: nodeCredentials.revokedAt })
+			.from(nodeCredentials)
+			.where(eq(nodeCredentials.nodeId, enrolled.node.node_id));
+		expect(credentialRows).toHaveLength(2);
+		expect(credentialRows.every((credential) => credential.revokedAt !== null)).toBe(true);
+
+		const [workspace] = await handle.db
+			.select({ status: workspaceBindings.status, revokedAt: workspaceBindings.revokedAt })
+			.from(workspaceBindings)
+			.where(eq(workspaceBindings.id, registered.body.workspace.workspace_binding_id));
+		expect(workspace?.status).toBe("revoked");
+		expect(workspace?.revokedAt).not.toBeNull();
+
+		const ownerListResponse = await app.request("/agents/me/nodes", {
+			headers: bearer(owner.key),
+		});
+		expect(ownerListResponse.status).toBe(200);
+		const ownerList = (await ownerListResponse.json()) as { nodes: OwnedNodeSummary[] };
+		expect(ownerList.nodes).toHaveLength(1);
+		expect(ownerList.nodes[0]?.node.status).toBe("revoked");
+		expect(ownerList.nodes[0]?.node.revoked_at).not.toBeNull();
+		expect(ownerList.nodes[0]?.active_credential_id).toBeNull();
+		expect(ownedNodeSummarySchema.parse(ownerList.nodes[0])).toEqual(ownerList.nodes[0]);
+
+		const mutationAudit = await handle.db
+			.select({
+				action: auditLog.action,
+				actorId: auditLog.actorId,
+				resourceType: auditLog.resourceType,
+				resourceId: auditLog.resourceId,
+				requestId: auditLog.requestId,
+				metadata: auditLog.metadata,
+			})
+			.from(auditLog)
+			.where(eq(auditLog.actorId, owner.id))
+			.orderBy(asc(auditLog.id));
+		expect(mutationAudit.map((row) => row.action)).toEqual([
+			"node.enroll",
+			"workspace.register",
+			"node.credential.rotate",
+			"node.revoke",
+		]);
+		expect(mutationAudit.map((row) => row.requestId)).toEqual([
+			"req_node_enroll",
+			"req_workspace_register",
+			"req_node_rotate",
+			"req_node_revoke",
+		]);
+		expect(mutationAudit[0]).toMatchObject({
+			resourceType: "node",
+			resourceId: enrolled.node.node_id,
+			metadata: { credential_id: enrolled.credential.id, name: "backend-mac" },
+		});
+		expect(mutationAudit[1]).toMatchObject({
+			resourceType: "workspace_binding",
+			resourceId: registered.body.workspace.workspace_binding_id,
+			metadata: {
+				node_id: enrolled.node.node_id,
+				credential_id: enrolled.credential.id,
+				alias: "backend-api",
+			},
+		});
+		expect(mutationAudit[2]).toMatchObject({
+			resourceType: "node",
+			resourceId: enrolled.node.node_id,
+			metadata: { credential_id: rotated.credential.id },
+		});
+		expect(mutationAudit[3]).toMatchObject({
+			resourceType: "node",
+			resourceId: enrolled.node.node_id,
+		});
+	});
+
+	it("serializes workspace registration against Node revocation", async () => {
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(owner.key);
+
+		const [registerResponse, revokeResponse] = await Promise.all([
+			app.request("/node/v1/workspaces", {
+				method: "POST",
+				headers: bearer(enrolled.credential.token),
+				body: JSON.stringify({
+					alias: "racing-workspace",
+					repository_url: "https://github.com/acme/backend.git",
+					allowed_base_refs: ["refs/heads/main"],
+				}),
+			}),
+			app.request(`/agents/me/nodes/${enrolled.node.node_id}`, {
+				method: "DELETE",
+				headers: bearer(owner.key),
+			}),
+		]);
+
+		expect(revokeResponse.status).toBe(204);
+		expect([201, 401]).toContain(registerResponse.status);
+		if (registerResponse.status === 401) {
+			const body = (await registerResponse.json()) as ErrorResponse;
+			expect(body.code).toBe("unauthenticated");
+		}
+
+		const activeCredentials = await handle.db
+			.select({ id: nodeCredentials.id })
+			.from(nodeCredentials)
+			.where(
+				and(eq(nodeCredentials.nodeId, enrolled.node.node_id), isNull(nodeCredentials.revokedAt)),
+			);
+		const activeWorkspaces = await handle.db
+			.select({ id: workspaceBindings.id })
+			.from(workspaceBindings)
+			.where(
+				and(
+					eq(workspaceBindings.nodeId, enrolled.node.node_id),
+					eq(workspaceBindings.status, "active"),
+				),
+			);
+		expect(activeCredentials).toEqual([]);
+		expect(activeWorkspaces).toEqual([]);
+
+		await expectError(
+			await app.request("/node/v1/workspaces", {
+				method: "POST",
+				headers: bearer(enrolled.credential.token),
+				body: JSON.stringify({
+					alias: "after-revocation",
+					repository_url: "https://github.com/acme/backend.git",
+					allowed_base_refs: ["refs/heads/main"],
+				}),
+			}),
+			401,
+			"unauthenticated",
+		);
+	});
+
+	it("keeps revocation chronology valid when presence lands after the transaction begins", async () => {
+		if (!TEST_DATABASE_URL) throw new Error("expected test database URL");
+		const owner = await createAgent("alice");
+		const enrolled = await enrollNode(owner.key);
+		const lockSql = postgres(TEST_DATABASE_URL, {
+			max: 1,
+			onnotice: () => undefined,
+		});
+		const lockAcquired = deferred();
+		const releaseLock = deferred();
+		let revokeRequest: Promise<Response> | undefined;
+		const blocker = lockSql.begin(async (tx) => {
+			await tx`SELECT pg_advisory_xact_lock(
+				hashtextextended(${`node:${enrolled.node.node_id}`}::text, 0)
+			)`;
+			lockAcquired.resolve();
+			await releaseLock.promise;
+		});
+
+		try {
+			await lockAcquired.promise;
+			revokeRequest = app.request(`/agents/me/nodes/${enrolled.node.node_id}`, {
+				method: "DELETE",
+				headers: bearer(owner.key),
+			});
+			await waitUntil(async () => {
+				const [row] = await handle.sql<Array<{ waiters: string }>>`
+					SELECT count(*)::text AS waiters
+					FROM pg_locks
+					WHERE locktype = 'advisory' AND NOT granted
+				`;
+				return Number(row?.waiters ?? "0") > 0;
+			}, "revocation did not wait on the Node lock");
+
+			const presenceResponse = await app.request("/node/v1/me", {
+				headers: bearer(enrolled.credential.token),
+			});
+			expect(presenceResponse.status).toBe(200);
+			await waitUntil(async () => {
+				const [row] = await handle.db
+					.select({ lastSeenAt: nodes.lastSeenAt })
+					.from(nodes)
+					.where(eq(nodes.id, enrolled.node.node_id));
+				return Boolean(row?.lastSeenAt);
+			}, "Node presence did not persist");
+
+			releaseLock.resolve();
+			await blocker;
+			const revokeResponse = await revokeRequest;
+			expect(revokeResponse.status).toBe(204);
+
+			const ownerListResponse = await app.request("/agents/me/nodes", {
+				headers: bearer(owner.key),
+			});
+			expect(ownerListResponse.status).toBe(200);
+			const ownerList = (await ownerListResponse.json()) as { nodes: OwnedNodeSummary[] };
+			const summary = ownedNodeSummarySchema.parse(ownerList.nodes[0]);
+			expect(summary.active_credential_id).toBeNull();
+			const revoked = nodeDescriptorSchema.parse(summary.node);
+			expect(revoked.status).toBe("revoked");
+			expect(revoked.last_seen_at).not.toBeNull();
+			expect(revoked.revoked_at).not.toBeNull();
+			expect(Date.parse(revoked.last_seen_at ?? "")).toBeLessThanOrEqual(
+				Date.parse(revoked.updated_at),
+			);
+			expect(Date.parse(revoked.revoked_at ?? "")).toBeLessThanOrEqual(
+				Date.parse(revoked.updated_at),
+			);
+		} finally {
+			releaseLock.resolve();
+			await blocker.catch(() => undefined);
+			await revokeRequest?.catch(() => undefined);
+			await lockSql.end({ timeout: 2 });
+		}
+	});
+});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve: () => void = () => undefined;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+async function waitUntil(
+	condition: () => Promise<boolean>,
+	message: string,
+	timeoutMs = 2_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await condition()) return;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(message);
+}

--- a/relay/src/server.ts
+++ b/relay/src/server.ts
@@ -9,6 +9,7 @@ import { createA2aRoutes } from "./routes/a2a.js";
 import { createAdminRoutes } from "./routes/admin.js";
 import { createAgentsRoutes } from "./routes/agents.js";
 import { createInviteRoutes } from "./routes/invites.js";
+import { createNodeRoutes } from "./routes/node.js";
 import type { AppEnv } from "./types.js";
 
 export type { AppEnv };
@@ -75,6 +76,13 @@ export function createServer(opts: CreateServerOptions): Hono<AppEnv> {
 				pepper: config.RELAY_PEPPER,
 				encryptionKey: config.RELAY_ENCRYPTION_KEY,
 				keyEnvironment,
+			}),
+		);
+		app.route(
+			"/node/v1",
+			createNodeRoutes({
+				db,
+				pepper: config.RELAY_PEPPER,
 			}),
 		);
 		app.route(

--- a/relay/src/services/node-enrollment.ts
+++ b/relay/src/services/node-enrollment.ts
@@ -1,0 +1,481 @@
+import { isDeepStrictEqual } from "node:util";
+import {
+	type NodeCredentialRotationInput,
+	type NodeDescriptor,
+	type NodeEnrollmentInput,
+	type OwnedNodeSummary,
+	type WorkspaceBindingDescriptor,
+	type WorkspaceRegistrationInput,
+	nodeDescriptorSchema,
+	ownedNodeSummarySchema,
+	workspaceBindingDescriptorSchema,
+} from "@agentrelay/protocol";
+import { and, asc, eq, isNull, sql } from "drizzle-orm";
+import { generateNodeKey } from "../auth/keys.js";
+import type { Database } from "../db/client.js";
+import {
+	type Node,
+	type WorkspaceBinding,
+	agents,
+	nodeCredentials,
+	nodes,
+	workspaceBindings,
+} from "../db/schema.js";
+import { RelayError } from "../errors.js";
+import { writeAudit } from "./audit.js";
+
+type NodeTransaction = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+interface MutationContext {
+	requestId?: string;
+}
+
+interface NodeCredentialContext {
+	nodeId: string;
+	agentId: string;
+	credentialId: string;
+	requestId?: string;
+}
+
+export interface IssuedNodeCredential {
+	id: string;
+	token: string;
+}
+
+export interface EnrollNodeResult {
+	node: NodeDescriptor;
+	credential: IssuedNodeCredential;
+}
+
+export interface RegisterWorkspaceResult {
+	workspace: WorkspaceBindingDescriptor;
+	replayed: boolean;
+}
+
+export async function enrollNode(
+	db: Database,
+	agentId: string,
+	input: NodeEnrollmentInput,
+	keyEnvironment: "live" | "test",
+	pepper: string,
+	context: MutationContext = {},
+): Promise<EnrollNodeResult> {
+	const capabilities = [...input.capabilities].sort();
+	const generated = generateNodeKey(keyEnvironment, pepper);
+
+	return db.transaction(async (tx) => {
+		await lock(tx, `node-enroll:${agentId}:${input.name}`);
+
+		const [existing] = await tx
+			.select({ id: nodes.id })
+			.from(nodes)
+			.where(
+				and(eq(nodes.agentId, agentId), eq(nodes.name, input.name), eq(nodes.status, "active")),
+			)
+			.limit(1);
+		if (existing) {
+			throw new RelayError("state_changed", "An active Node with this name already exists", {
+				node_id: existing.id,
+			});
+		}
+
+		const [node] = await tx
+			.insert(nodes)
+			.values({ agentId, name: input.name, capabilities })
+			.returning();
+		if (!node) throw new RelayError("internal", "Failed to enroll Node");
+
+		const [credential] = await tx
+			.insert(nodeCredentials)
+			.values({
+				nodeId: node.id,
+				keyHash: generated.hash,
+				salt: generated.salt,
+				label: "enrollment",
+			})
+			.returning({ id: nodeCredentials.id });
+		if (!credential) throw new RelayError("internal", "Failed to issue Node credential");
+
+		await writeAudit(tx, {
+			actorId: agentId,
+			action: "node.enroll",
+			resourceType: "node",
+			resourceId: node.id,
+			requestId: context.requestId,
+			metadata: {
+				credential_id: credential.id,
+				name: node.name,
+				capabilities,
+			},
+		});
+
+		return {
+			node: toNodeDescriptor(node),
+			credential: { id: credential.id, token: generated.raw },
+		};
+	});
+}
+
+export async function listNodes(db: Database, agentId: string): Promise<OwnedNodeSummary[]> {
+	const rows = await db
+		.select({ node: nodes, activeCredentialId: nodeCredentials.id })
+		.from(nodes)
+		.leftJoin(
+			nodeCredentials,
+			and(eq(nodeCredentials.nodeId, nodes.id), isNull(nodeCredentials.revokedAt)),
+		)
+		.where(eq(nodes.agentId, agentId))
+		.orderBy(asc(nodes.createdAt), asc(nodes.id));
+	const seenNodeIds = new Set<string>();
+	return rows.map((row) => {
+		if (seenNodeIds.has(row.node.id)) {
+			throw new RelayError("internal", "Node has multiple active credentials");
+		}
+		seenNodeIds.add(row.node.id);
+		return ownedNodeSummarySchema.parse({
+			node: toNodeDescriptor(row.node),
+			active_credential_id: row.activeCredentialId,
+		});
+	});
+}
+
+export async function getNode(
+	db: Database,
+	nodeId: string,
+	agentId: string,
+): Promise<NodeDescriptor> {
+	const [node] = await db
+		.select()
+		.from(nodes)
+		.where(and(eq(nodes.id, nodeId), eq(nodes.agentId, agentId)))
+		.limit(1);
+	if (!node) throw new RelayError("node_not_found", "Node not found");
+	return toNodeDescriptor(node);
+}
+
+export async function rotateNodeCredential(
+	db: Database,
+	agentId: string,
+	nodeId: string,
+	input: NodeCredentialRotationInput,
+	keyEnvironment: "live" | "test",
+	pepper: string,
+	context: MutationContext = {},
+): Promise<IssuedNodeCredential> {
+	const generated = generateNodeKey(keyEnvironment, pepper);
+
+	return db.transaction(async (tx) => {
+		await lock(tx, `node:${nodeId}`);
+		const [node] = await tx
+			.select({ id: nodes.id, status: nodes.status })
+			.from(nodes)
+			.where(and(eq(nodes.id, nodeId), eq(nodes.agentId, agentId)))
+			.limit(1);
+		if (!node) throw new RelayError("node_not_found", "Node not found");
+		if (node.status !== "active") {
+			throw new RelayError("invalid_transition", "Cannot rotate a revoked Node credential");
+		}
+		const activeCredentials = await loadActiveCredentialIds(tx, nodeId);
+		if (
+			activeCredentials.length !== 1 ||
+			activeCredentials[0]?.id !== input.expected_credential_id
+		) {
+			throw credentialStateChanged(input.expected_credential_id, activeCredentials);
+		}
+
+		const [revoked] = await tx
+			.update(nodeCredentials)
+			.set({ revokedAt: sql`clock_timestamp()` })
+			.where(
+				and(
+					eq(nodeCredentials.id, input.expected_credential_id),
+					eq(nodeCredentials.nodeId, nodeId),
+					isNull(nodeCredentials.revokedAt),
+				),
+			)
+			.returning({ id: nodeCredentials.id });
+		if (!revoked) {
+			throw credentialStateChanged(
+				input.expected_credential_id,
+				await loadActiveCredentialIds(tx, nodeId),
+			);
+		}
+		const [credential] = await tx
+			.insert(nodeCredentials)
+			.values({
+				nodeId,
+				keyHash: generated.hash,
+				salt: generated.salt,
+				label: "owner-rotated",
+			})
+			.returning({ id: nodeCredentials.id });
+		if (!credential) throw new RelayError("internal", "Failed to issue rotated credential");
+
+		await writeAudit(tx, {
+			actorId: agentId,
+			action: "node.credential.rotate",
+			resourceType: "node",
+			resourceId: nodeId,
+			requestId: context.requestId,
+			metadata: {
+				previous_credential_id: revoked.id,
+				credential_id: credential.id,
+			},
+		});
+
+		return { id: credential.id, token: generated.raw };
+	});
+}
+
+export async function revokeNode(
+	db: Database,
+	agentId: string,
+	nodeId: string,
+	context: MutationContext = {},
+): Promise<void> {
+	await db.transaction(async (tx) => {
+		await lock(tx, `node:${nodeId}`);
+		const [node] = await tx
+			.select({ id: nodes.id, status: nodes.status })
+			.from(nodes)
+			.where(and(eq(nodes.id, nodeId), eq(nodes.agentId, agentId)))
+			.limit(1);
+		if (!node) throw new RelayError("node_not_found", "Node not found");
+		if (node.status === "revoked") return;
+
+		await tx
+			.update(nodes)
+			.set({ status: "revoked", revokedAt: sql`clock_timestamp()` })
+			.where(eq(nodes.id, nodeId));
+		await tx
+			.update(nodeCredentials)
+			.set({ revokedAt: sql`clock_timestamp()` })
+			.where(and(eq(nodeCredentials.nodeId, nodeId), isNull(nodeCredentials.revokedAt)));
+		await tx
+			.update(workspaceBindings)
+			.set({ status: "revoked", revokedAt: sql`clock_timestamp()` })
+			.where(and(eq(workspaceBindings.nodeId, nodeId), eq(workspaceBindings.status, "active")));
+
+		await writeAudit(tx, {
+			actorId: agentId,
+			action: "node.revoke",
+			resourceType: "node",
+			resourceId: nodeId,
+			requestId: context.requestId,
+		});
+	});
+}
+
+export async function registerWorkspace(
+	db: Database,
+	auth: NodeCredentialContext,
+	input: WorkspaceRegistrationInput,
+): Promise<RegisterWorkspaceResult> {
+	const allowedBaseRefs = [...input.allowed_base_refs].sort();
+
+	return db.transaction(async (tx) => {
+		await lock(tx, `node:${auth.nodeId}`);
+		await lock(tx, `workspace:${auth.nodeId}:${input.alias}`);
+		await assertActiveNodeCredential(tx, auth);
+
+		const [existing] = await tx
+			.select()
+			.from(workspaceBindings)
+			.where(
+				and(eq(workspaceBindings.nodeId, auth.nodeId), eq(workspaceBindings.alias, input.alias)),
+			)
+			.orderBy(asc(workspaceBindings.createdAt))
+			.limit(1);
+		if (existing) {
+			if (existing.status !== "active") {
+				throw new RelayError(
+					"invalid_transition",
+					"A revoked workspace alias cannot be registered again",
+				);
+			}
+			if (
+				existing.repositoryUrl !== input.repository_url ||
+				!isDeepStrictEqual(existing.allowedBaseRefs, allowedBaseRefs)
+			) {
+				throw new RelayError(
+					"state_changed",
+					"Workspace alias is already registered with different configuration",
+					{ workspace_binding_id: existing.id },
+				);
+			}
+			return {
+				workspace: toWorkspaceDescriptor(existing, auth.agentId),
+				replayed: true,
+			};
+		}
+
+		const [workspace] = await tx
+			.insert(workspaceBindings)
+			.values({
+				nodeId: auth.nodeId,
+				alias: input.alias,
+				repositoryUrl: input.repository_url,
+				allowedBaseRefs,
+			})
+			.returning();
+		if (!workspace) throw new RelayError("internal", "Failed to register workspace");
+
+		await writeAudit(tx, {
+			actorId: auth.agentId,
+			action: "workspace.register",
+			resourceType: "workspace_binding",
+			resourceId: workspace.id,
+			requestId: auth.requestId,
+			metadata: {
+				node_id: auth.nodeId,
+				credential_id: auth.credentialId,
+				alias: workspace.alias,
+			},
+		});
+
+		return {
+			workspace: toWorkspaceDescriptor(workspace, auth.agentId),
+			replayed: false,
+		};
+	});
+}
+
+export async function listWorkspaces(
+	db: Database,
+	nodeId: string,
+	agentId: string,
+): Promise<WorkspaceBindingDescriptor[]> {
+	const rows = await db
+		.select()
+		.from(workspaceBindings)
+		.where(eq(workspaceBindings.nodeId, nodeId))
+		.orderBy(asc(workspaceBindings.createdAt), asc(workspaceBindings.id));
+	return rows.map((row) => toWorkspaceDescriptor(row, agentId));
+}
+
+export async function revokeWorkspace(
+	db: Database,
+	auth: NodeCredentialContext,
+	alias: string,
+): Promise<void> {
+	await db.transaction(async (tx) => {
+		await lock(tx, `node:${auth.nodeId}`);
+		await lock(tx, `workspace:${auth.nodeId}:${alias}`);
+		await assertActiveNodeCredential(tx, auth);
+
+		const [workspace] = await tx
+			.select()
+			.from(workspaceBindings)
+			.where(and(eq(workspaceBindings.nodeId, auth.nodeId), eq(workspaceBindings.alias, alias)))
+			.orderBy(asc(workspaceBindings.createdAt))
+			.limit(1);
+		if (!workspace) throw new RelayError("workspace_not_found", "Workspace not found");
+		if (workspace.status === "revoked") return;
+
+		const [revoked] = await tx
+			.update(workspaceBindings)
+			.set({ status: "revoked", revokedAt: sql`clock_timestamp()` })
+			.where(eq(workspaceBindings.id, workspace.id))
+			.returning({ id: workspaceBindings.id });
+		if (!revoked) throw new RelayError("internal", "Failed to revoke workspace");
+
+		await writeAudit(tx, {
+			actorId: auth.agentId,
+			action: "workspace.revoke",
+			resourceType: "workspace_binding",
+			resourceId: workspace.id,
+			requestId: auth.requestId,
+			metadata: {
+				node_id: auth.nodeId,
+				credential_id: auth.credentialId,
+				alias: workspace.alias,
+			},
+		});
+	});
+}
+
+function toNodeDescriptor(node: Node): NodeDescriptor {
+	return nodeDescriptorSchema.parse({
+		node_id: node.id,
+		agent_id: node.agentId,
+		name: node.name,
+		status: node.status,
+		capabilities: node.capabilities,
+		last_seen_at: node.lastSeenAt?.toISOString() ?? null,
+		created_at: node.createdAt.toISOString(),
+		updated_at: node.updatedAt.toISOString(),
+		revoked_at: node.revokedAt?.toISOString() ?? null,
+	});
+}
+
+function toWorkspaceDescriptor(
+	workspace: WorkspaceBinding,
+	agentId: string,
+): WorkspaceBindingDescriptor {
+	return workspaceBindingDescriptorSchema.parse({
+		workspace_binding_id: workspace.id,
+		node_id: workspace.nodeId,
+		agent_id: agentId,
+		alias: workspace.alias,
+		repository_url: workspace.repositoryUrl,
+		allowed_base_refs: workspace.allowedBaseRefs,
+		status: workspace.status,
+		created_at: workspace.createdAt.toISOString(),
+		updated_at: workspace.updatedAt.toISOString(),
+		revoked_at: workspace.revokedAt?.toISOString() ?? null,
+	});
+}
+
+async function assertActiveNodeCredential(
+	tx: NodeTransaction,
+	auth: NodeCredentialContext,
+): Promise<void> {
+	const [authorized] = await tx
+		.select({ id: nodeCredentials.id })
+		.from(nodeCredentials)
+		.innerJoin(nodes, eq(nodes.id, nodeCredentials.nodeId))
+		.innerJoin(agents, eq(agents.id, nodes.agentId))
+		.where(
+			and(
+				eq(nodeCredentials.id, auth.credentialId),
+				eq(nodeCredentials.nodeId, auth.nodeId),
+				isNull(nodeCredentials.revokedAt),
+				eq(nodes.agentId, auth.agentId),
+				eq(nodes.status, "active"),
+				eq(agents.status, "active"),
+			),
+		)
+		.limit(1);
+	if (!authorized) {
+		throw new RelayError("unauthenticated", "Node credential no longer authorizes this operation");
+	}
+}
+
+async function loadActiveCredentialIds(
+	tx: NodeTransaction,
+	nodeId: string,
+): Promise<Array<{ id: string }>> {
+	return tx
+		.select({ id: nodeCredentials.id })
+		.from(nodeCredentials)
+		.where(and(eq(nodeCredentials.nodeId, nodeId), isNull(nodeCredentials.revokedAt)))
+		.limit(2);
+}
+
+function credentialStateChanged(
+	expectedCredentialId: string,
+	activeCredentials: ReadonlyArray<{ id: string }>,
+): RelayError {
+	return new RelayError(
+		"state_changed",
+		"Active Node credential changed; refresh the owner Node summary",
+		{
+			expected_credential_id: expectedCredentialId,
+			active_credential_id: activeCredentials.length === 1 ? activeCredentials[0]!.id : null,
+		},
+	);
+}
+
+async function lock(tx: NodeTransaction, key: string): Promise<void> {
+	await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}::text, 0))`);
+}

--- a/relay/src/types.ts
+++ b/relay/src/types.ts
@@ -1,8 +1,9 @@
-import type { AuthenticatedAgent } from "./auth/middleware.js";
+import type { AuthenticatedAgent, AuthenticatedNode } from "./auth/middleware.js";
 import type { AppVariables } from "./middleware.js";
 
 export type AppEnv = {
 	Variables: AppVariables & {
 		agent?: AuthenticatedAgent;
+		node?: AuthenticatedNode;
 	};
 };


### PR DESCRIPTION
## Summary

- add separately scoped, hash-only Node credentials and owner-authenticated enrollment/list/revocation APIs
- make credential rotation a generation compare-and-swap with one active credential per Node
- add Node-authenticated identity and logical workspace registration/revocation routes
- keep local checkout paths, runtime commands, and raw credentials outside relay-visible persistence
- update protocol contracts, migrations, operational docs, and integration coverage

## Safety and recovery

- agent keys cannot authenticate Node routes, and Node keys cannot authenticate agent or A2A routes
- Node revocation atomically disables its active credential and workspace bindings while retaining Mission history
- rotation requires the owner-visible `active_credential_id`; concurrent or stale generations fail without mutation
- presence/revocation chronology and register/revoke races have deterministic regression coverage
- Mission polling, leases, and coding-agent runtime activation remain explicitly deferred

## Validation

- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r build`
- protocol, relay, and MCP unit suites
- relay Postgres integration: 109 passed
- end-to-end suite: 5 passed
- protocol export smoke
- relay Docker image build and runtime protocol import
- concurrency regressions repeated 5/5

Stacked on #55; this PR contains one commit (`6378274`).
