### PR TITLE
feat(landing): redesign AgentRelay homepage

### DIFF
--- a/landing/favicon.svg
+++ b/landing/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+	<rect width="64" height="64" fill="#f4f0e7" />
+	<path d="M4 32h15m26 0h15M19 32c0-11 5.8-18 13-18s13 7 13 18-5.8 18-13 18-13-7-13-18Z" fill="none" stroke="#0c1d2b" stroke-width="4" />
+	<circle cx="4" cy="32" r="4" fill="#ed2b10" />
+	<circle cx="60" cy="32" r="4" fill="#ed2b10" />
+</svg>

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,1471 +1,47 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#f3efe6" />
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+		<meta name="theme-color" content="#f4f0e7">
 		<meta
 			name="description"
-			content="AgentRelay is an open communication layer for agents that work for different people, on different devices, with different context."
-		/>
-		<meta property="og:title" content="AgentRelay — your agent should be able to call theirs" />
+			content="AgentRelay is a durable communication network for independently owned AI agents across machines, repositories, and runtimes."
+		>
+		<meta property="og:title" content="AgentRelay — your agent should be able to call theirs">
 		<meta
 			property="og:description"
-			content="A communication layer for agents across people, devices, repos, and runtimes."
-		/>
-		<meta property="og:type" content="website" />
-		<title>AgentRelay — agents that can reach each other</title>
-
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&amp;family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&amp;display=swap"
-			rel="stylesheet"
-		/>
-
-		<style>
-			:root {
-				--paper: #f3efe6;
-				--paper-deep: #e5ded0;
-				--surface: #fbf8f1;
-				--ink: #17211c;
-				--ink-soft: #536057;
-				--signal: #c83d1c;
-				--signal-dark: #8f2610;
-				--signal-surface: #ef724e;
-				--moss: #315b45;
-				--mint: #bcd6c2;
-				--line: rgba(23, 33, 28, 0.18);
-				--line-strong: rgba(23, 33, 28, 0.42);
-				--shadow: rgba(23, 33, 28, 0.12);
-				--sans: "Manrope", "Avenir Next", "Segoe UI", sans-serif;
-				--serif: "Newsreader", Georgia, serif;
-				--mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-				--page: min(1180px, calc(100vw - 40px));
-			}
-
-			* {
-				box-sizing: border-box;
-			}
-
-			html {
-				scroll-behavior: smooth;
-			}
-
-			body {
-				margin: 0;
-				background: var(--paper);
-				color: var(--ink);
-				font-family: var(--sans);
-				font-size: 16px;
-				line-height: 1.6;
-				-webkit-font-smoothing: antialiased;
-			}
-
-			body::before {
-				position: fixed;
-				inset: 0;
-				z-index: -1;
-				background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180' viewBox='0 0 180 180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.026'/%3E%3C/svg%3E");
-				content: "";
-				pointer-events: none;
-			}
-
-			a {
-				color: inherit;
-				text-decoration-thickness: 1px;
-				text-underline-offset: 0.22em;
-			}
-
-			button,
-			input,
-			textarea {
-				font: inherit;
-			}
-
-			button,
-			a {
-				-webkit-tap-highlight-color: transparent;
-			}
-
-			:focus-visible {
-				outline: 3px solid var(--signal);
-				outline-offset: 4px;
-			}
-
-			::selection {
-				background: var(--mint);
-				color: var(--ink);
-			}
-
-			.skip-link {
-				position: fixed;
-				top: 12px;
-				left: 12px;
-				z-index: 100;
-				padding: 10px 14px;
-				background: var(--ink);
-				color: var(--surface);
-				transform: translateY(-160%);
-				transition: transform 160ms ease;
-			}
-
-			.skip-link:focus {
-				transform: translateY(0);
-			}
-
-			.shell {
-				width: var(--page);
-				margin-inline: auto;
-			}
-
-			.eyebrow {
-				display: flex;
-				align-items: center;
-				gap: 10px;
-				margin: 0 0 22px;
-				font-family: var(--mono);
-				font-size: 0.72rem;
-				font-weight: 600;
-				letter-spacing: 0.11em;
-				line-height: 1.3;
-				text-transform: uppercase;
-			}
-
-			.eyebrow::before {
-				width: 27px;
-				height: 2px;
-				background: var(--signal);
-				content: "";
-			}
-
-			.nav-wrap {
-				position: relative;
-				z-index: 20;
-				border-bottom: 1px solid var(--line);
-			}
-
-			.nav {
-				display: flex;
-				min-height: 76px;
-				align-items: center;
-				justify-content: space-between;
-				gap: 24px;
-			}
-
-			.brand {
-				display: inline-flex;
-				align-items: center;
-				gap: 12px;
-				font-size: 0.95rem;
-				font-weight: 700;
-				letter-spacing: -0.02em;
-				text-decoration: none;
-			}
-
-			.brand-mark {
-				position: relative;
-				display: grid;
-				width: 32px;
-				height: 32px;
-				place-items: center;
-				border: 1px solid var(--ink);
-				font-family: var(--mono);
-				font-size: 0.67rem;
-				font-weight: 700;
-			}
-
-			.brand-mark::after {
-				position: absolute;
-				right: -4px;
-				bottom: -4px;
-				width: 7px;
-				height: 7px;
-				background: var(--signal);
-				content: "";
-			}
-
-			.nav-links {
-				display: flex;
-				align-items: center;
-				gap: 30px;
-			}
-
-			.nav-links a {
-				font-size: 0.84rem;
-				font-weight: 600;
-				text-decoration: none;
-			}
-
-			.nav-links a:not(.nav-cta)::after {
-				display: block;
-				width: 0;
-				height: 1px;
-				background: currentColor;
-				content: "";
-				transition: width 180ms ease;
-			}
-
-			.nav-links a:not(.nav-cta):hover::after {
-				width: 100%;
-			}
-
-			.nav-cta {
-				display: inline-flex;
-				min-height: 42px;
-				align-items: center;
-				padding: 0 16px;
-				border: 1px solid var(--ink);
-				background: var(--ink);
-				color: var(--surface);
-				transition:
-					background 160ms ease,
-					color 160ms ease;
-			}
-
-			.nav-cta:hover {
-				background: transparent;
-				color: var(--ink);
-			}
-
-			.hero {
-				position: relative;
-				display: grid;
-				min-height: 720px;
-				grid-template-columns: minmax(0, 1.18fr) minmax(280px, 0.62fr);
-				align-items: end;
-				gap: clamp(40px, 7vw, 100px);
-				padding: clamp(86px, 12vw, 154px) 0 84px;
-			}
-
-			.hero::after {
-				position: absolute;
-				right: 0;
-				bottom: -1px;
-				left: 0;
-				height: 1px;
-				background: var(--line-strong);
-				content: "";
-			}
-
-			.hero-copy {
-				position: relative;
-				z-index: 2;
-			}
-
-			.status-flag {
-				display: inline-flex;
-				align-items: center;
-				gap: 9px;
-				margin-bottom: 30px;
-				padding: 8px 11px;
-				border: 1px solid var(--line-strong);
-				font-family: var(--mono);
-				font-size: 0.68rem;
-				font-weight: 600;
-				letter-spacing: 0.08em;
-				line-height: 1;
-				text-transform: uppercase;
-			}
-
-			.status-dot {
-				width: 7px;
-				height: 7px;
-				background: var(--signal);
-				box-shadow: 0 0 0 4px rgba(200, 61, 28, 0.15);
-			}
-
-			h1 {
-				max-width: 850px;
-				margin: 0;
-				font-family: var(--serif);
-				font-size: clamp(4rem, 8.2vw, 7.35rem);
-				font-weight: 500;
-				letter-spacing: -0.065em;
-				line-height: 0.87;
-			}
-
-			h1 em {
-				color: var(--signal);
-				font-weight: 400;
-			}
-
-			.hero-side {
-				align-self: end;
-				padding-bottom: 6px;
-			}
-
-			.hero-side p {
-				max-width: 430px;
-				margin: 0 0 30px;
-				color: var(--ink-soft);
-				font-size: clamp(1.04rem, 1.6vw, 1.28rem);
-				line-height: 1.55;
-			}
-
-			.hero-side strong {
-				color: var(--ink);
-				font-weight: 600;
-			}
-
-			.button-row {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 12px;
-			}
-
-			.button {
-				display: inline-flex;
-				min-height: 52px;
-				align-items: center;
-				justify-content: center;
-				gap: 12px;
-				padding: 0 20px;
-				border: 1px solid var(--ink);
-				font-size: 0.83rem;
-				font-weight: 700;
-				letter-spacing: 0.01em;
-				text-decoration: none;
-				transition:
-					transform 160ms ease,
-					box-shadow 160ms ease,
-					background 160ms ease;
-			}
-
-			.button:hover {
-				transform: translate(-2px, -2px);
-				box-shadow: 4px 4px 0 var(--ink);
-			}
-
-			.button-primary {
-				background: var(--signal);
-				color: #fffaf3;
-			}
-
-			.button-secondary {
-				background: transparent;
-			}
-
-			.button-arrow {
-				font-family: var(--mono);
-				font-size: 1rem;
-			}
-
-			.hero-note {
-				display: flex;
-				align-items: center;
-				gap: 8px;
-				margin-top: 22px;
-				color: var(--ink-soft);
-				font-family: var(--mono);
-				font-size: 0.68rem;
-				letter-spacing: 0.03em;
-			}
-
-			.hero-note span {
-				color: var(--moss);
-			}
-
-			.marquee {
-				overflow: hidden;
-				border-bottom: 1px solid var(--line-strong);
-				background: var(--ink);
-				color: var(--paper);
-			}
-
-			.marquee-track {
-				display: flex;
-				width: max-content;
-				animation: marquee 28s linear infinite;
-			}
-
-			.marquee-item {
-				display: flex;
-				min-height: 46px;
-				align-items: center;
-				gap: 24px;
-				padding-right: 24px;
-				font-family: var(--mono);
-				font-size: 0.7rem;
-				letter-spacing: 0.09em;
-				text-transform: uppercase;
-			}
-
-			.marquee-item::after {
-				color: var(--signal);
-				content: "◆";
-			}
-
-			@keyframes marquee {
-				to {
-					transform: translateX(-50%);
-				}
-			}
-
-			.demo-section {
-				padding: clamp(88px, 11vw, 142px) 0;
-			}
-
-			.section-head {
-				display: grid;
-				grid-template-columns: minmax(0, 0.9fr) minmax(280px, 0.45fr);
-				align-items: end;
-				gap: 60px;
-				margin-bottom: 52px;
-			}
-
-			.section-title {
-				max-width: 800px;
-				margin: 0;
-				font-family: var(--serif);
-				font-size: clamp(2.9rem, 5.2vw, 5rem);
-				font-weight: 500;
-				letter-spacing: -0.05em;
-				line-height: 0.98;
-			}
-
-			.section-intro {
-				margin: 0;
-				color: var(--ink-soft);
-				font-size: 1rem;
-			}
-
-			.demo-window {
-				border: 1px solid var(--ink);
-				background: var(--surface);
-				box-shadow: 10px 10px 0 var(--paper-deep);
-			}
-
-			.window-bar {
-				display: flex;
-				min-height: 47px;
-				align-items: center;
-				justify-content: space-between;
-				gap: 20px;
-				padding: 0 16px;
-				border-bottom: 1px solid var(--ink);
-				font-family: var(--mono);
-				font-size: 0.67rem;
-				letter-spacing: 0.07em;
-				text-transform: uppercase;
-			}
-
-			.window-lights {
-				display: flex;
-				gap: 6px;
-			}
-
-			.window-lights i {
-				display: block;
-				width: 8px;
-				height: 8px;
-				border: 1px solid var(--ink);
-			}
-
-			.window-lights i:first-child {
-				background: var(--signal);
-			}
-
-			.window-status {
-				display: flex;
-				align-items: center;
-				gap: 7px;
-				color: var(--moss);
-			}
-
-			.window-status::before {
-				width: 6px;
-				height: 6px;
-				background: var(--moss);
-				content: "";
-			}
-
-			.exchange {
-				display: grid;
-				min-height: 460px;
-				grid-template-columns: minmax(0, 1fr) 160px minmax(0, 1fr);
-			}
-
-			.agent-pane {
-				display: flex;
-				min-width: 0;
-				flex-direction: column;
-				padding: clamp(22px, 3vw, 36px);
-			}
-
-			.agent-pane:first-child {
-				border-right: 1px solid var(--line);
-			}
-
-			.agent-pane:last-child {
-				border-left: 1px solid var(--line);
-			}
-
-			.agent-meta {
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-				gap: 16px;
-				padding-bottom: 24px;
-				border-bottom: 1px solid var(--line);
-			}
-
-			.agent-identity {
-				display: flex;
-				align-items: center;
-				gap: 12px;
-			}
-
-			.agent-avatar {
-				display: grid;
-				width: 38px;
-				height: 38px;
-				place-items: center;
-				background: var(--ink);
-				color: var(--surface);
-				font-family: var(--mono);
-				font-size: 0.67rem;
-			}
-
-			.agent-pane:last-child .agent-avatar {
-				background: var(--moss);
-			}
-
-			.agent-name {
-				font-size: 0.83rem;
-				font-weight: 700;
-				line-height: 1.25;
-			}
-
-			.agent-context {
-				color: var(--ink-soft);
-				font-family: var(--mono);
-				font-size: 0.63rem;
-			}
-
-			.presence {
-				color: var(--moss);
-				font-family: var(--mono);
-				font-size: 0.62rem;
-				text-transform: uppercase;
-			}
-
-			.prompt {
-				margin: 34px 0 0;
-				color: var(--ink-soft);
-				font-family: var(--mono);
-				font-size: clamp(0.72rem, 1vw, 0.82rem);
-				line-height: 1.7;
-			}
-
-			.prompt-label {
-				display: block;
-				margin-bottom: 9px;
-				color: var(--signal-dark);
-				font-size: 0.62rem;
-				font-weight: 700;
-				letter-spacing: 0.08em;
-				text-transform: uppercase;
-			}
-
-			.prompt strong {
-				color: var(--ink);
-				font-weight: 600;
-			}
-
-			.agent-artifact {
-				margin-top: auto;
-				padding: 14px;
-				border: 1px solid var(--line-strong);
-				background: var(--paper);
-				font-family: var(--mono);
-				font-size: 0.67rem;
-			}
-
-			.artifact-top {
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-				gap: 12px;
-				margin-bottom: 8px;
-				color: var(--ink-soft);
-			}
-
-			.artifact-state {
-				color: var(--moss);
-			}
-
-			.relay-spine {
-				position: relative;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				overflow: hidden;
-				background: var(--paper-deep);
-			}
-
-			.relay-spine::before {
-				position: absolute;
-				top: 50%;
-				right: 0;
-				left: 0;
-				height: 1px;
-				background: var(--ink);
-				content: "";
-			}
-
-			.relay-node {
-				position: relative;
-				z-index: 2;
-				display: grid;
-				width: 70px;
-				height: 70px;
-				place-items: center;
-				border: 1px solid var(--ink);
-				background: var(--signal);
-				color: #fffaf3;
-				font-family: var(--mono);
-				font-size: 0.61rem;
-				font-weight: 700;
-				letter-spacing: 0.07em;
-				line-height: 1.25;
-				text-align: center;
-				text-transform: uppercase;
-				transform: rotate(45deg);
-			}
-
-			.relay-node span {
-				transform: rotate(-45deg);
-			}
-
-			.packet {
-				position: absolute;
-				top: calc(50% - 5px);
-				left: -12px;
-				z-index: 3;
-				width: 10px;
-				height: 10px;
-				border: 2px solid var(--surface);
-				background: var(--ink);
-				box-shadow: 0 0 0 1px var(--ink);
-				animation: packet-cross 3.8s ease-in-out infinite;
-			}
-
-			@keyframes packet-cross {
-				0% {
-					transform: translateX(0);
-				}
-
-				45%,
-				55% {
-					transform: translateX(76px) rotate(45deg);
-				}
-
-				100% {
-					transform: translateX(172px);
-				}
-			}
-
-			.exchange-footer {
-				display: flex;
-				min-height: 70px;
-				align-items: center;
-				justify-content: space-between;
-				gap: 24px;
-				padding: 14px 20px;
-				border-top: 1px solid var(--ink);
-			}
-
-			.scene-controls {
-				display: flex;
-				align-items: center;
-				gap: 7px;
-			}
-
-			.scene-button {
-				display: grid;
-				width: 34px;
-				height: 34px;
-				place-items: center;
-				border: 1px solid var(--line-strong);
-				border-radius: 0;
-				background: transparent;
-				color: var(--ink-soft);
-				font-family: var(--mono);
-				font-size: 0.64rem;
-				cursor: pointer;
-			}
-
-			.scene-button[aria-current="step"] {
-				border-color: var(--ink);
-				background: var(--ink);
-				color: var(--surface);
-			}
-
-			.scene-caption {
-				margin: 0;
-				color: var(--ink-soft);
-				font-family: var(--mono);
-				font-size: 0.67rem;
-				text-align: right;
-			}
-
-			.scene-caption strong {
-				color: var(--ink);
-			}
-
-			.demo-disclaimer {
-				display: flex;
-				align-items: flex-start;
-				gap: 9px;
-				margin: 18px 0 0;
-				color: var(--ink-soft);
-				font-family: var(--mono);
-				font-size: 0.66rem;
-				letter-spacing: 0.025em;
-			}
-
-			.demo-disclaimer::before {
-				flex: 0 0 auto;
-				color: var(--signal-dark);
-				content: "↳";
-			}
-
-			.thesis {
-				border-block: 1px solid var(--ink);
-				background: var(--ink);
-				color: var(--paper);
-			}
-
-			.thesis-grid {
-				display: grid;
-				grid-template-columns: minmax(260px, 0.65fr) minmax(0, 1.35fr);
-				gap: clamp(50px, 10vw, 140px);
-				padding: clamp(86px, 12vw, 152px) 0;
-			}
-
-			.thesis-index {
-				font-family: var(--mono);
-				font-size: 0.68rem;
-				letter-spacing: 0.1em;
-				text-transform: uppercase;
-			}
-
-			.thesis-index span {
-				display: block;
-				width: 56px;
-				height: 56px;
-				margin-bottom: 20px;
-				padding-top: 16px;
-				border: 1px solid rgba(243, 239, 230, 0.5);
-				color: var(--signal);
-				text-align: center;
-			}
-
-			.thesis-copy p {
-				max-width: 900px;
-				margin: 0;
-				font-family: var(--serif);
-				font-size: clamp(2.7rem, 5vw, 5rem);
-				font-weight: 400;
-				letter-spacing: -0.045em;
-				line-height: 1.02;
-			}
-
-			.thesis-copy em {
-				color: var(--mint);
-				font-weight: 400;
-			}
-
-			.thesis-note {
-				display: grid;
-				grid-template-columns: repeat(2, minmax(0, 1fr));
-				gap: 30px;
-				margin-top: 60px;
-				padding-top: 26px;
-				border-top: 1px solid rgba(243, 239, 230, 0.24);
-				color: rgba(243, 239, 230, 0.7);
-				font-size: 0.88rem;
-			}
-
-			.thesis-note strong {
-				display: block;
-				margin-bottom: 5px;
-				color: var(--paper);
-				font-family: var(--mono);
-				font-size: 0.65rem;
-				letter-spacing: 0.08em;
-				text-transform: uppercase;
-			}
-
-			.protocol {
-				padding: clamp(88px, 12vw, 156px) 0;
-			}
-
-			.protocol-layout {
-				display: grid;
-				grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1fr);
-				gap: clamp(56px, 10vw, 140px);
-			}
-
-			.protocol-sticky {
-				align-self: start;
-			}
-
-			.protocol-sticky .section-title {
-				font-size: clamp(3rem, 5vw, 4.8rem);
-			}
-
-			.protocol-sticky p {
-				max-width: 430px;
-				margin: 28px 0 0;
-				color: var(--ink-soft);
-			}
-
-			.protocol-list {
-				border-top: 1px solid var(--ink);
-			}
-
-			.protocol-step {
-				display: grid;
-				grid-template-columns: 54px minmax(0, 1fr);
-				gap: 20px;
-				padding: 28px 0 32px;
-				border-bottom: 1px solid var(--line-strong);
-			}
-
-			.protocol-number {
-				padding-top: 5px;
-				color: var(--signal-dark);
-				font-family: var(--mono);
-				font-size: 0.7rem;
-			}
-
-			.protocol-step h3 {
-				margin: 0 0 6px;
-				font-family: var(--serif);
-				font-size: 1.75rem;
-				font-weight: 500;
-				letter-spacing: -0.025em;
-				line-height: 1.15;
-			}
-
-			.protocol-step p {
-				max-width: 620px;
-				margin: 0;
-				color: var(--ink-soft);
-				font-size: 0.9rem;
-			}
-
-			.trust-band {
-				border-block: 1px solid var(--ink);
-				background: var(--mint);
-			}
-
-			.trust-grid {
-				display: grid;
-				grid-template-columns: minmax(0, 1fr) minmax(300px, 0.7fr);
-				gap: clamp(50px, 10vw, 130px);
-				padding: clamp(80px, 10vw, 125px) 0;
-			}
-
-			.trust-grid .section-title {
-				max-width: 760px;
-			}
-
-			.trust-copy {
-				align-self: end;
-			}
-
-			.trust-copy p {
-				margin: 0 0 24px;
-				font-size: 1.02rem;
-			}
-
-			.trust-principles {
-				display: grid;
-				grid-template-columns: repeat(2, minmax(0, 1fr));
-				gap: 1px;
-				border: 1px solid var(--ink);
-				background: var(--ink);
-			}
-
-			.trust-principle {
-				min-height: 104px;
-				padding: 18px;
-				background: var(--mint);
-			}
-
-			.trust-principle strong {
-				display: block;
-				margin-bottom: 4px;
-				font-family: var(--mono);
-				font-size: 0.67rem;
-				letter-spacing: 0.07em;
-				text-transform: uppercase;
-			}
-
-			.trust-principle span {
-				font-size: 0.8rem;
-			}
-
-			.reality {
-				padding: clamp(88px, 11vw, 142px) 0;
-			}
-
-			.reality-header {
-				display: flex;
-				align-items: flex-end;
-				justify-content: space-between;
-				gap: 40px;
-				margin-bottom: 48px;
-			}
-
-			.reality-header .section-title {
-				max-width: 720px;
-			}
-
-			.reality-stamp {
-				flex: 0 0 auto;
-				padding: 12px 14px;
-				border: 1px solid var(--ink);
-				color: var(--signal-dark);
-				font-family: var(--mono);
-				font-size: 0.66rem;
-				font-weight: 700;
-				letter-spacing: 0.08em;
-				text-transform: uppercase;
-				transform: rotate(-2deg);
-			}
-
-			.reality-grid {
-				display: grid;
-				grid-template-columns: repeat(2, minmax(0, 1fr));
-				border-block: 1px solid var(--ink);
-			}
-
-			.reality-column {
-				padding: 34px clamp(22px, 4vw, 50px) 40px 0;
-			}
-
-			.reality-column + .reality-column {
-				padding-right: 0;
-				padding-left: clamp(22px, 4vw, 50px);
-				border-left: 1px solid var(--ink);
-			}
-
-			.reality-label {
-				display: flex;
-				align-items: center;
-				gap: 10px;
-				margin-bottom: 28px;
-				font-family: var(--mono);
-				font-size: 0.68rem;
-				font-weight: 700;
-				letter-spacing: 0.08em;
-				text-transform: uppercase;
-			}
-
-			.reality-label::before {
-				width: 10px;
-				height: 10px;
-				border: 1px solid var(--ink);
-				content: "";
-			}
-
-			.reality-column:first-child .reality-label::before {
-				background: var(--moss);
-			}
-
-			.reality-column:last-child .reality-label::before {
-				background: var(--signal);
-			}
-
-			.reality-list {
-				margin: 0;
-				padding: 0;
-				list-style: none;
-			}
-
-			.reality-list li {
-				position: relative;
-				padding: 17px 0 17px 26px;
-				border-top: 1px solid var(--line);
-				font-size: 0.92rem;
-			}
-
-			.reality-list li::before {
-				position: absolute;
-				top: 23px;
-				left: 0;
-				color: var(--signal-dark);
-				font-family: var(--mono);
-				font-size: 0.68rem;
-				content: "→";
-			}
-
-			.objections {
-				padding: 0 0 clamp(88px, 11vw, 142px);
-			}
-
-			.objections-layout {
-				display: grid;
-				grid-template-columns: minmax(250px, 0.62fr) minmax(0, 1fr);
-				gap: clamp(50px, 10vw, 130px);
-				padding-top: clamp(52px, 7vw, 82px);
-				border-top: 1px solid var(--ink);
-			}
-
-			.objections-heading h2 {
-				max-width: 490px;
-				margin: 0;
-				font-family: var(--serif);
-				font-size: clamp(2.7rem, 4.5vw, 4.4rem);
-				font-weight: 500;
-				letter-spacing: -0.045em;
-				line-height: 0.98;
-			}
-
-			.objections-list {
-				border-top: 1px solid var(--line-strong);
-			}
-
-			.objections-list details {
-				border-bottom: 1px solid var(--line-strong);
-			}
-
-			.objections-list summary {
-				position: relative;
-				padding: 22px 48px 22px 0;
-				font-family: var(--serif);
-				font-size: 1.35rem;
-				font-weight: 500;
-				letter-spacing: -0.02em;
-				line-height: 1.2;
-				cursor: pointer;
-				list-style: none;
-			}
-
-			.objections-list summary::-webkit-details-marker {
-				display: none;
-			}
-
-			.objections-list summary::after {
-				position: absolute;
-				top: 18px;
-				right: 0;
-				font-family: var(--mono);
-				font-size: 1.2rem;
-				font-weight: 400;
-				content: "+";
-			}
-
-			.objections-list details[open] summary::after {
-				content: "−";
-			}
-
-			.objections-list details p {
-				max-width: 680px;
-				margin: -2px 0 24px;
-				color: var(--ink-soft);
-				font-size: 0.9rem;
-			}
-
-			.pilot {
-				padding: 0 0 clamp(80px, 10vw, 130px);
-			}
-
-			.pilot-box {
-				display: grid;
-				grid-template-columns: minmax(0, 0.82fr) minmax(320px, 0.68fr);
-				gap: clamp(50px, 10vw, 130px);
-				padding: clamp(42px, 7vw, 76px);
-				border: 1px solid var(--ink);
-				background: var(--signal-surface);
-				box-shadow: 10px 10px 0 var(--ink);
-			}
-
-			.pilot-copy h2 {
-				max-width: 660px;
-				margin: 0 0 22px;
-				font-family: var(--serif);
-				font-size: clamp(3rem, 5vw, 5.1rem);
-				font-weight: 500;
-				letter-spacing: -0.052em;
-				line-height: 0.96;
-			}
-
-			.pilot-copy p {
-				max-width: 580px;
-				margin: 0;
-				font-size: 0.95rem;
-			}
-
-			.pilot-form {
-				display: flex;
-				flex-direction: column;
-				gap: 18px;
-			}
-
-			.form-field {
-				display: grid;
-				gap: 7px;
-			}
-
-			.form-field label {
-				font-family: var(--mono);
-				font-size: 0.66rem;
-				font-weight: 700;
-				letter-spacing: 0.07em;
-				text-transform: uppercase;
-			}
-
-			.form-field input,
-			.form-field textarea {
-				width: 100%;
-				border: 1px solid var(--ink);
-				border-radius: 0;
-				background: rgba(255, 250, 243, 0.16);
-				color: var(--ink);
-			}
-
-			.form-field input {
-				min-height: 48px;
-				padding: 0 13px;
-			}
-
-			.form-field textarea {
-				min-height: 92px;
-				padding: 12px 13px;
-				resize: vertical;
-			}
-
-			.form-field input::placeholder,
-			.form-field textarea::placeholder {
-				color: rgba(23, 33, 28, 0.63);
-			}
-
-			.form-submit {
-				min-height: 52px;
-				border: 1px solid var(--ink);
-				border-radius: 0;
-				background: var(--ink);
-				color: var(--surface);
-				font-size: 0.82rem;
-				font-weight: 700;
-				cursor: pointer;
-				transition:
-					transform 160ms ease,
-					box-shadow 160ms ease;
-			}
-
-			.form-submit:hover {
-				transform: translate(-2px, -2px);
-				box-shadow: 4px 4px 0 var(--surface);
-			}
-
-			.form-note {
-				margin: -4px 0 0;
-				font-size: 0.7rem;
-			}
-
-			.form-commitment {
-				display: grid;
-				grid-template-columns: 20px minmax(0, 1fr);
-				align-items: start;
-				gap: 10px;
-				font-size: 0.76rem;
-				line-height: 1.45;
-				cursor: pointer;
-			}
-
-			.form-commitment input {
-				width: 18px;
-				height: 18px;
-				margin: 1px 0 0;
-				accent-color: var(--ink);
-			}
-
-			footer {
-				border-top: 1px solid var(--ink);
-			}
-
-			.footer-grid {
-				display: grid;
-				grid-template-columns: 1fr auto;
-				align-items: end;
-				gap: 50px;
-				padding: 48px 0;
-			}
-
-			.footer-statement {
-				max-width: 660px;
-				margin: 22px 0 0;
-				font-family: var(--serif);
-				font-size: clamp(1.8rem, 3vw, 2.8rem);
-				letter-spacing: -0.035em;
-				line-height: 1.08;
-			}
-
-			.footer-links {
-				display: flex;
-				gap: 24px;
-				font-size: 0.78rem;
-				font-weight: 600;
-			}
-
-			.footer-legal {
-				display: flex;
-				justify-content: space-between;
-				gap: 24px;
-				padding: 15px 0 24px;
-				border-top: 1px solid var(--line);
-				color: var(--ink-soft);
-				font-family: var(--mono);
-				font-size: 0.61rem;
-				letter-spacing: 0.04em;
-				text-transform: uppercase;
-			}
-
-			@media (min-width: 1000px) {
-				.protocol-sticky {
-					position: sticky;
-					top: 34px;
-				}
-			}
-
-			@media (max-width: 900px) {
-				:root {
-					--page: min(100% - 32px, 720px);
-				}
-
-				.nav-link-optional {
-					display: none;
-				}
-
-				.hero {
-					min-height: 0;
-					grid-template-columns: 1fr;
-					align-items: start;
-					gap: 48px;
-					padding: 94px 0 72px;
-				}
-
-				.hero-side {
-					max-width: 600px;
-				}
-
-				.section-head,
-				.thesis-grid,
-				.protocol-layout,
-				.trust-grid,
-				.objections-layout,
-				.pilot-box {
-					grid-template-columns: 1fr;
-				}
-
-				.section-head {
-					gap: 26px;
-				}
-
-				.exchange {
-					min-height: 0;
-					grid-template-columns: 1fr;
-				}
-
-				.agent-pane {
-					min-height: 360px;
-				}
-
-				.agent-pane:first-child,
-				.agent-pane:last-child {
-					border: 0;
-				}
-
-				.agent-pane:first-child {
-					border-bottom: 1px solid var(--line);
-				}
-
-				.relay-spine {
-					min-height: 130px;
-					border-block: 1px solid var(--line);
-				}
-
-				.relay-spine::before {
-					top: 0;
-					bottom: 0;
-					left: 50%;
-					width: 1px;
-					height: auto;
-				}
-
-				.packet {
-					top: -10px;
-					left: calc(50% - 5px);
-					animation-name: packet-drop;
-				}
-
-				@keyframes packet-drop {
-					0% {
-						transform: translateY(0);
-					}
-
-					45%,
-					55% {
-						transform: translateY(64px) rotate(45deg);
-					}
-
-					100% {
-						transform: translateY(140px);
-					}
-				}
-
-				.thesis-note {
-					margin-top: 46px;
-				}
-
-				.reality-grid {
-					grid-template-columns: 1fr;
-				}
-
-				.reality-column,
-				.reality-column + .reality-column {
-					padding-inline: 0;
-				}
-
-				.reality-column + .reality-column {
-					border-top: 1px solid var(--ink);
-					border-left: 0;
-				}
-			}
-
-			@media (max-width: 600px) {
-				:root {
-					--page: calc(100% - 24px);
-				}
-
-				.nav {
-					min-height: 66px;
-				}
-
-				.nav-links {
-					gap: 10px;
-				}
-
-				.nav-links > a:not(.nav-cta) {
-					display: none;
-				}
-
-				.nav-cta {
-					min-height: 40px;
-					padding: 0 12px;
-					font-size: 0.73rem;
-				}
-
-				.hero {
-					padding-top: 70px;
-				}
-
-				h1 {
-					font-size: clamp(3.5rem, 18vw, 5.1rem);
-				}
-
-				.button-row {
-					flex-direction: column;
-				}
-
-				.button {
-					width: 100%;
-				}
-
-				.window-bar {
-					padding-inline: 12px;
-				}
-
-				.window-status {
-					display: none;
-				}
-
-				.agent-pane {
-					min-height: 335px;
-					padding: 20px;
-				}
-
-				.exchange-footer {
-					align-items: flex-start;
-					flex-direction: column;
-				}
-
-				.scene-caption {
-					text-align: left;
-				}
-
-				.thesis-note,
-				.trust-principles {
-					grid-template-columns: 1fr;
-				}
-
-				.reality-header {
-					align-items: flex-start;
-					flex-direction: column;
-				}
-
-				.pilot-box {
-					padding: 32px 20px;
-					box-shadow: 6px 6px 0 var(--ink);
-				}
-
-				.footer-grid {
-					grid-template-columns: 1fr;
-				}
-
-				.footer-links {
-					flex-wrap: wrap;
-				}
-
-				.footer-legal {
-					align-items: flex-start;
-					flex-direction: column;
-				}
-			}
-
-			@media (prefers-reduced-motion: reduce) {
-				html {
-					scroll-behavior: auto;
-				}
-
-				*,
-				*::before,
-				*::after {
-					scroll-behavior: auto !important;
-					animation-duration: 0.01ms !important;
-					animation-iteration-count: 1 !important;
-					transition-duration: 0.01ms !important;
-				}
-			}
-		</style>
+			content="Durable, structured handoffs between agents that work for different people on different machines."
+		>
+		<meta property="og:type" content="website">
+		<meta property="og:url" content="https://swayamg20.github.io/AgentRelay/">
+		<title>AgentRelay — a durable line between agents</title>
+		<link rel="icon" href="./favicon.svg" type="image/svg+xml">
+
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link rel="stylesheet" href="./site.css">
+		<script src="./site.js" defer></script>
 	</head>
-
 	<body>
 		<a class="skip-link" href="#main">Skip to content</a>
 
-		<header class="nav-wrap">
-			<nav class="nav shell" aria-label="Primary navigation">
-				<a class="brand" href="#top" aria-label="AgentRelay home">
-					<span class="brand-mark" aria-hidden="true">A/R</span>
+		<header class="site-header">
+			<nav class="site-nav shell" aria-label="Primary navigation">
+				<a class="brand" href="#top">
+					<svg class="brand-mark" viewBox="0 0 38 28" aria-hidden="true">
+						<path d="M2 14h10M26 14h10M12 14c0-6 3-10 7-10s7 4 7 10-3 10-7 10-7-4-7-10Z" />
+						<circle cx="2" cy="14" r="2" />
+						<circle cx="36" cy="14" r="2" />
+					</svg>
 					<span>AgentRelay</span>
+					<span class="brand-version">0.2</span>
 				</a>
+
 				<div class="nav-links">
-					<a class="nav-link-optional" href="#protocol">How it works</a>
-					<a class="nav-link-optional" href="#reality">What exists</a>
-					<a
-						class="nav-link-optional"
-						href="https://github.com/swayamg20/AgentRelay"
-						target="_blank"
-						rel="noreferrer"
-						>GitHub ↗</a
-					>
-					<a class="nav-cta" href="#pilot">Bring a workflow</a>
+					<a class="nav-optional" href="#workflow">The workflow</a>
+					<a class="nav-optional" href="#status">Build status</a>
+					<a href="https://github.com/swayamg20/AgentRelay">GitHub <span aria-hidden="true">↗</span></a>
+					<a class="nav-action" href="#use">Use it today</a>
 				</div>
 			</nav>
 		</header>
@@ -1473,599 +49,412 @@
 		<main id="main">
 			<section class="hero shell" id="top">
 				<div class="hero-copy">
-					<div class="status-flag">
-						<span class="status-dot" aria-hidden="true"></span>
-						Design-partner preview · 2026
+					<div class="availability-pill">
+						<span class="availability-dot" aria-hidden="true"></span>
+						Mailbox available now
+						<span aria-hidden="true">/</span>
+						Runtime path in progress
 					</div>
 					<h1>Your agent should be able to call <em>theirs.</em></h1>
+					<p class="hero-lead">
+						AgentRelay gives independently owned agents a durable line across machines. They
+						exchange questions, contracts, and evidence while repositories, credentials, and
+						local authority stay with their owners.
+					</p>
+					<div class="hero-actions">
+						<a class="button button-primary" href="#use">
+							Use the mailbox
+							<span aria-hidden="true">↓</span>
+						</a>
+						<a class="button button-secondary" href="https://github.com/swayamg20/AgentRelay">
+							Read the source
+							<span aria-hidden="true">↗</span>
+						</a>
+					</div>
+					<p class="hero-footnote">
+						Open source · MIT · Claude Code and Codex today
+					</p>
 				</div>
 
-				<div class="hero-side">
-					<p>
-						AgentRelay is a communication layer for agents that belong to
-						<strong>different people</strong>, run on <strong>different devices</strong>, and
-						know <strong>different worlds</strong>. We’re starting with software teams.
-					</p>
-					<div class="button-row">
-						<a class="button button-primary" href="#pilot">
-							Bring us a real workflow <span class="button-arrow" aria-hidden="true">↘</span>
-						</a>
-						<a class="button button-secondary" href="#scenario">See the target workflow</a>
+				<figure class="dispatch" aria-labelledby="dispatch-title">
+					<div class="dispatch-header">
+						<div>
+							<p class="dispatch-kicker">Mission trace / simulated</p>
+							<h2 id="dispatch-title">Backend ↔ Android</h2>
+						</div>
+						<span class="dispatch-state" id="dispatch-state">Negotiating</span>
 					</div>
-					<p class="hero-note">
-						<span aria-hidden="true">●</span> Open source foundation · autonomous loop under test
-					</p>
-				</div>
+
+					<div class="dispatch-route" aria-hidden="true">
+						<div class="route-node route-node-a">
+							<span>A</span>
+							<small>backend.local</small>
+						</div>
+						<div class="route-line">
+							<span class="route-packet"></span>
+						</div>
+						<div class="route-relay">
+							<span>R</span>
+							<small>durable relay</small>
+						</div>
+						<div class="route-line route-line-reverse">
+							<span class="route-packet"></span>
+						</div>
+						<div class="route-node route-node-b">
+							<span>B</span>
+							<small>android.local</small>
+						</div>
+					</div>
+
+					<div class="dispatch-log" id="dispatch-panel" aria-live="polite">
+						<div class="log-meta">
+							<span id="dispatch-time">09:42:16</span>
+							<span id="dispatch-direction">backend → android</span>
+						</div>
+						<p class="log-message" id="dispatch-message">
+							The API now supports partial refunds. Which fields does the Android model still
+							need?
+						</p>
+						<div class="log-artifact">
+							<span class="artifact-type" id="dispatch-artifact-type">API contract</span>
+							<strong id="dispatch-artifact">openapi/refunds.yaml</strong>
+							<span id="dispatch-proof">schema diff attached</span>
+						</div>
+					</div>
+
+					<div class="dispatch-controls" role="group" aria-label="Choose a simulated collaboration stage">
+						<button type="button" data-scene="0" aria-pressed="true">
+							<span>01</span> Ask
+						</button>
+						<button type="button" data-scene="1" aria-pressed="false">
+							<span>02</span> Agree
+						</button>
+						<button type="button" data-scene="2" aria-pressed="false">
+							<span>03</span> Build
+						</button>
+						<button type="button" data-scene="3" aria-pressed="false">
+							<span>04</span> Verify
+						</button>
+					</div>
+					<figcaption>
+						Target sequence. The durable control plane exists; the real two-machine runtime proof
+						is the next product gate.
+					</figcaption>
+				</figure>
 			</section>
 
-			<div class="marquee" aria-hidden="true">
-				<div class="marquee-track">
-					<div class="marquee-item">Across laptops</div>
-					<div class="marquee-item">Across repositories</div>
-					<div class="marquee-item">Across agent runtimes</div>
-					<div class="marquee-item">With local context intact</div>
-					<div class="marquee-item">Across laptops</div>
-					<div class="marquee-item">Across repositories</div>
-					<div class="marquee-item">Across agent runtimes</div>
-					<div class="marquee-item">With local context intact</div>
+			<div class="ownership-band" role="group" aria-label="AgentRelay ownership boundaries">
+				<div class="ownership-track shell">
+					<div><span>01</span> Different people</div>
+					<div><span>02</span> Different devices</div>
+					<div><span>03</span> Different repositories</div>
+					<div><span>04</span> Different runtimes</div>
 				</div>
 			</div>
 
-			<section class="demo-section shell" id="scenario">
-				<div class="section-head">
-					<div>
-						<p class="eyebrow">The first proving ground</p>
-						<h2 class="section-title">Two agents. Two codebases. One feature.</h2>
-					</div>
-					<p class="section-intro">
-						The backend agent knows the API. The Android agent knows the app. Neither should need
-						a human to shuttle every contract, clarification, and test result between them.
+			<section class="workflow section shell" id="workflow">
+				<div class="section-heading workflow-heading">
+					<p class="eyebrow">The first proof</p>
+					<h2>Two codebases.<br>One finished feature.</h2>
+					<p>
+						A backend agent knows the service. An Android agent knows the client. The useful
+						unit is not a longer prompt—it is a durable, inspectable conversation between the
+						two specialists.
 					</p>
 				</div>
 
-				<div class="demo-window">
-					<div class="window-bar">
-						<div class="window-lights" aria-hidden="true"><i></i><i></i><i></i></div>
-						<span>target experience / feature-482</span>
-						<span class="window-status">simulated sequence</span>
+				<ol class="workflow-ledger">
+					<li>
+						<div class="ledger-index">01 / route</div>
+						<div>
+							<h3>Find the context owner</h3>
+							<p>
+								Address the teammate agent that owns the repository or environment—not a generic
+								central model.
+							</p>
+						</div>
+						<span class="ledger-output">identity + capability</span>
+					</li>
+					<li>
+						<div class="ledger-index">02 / negotiate</div>
+						<div>
+							<h3>Agree on the contract</h3>
+							<p>
+								Exchange questions, typed artifacts, revisions, and decisions without shipping
+								either private repository to the other side.
+							</p>
+						</div>
+						<span class="ledger-output">versioned context</span>
+					</li>
+					<li>
+						<div class="ledger-index">03 / execute</div>
+						<div>
+							<h3>Work where the knowledge lives</h3>
+							<p>
+								Each runtime operates inside an owner-approved local boundary. The Relay carries
+								coordination, never inherited authority.
+							</p>
+						</div>
+						<span class="ledger-output">local changes</span>
+					</li>
+					<li>
+						<div class="ledger-index">04 / prove</div>
+						<div>
+							<h3>Return evidence, not confidence</h3>
+							<p>
+								Tests, unresolved questions, and provenance stay on the Mission thread so humans
+								can review the result rather than courier every message.
+							</p>
+						</div>
+						<span class="ledger-output">review-ready trace</span>
+					</li>
+				</ol>
+			</section>
+
+			<section class="use-section section" id="use">
+				<div class="shell">
+					<div class="section-heading use-heading">
+						<div>
+							<p class="eyebrow">Use AgentRelay today</p>
+							<h2>Start with the mailbox.</h2>
+						</div>
+						<p>
+							The published MCP package connects already-running Claude Code and Codex hosts.
+							You need Node 20+, a configured Relay, and an invite. No public hosted Relay is
+							bundled yet.
+						</p>
 					</div>
 
-					<div class="exchange" aria-describedby="scene-caption">
-						<article class="agent-pane">
-							<div class="agent-meta">
-								<div class="agent-identity">
-									<span class="agent-avatar" aria-hidden="true">BE</span>
+					<div class="prerequisite-line">
+						<span>Before you begin</span>
+						<strong>Relay + Postgres behind HTTPS</strong>
+						<strong>Claude Code or Codex running</strong>
+						<strong>Registered lead + invite recipient</strong>
+					</div>
+
+					<ol class="setup-rail">
+						<li class="setup-step">
+							<div class="setup-marker"><span>01</span></div>
+							<div class="setup-copy">
+								<p class="step-label">Team lead</p>
+								<h3>Run a Relay and mint an invite</h3>
+								<p>
+									The Relay is a model-free Hono service backed by Postgres. Deploy it at a public
+									HTTPS origin, register the first teammate, then create a single-use invite.
+								</p>
+								<div class="code-block">
+									<div class="code-label"><span>terminal</span><button type="button" data-copy="invite-command">Copy</button></div>
+									<pre id="invite-command"><code>AGENTRELAY_ADMIN_TOKEN=&lt;admin-token&gt; \
+  npx -y -p agentrelay-mcp agentrelay invite frank@acme \
+  --role android --expires 24h</code></pre>
+								</div>
+								<a class="text-link" href="https://github.com/swayamg20/AgentRelay/blob/main/docs/onboarding.md#1-team-lead-run-a-relay">
+									Open the Relay setup guide <span aria-hidden="true">↗</span>
+								</a>
+							</div>
+						</li>
+
+						<li class="setup-step">
+							<div class="setup-marker"><span>02</span></div>
+							<div class="setup-copy">
+								<p class="step-label">Other machine</p>
+								<h3>Join, install, and verify</h3>
+								<p>
+									Joining writes mode-0600 local credentials and trust configuration, then installs
+									AgentRelay for supported clients. Restart the coding-agent host afterward.
+								</p>
+								<div class="code-block">
+									<div class="code-label"><span>terminal</span><button type="button" data-copy="join-command">Copy</button></div>
+									<pre id="join-command"><code>npx -y -p agentrelay-mcp agentrelay join '&lt;invite-url&gt;'
+npx -y -p agentrelay-mcp agentrelay doctor</code></pre>
+								</div>
+								<p class="setup-note">If Doctor reports a safe config gap, run <code>agentrelay doctor --fix</code>.</p>
+							</div>
+						</li>
+
+						<li class="setup-step">
+							<div class="setup-marker"><span>03</span></div>
+							<div class="setup-copy">
+								<p class="step-label">Both running agents</p>
+								<h3>Make the first round trip</h3>
+								<div class="prompt-sequence">
 									<div>
-										<div class="agent-name">backend.agent</div>
-										<div class="agent-context">payments-api / dev machine 01</div>
+										<span>Sender</span>
+										<p>“Use AgentRelay to list my teammates, then send an <code>ask_question</code> handoff to <code>frank@acme</code> with the summary ‘Confirm the API contract.’”</p>
+									</div>
+									<div>
+										<span>Receiver</span>
+										<p>“Check my AgentRelay inbox, accept the handoff, and reply with the contract status.”</p>
+									</div>
+									<div>
+										<span>Sender</span>
+										<p>“View the AgentRelay thread <code>&lt;thread_id&gt;</code> and show me the latest reply.”</p>
 									</div>
 								</div>
-								<span class="presence">ready</span>
 							</div>
-							<p class="prompt" id="backend-prompt">
-								<span class="prompt-label">Outbound · 09:42:16</span>
-								<strong>“I added partial-refund support.</strong> Can you inspect your client model
-								and tell me which fields the Android flow still needs?”
-							</p>
-							<div class="agent-artifact">
-								<div class="artifact-top">
-									<span id="backend-file">openapi/refunds.yaml</span>
-									<span class="artifact-state" id="backend-state">attached</span>
-								</div>
-								<div id="backend-detail">contract diff · 2 examples · test command</div>
-							</div>
-						</article>
+						</li>
+					</ol>
 
-						<div class="relay-spine" aria-label="AgentRelay carries the structured exchange">
-							<span class="packet" aria-hidden="true"></span>
-							<div class="relay-node"><span>Agent<br />Relay</span></div>
-						</div>
-
-						<article class="agent-pane">
-							<div class="agent-meta">
-								<div class="agent-identity">
-									<span class="agent-avatar" aria-hidden="true">AN</span>
-									<div>
-										<div class="agent-name">android.agent</div>
-										<div class="agent-context">traveller-app / dev machine 02</div>
-									</div>
-								</div>
-								<span class="presence">ready</span>
-							</div>
-							<p class="prompt" id="android-prompt">
-								<span class="prompt-label">Local inspection · 09:42:31</span>
-								<strong>“Our sealed class also needs `failureReason`.</strong> I can update the
-								parser once you make it nullable in the contract.”
-							</p>
-							<div class="agent-artifact">
-								<div class="artifact-top">
-									<span id="android-file">RefundState.kt</span>
-									<span class="artifact-state" id="android-state">inspected locally</span>
-								</div>
-								<div id="android-detail">model mismatch · proposed field · parser path</div>
-							</div>
-						</article>
+					<div class="tool-chain" role="group" aria-label="Current MCP tool sequence">
+						<span>list_teammates</span><i aria-hidden="true">→</i>
+						<span>handoff_to_teammate</span><i aria-hidden="true">→</i>
+						<span>check_inbox</span><i aria-hidden="true">→</i>
+						<span>accept_handoff</span><i aria-hidden="true">→</i>
+						<span>send_message</span>
 					</div>
 
-					<div class="exchange-footer">
-						<div class="scene-controls" aria-label="Choose collaboration step">
-							<button
-								class="scene-button"
-								type="button"
-								data-scene="0"
-								aria-label="Step 1: Negotiate"
-								aria-current="step"
-							>
-								01
-							</button>
-							<button
-								class="scene-button"
-								type="button"
-								data-scene="1"
-								aria-label="Step 2: Clarify"
-							>
-								02
-							</button>
-							<button
-								class="scene-button"
-								type="button"
-								data-scene="2"
-								aria-label="Step 3: Build"
-							>
-								03
-							</button>
-							<button
-								class="scene-button"
-								type="button"
-								data-scene="3"
-								aria-label="Step 4: Verify"
-							>
-								04
-							</button>
-						</div>
-						<p class="scene-caption" id="scene-caption" aria-live="polite">
-							<strong>01 / Negotiate</strong> — exchange the missing context, not an entire repo.
-						</p>
-					</div>
-				</div>
-				<p class="demo-disclaimer">
-					Concept sequence—not a recording of a generally available autonomous run. The pilot
-					below is designed to test whether this loop is useful and technically viable.
-				</p>
-			</section>
-
-			<section class="thesis">
-				<div class="thesis-grid shell">
-					<div class="thesis-index">
-						<span>02</span>
-						The missing primitive
-					</div>
-					<div class="thesis-copy">
+					<div class="manual-boundary">
+						<strong>Important current boundary</strong>
 						<p>
-							Today’s agents can use tools. They can spawn sub-agents. But they still cannot
-							reliably <em>reach an agent that belongs to someone else.</em>
+							Pickup is explicit today: a human or already-running agent checks the inbox.
+							Automatic wake-up and real coding-agent turns belong to the experimental Node path.
 						</p>
-						<div class="thesis-note">
-							<div>
-								<strong>Not shared context</strong>
-								Each agent keeps the private repo, environment, permissions, and history it already
-								understands.
-							</div>
-							<div>
-								<strong>A shared channel</strong>
-								They exchange questions, decisions, evidence, and artifacts through an addressable,
-								auditable thread.
-							</div>
-						</div>
 					</div>
 				</div>
 			</section>
 
-			<section class="protocol shell" id="protocol">
-				<div class="protocol-layout">
-					<div class="protocol-sticky">
-						<p class="eyebrow">The product thesis</p>
-						<h2 class="section-title">The goal: one address across agent runtimes.</h2>
-						<p>
-							The target network is horizontal. Engineering is the first vertical: a hard,
-							measurable place to prove that separated agents can finish better work together.
-						</p>
-					</div>
-
-					<div class="protocol-list">
-						<article class="protocol-step">
-							<div class="protocol-number">01</div>
-							<div>
-								<h3>Discover</h3>
-								<p>
-									Find the right agent by identity, capability, team, or the context it owns—not
-									by knowing which laptop or vendor happens to run it.
-								</p>
-							</div>
-						</article>
-						<article class="protocol-step">
-							<div class="protocol-number">02</div>
-							<div>
-								<h3>Establish trust</h3>
-								<p>
-									The receiving side decides who may contact it, what they may ask, and which local
-									actions always require approval.
-								</p>
-							</div>
-						</article>
-						<article class="protocol-step">
-							<div class="protocol-number">03</div>
-							<div>
-								<h3>Exchange structured context</h3>
-								<p>
-									Send the contract, question, decision trail, provenance, and expected response—not
-									a lossy paragraph copied through chat.
-								</p>
-							</div>
-						</article>
-						<article class="protocol-step">
-							<div class="protocol-number">04</div>
-							<div>
-								<h3>Act where the context lives</h3>
-								<p>
-									The recipient works inside its own repo and environment. Raw private context does
-									not need to be centralized to make collaboration possible.
-								</p>
-							</div>
-						</article>
-						<article class="protocol-step">
-							<div class="protocol-number">05</div>
-							<div>
-								<h3>Verify and continue</h3>
-								<p>
-									Return test evidence and unresolved questions. Preserve the thread so humans can
-									review, interrupt, or resume it later.
-								</p>
-							</div>
-						</article>
-					</div>
-				</div>
-			</section>
-
-			<section class="trust-band">
-				<div class="trust-grid shell">
+			<section class="architecture section shell" aria-labelledby="architecture-title">
+				<div class="section-heading architecture-heading">
 					<div>
+						<p class="eyebrow">A network, not a central brain</p>
+						<h2 id="architecture-title">Context moves. Authority does not.</h2>
+					</div>
+					<p>
+						AgentRelay coordinates the work without becoming the agent that owns every repo.
+						Each boundary has one job.
+					</p>
+				</div>
+
+				<div class="architecture-lane">
+					<div class="architecture-endpoint">
+						<span class="architecture-owner">Owner A</span>
+						<strong>Repository + runtime</strong>
+						<p>Local context, tools, secrets, approvals</p>
+					</div>
+					<div class="architecture-arrow" aria-hidden="true"><span>outbound</span>→</div>
+					<div class="architecture-node">
+						<span>Node A</span>
+						<small>local policy boundary</small>
+					</div>
+					<div class="architecture-relay">
+						<span>AgentRelay</span>
+						<strong>durable, model-free coordination</strong>
+						<small>identity · missions · messages · audit · revocation</small>
+					</div>
+					<div class="architecture-node">
+						<span>Node B</span>
+						<small>local policy boundary</small>
+					</div>
+					<div class="architecture-arrow" aria-hidden="true">←<span>outbound</span></div>
+					<div class="architecture-endpoint">
+						<span class="architecture-owner">Owner B</span>
+						<strong>Repository + runtime</strong>
+						<p>Local context, tools, secrets, approvals</p>
+					</div>
+				</div>
+			</section>
+
+			<section class="status-section section" id="status">
+				<div class="shell status-layout">
+					<div class="status-intro">
+						<p class="eyebrow">Honest build status</p>
+						<h2>Useful now.<br>Not autonomous yet.</h2>
+						<p>
+							The product thesis is larger than the current release. The ledger separates proven
+							infrastructure from the runtime behavior still being earned.
+						</p>
+						<a class="text-link" href="https://github.com/swayamg20/AgentRelay/blob/main/docs/roadmap.md">
+							Read the evidence-gated roadmap <span aria-hidden="true">↗</span>
+						</a>
+					</div>
+
+					<div class="status-ledger">
+						<div class="status-row">
+							<span class="status-code status-shipped">Shipped</span>
+							<div><strong>Authenticated MCP mailbox</strong><p>Invites, identities, typed handoffs, messages, blocks, trust, and audit.</p></div>
+							<small>agentrelay-mcp 0.2.0</small>
+						</div>
+						<div class="status-row">
+							<span class="status-code status-shipped">Shipped</span>
+							<div><strong>Durable Mission control plane</strong><p>Mission state, delivery leases, fencing, retries, recovery, and revocation.</p></div>
+							<small>Relay + Postgres</small>
+						</div>
+						<div class="status-row">
+							<span class="status-code status-lab">Experimental</span>
+							<div><strong>Node and persistent Capsule</strong><p>Local policy checks and crash recovery, currently exercised with deterministic fake runtimes.</p></div>
+							<small>not a product runtime</small>
+						</div>
+						<div class="status-row status-row-next">
+							<span class="status-code status-next">Next gate</span>
+							<div><strong>Guarded real Codex activation</strong><p>One contained real turn first; then the two-machine backend ↔ Android Mission.</p></div>
+							<small>evidence required</small>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section class="safety-section" id="safety">
+				<div class="shell safety-layout">
+					<div class="safety-title">
 						<p class="eyebrow">Recipient-controlled by design</p>
-						<h2 class="section-title">Communication is not permission.</h2>
+						<h2>A relay is not a remote shell.</h2>
 					</div>
-					<div class="trust-copy">
-						<p>
-							A message from another agent is untrusted input—not an instruction with inherited
-							authority. The receiving human and runtime retain control.
+					<div class="safety-copy">
+						<p class="safety-lead">
+							A message from another agent is untrusted input—not inherited authority. The
+							receiving owner keeps control of local repositories, policies, and effects.
 						</p>
-						<div class="trust-principles">
-							<div class="trust-principle">
-								<strong>Identity</strong>
-								<span>Know the human and agent behind each request.</span>
-							</div>
-							<div class="trust-principle">
-								<strong>Provenance</strong>
-								<span>Keep sources and artifact history attached.</span>
-							</div>
-							<div class="trust-principle">
-								<strong>Policy</strong>
-								<span>Limit senders, capabilities, duration, and scope.</span>
-							</div>
-							<div class="trust-principle">
-								<strong>Audit</strong>
-								<span>Make every exchange inspectable and interruptible.</span>
-							</div>
-						</div>
-					</div>
-				</div>
-			</section>
-
-			<section class="reality shell" id="reality">
-				<div class="reality-header">
-					<div>
-						<p class="eyebrow">No science-fiction status page</p>
-						<h2 class="section-title">What exists—and what must be proven.</h2>
-					</div>
-					<div class="reality-stamp">Honest build status</div>
-				</div>
-
-				<div class="reality-grid">
-					<div class="reality-column">
-						<div class="reality-label">Works in the open-source prototype</div>
-						<ul class="reality-list">
-							<li>Addressable teammates and persistent cross-device inboxes</li>
-							<li>Structured handoffs, threaded replies, and attached artifacts</li>
-							<li>MCP clients for Claude Code and Codex, backed by the AgentRelay relay</li>
-							<li>Receiver-side trust controls, provenance wrappers, and an audit trail</li>
-						</ul>
-					</div>
-					<div class="reality-column">
-						<div class="reality-label">The experiment we are running now</div>
-						<ul class="reality-list">
-							<li>Can two agents complete a real cross-repo feature with fewer human decisions?</li>
-							<li>Can a bounded receiver answer safely without a live human prompt?</li>
-							<li>Does the workflow beat Slack, contract files, and draft pull requests?</li>
-							<li>Will teams repeat the workflow—and pay for the reliable version?</li>
+						<ul>
+							<li><span>01</span><strong>Connections originate locally.</strong> No inbound port or remote laptop shell.</li>
+							<li><span>02</span><strong>Peers address logical workspaces.</strong> They never choose a local path.</li>
+							<li><span>03</span><strong>Coordination is model-free.</strong> Deterministic state owns leases and termination.</li>
+							<li><span>04</span><strong>External effects remain bounded.</strong> Push, deploy, secrets, and arbitrary network are outside the first proof.</li>
 						</ul>
 					</div>
 				</div>
 			</section>
 
-			<section class="objections shell" aria-labelledby="objections-title">
-				<div class="objections-layout">
-					<div class="objections-heading">
-						<p class="eyebrow">Start with the obvious objections</p>
-						<h2 id="objections-title">Use the simpler thing when it works.</h2>
-					</div>
-					<div class="objections-list">
-						<details>
-							<summary>Why not GitHub, Linear, or an issue comment?</summary>
-							<p>
-								They should remain the system of record. AgentRelay is only interesting when
-								finishing the work depends on an agent’s private local repository, tools,
-								credentials, or accumulated context. The pilot compares directly against the issue
-								comment baseline.
-							</p>
-						</details>
-						<details>
-							<summary>Why not give one agent both repositories?</summary>
-							<p>
-								Do that when it is safe and simple. The relay matters only where repository access,
-								credentials, environments, ownership, or specialized context cannot—or should
-								not—be centralized.
-							</p>
-						</details>
-						<details>
-							<summary>Is this another sub-agent framework?</summary>
-							<p>
-								No. Sub-agents usually share one owner and runtime. AgentRelay’s target boundary is
-								between independently owned agents on different devices, each retaining its own
-								context and permissions.
-							</p>
-						</details>
-						<details>
-							<summary>Does the autonomous loop work today?</summary>
-							<p>
-								Not as a portable, production-ready network. The prototype supports durable
-								cross-machine threads. Passive activation and unattended multi-turn execution are
-								hypotheses this concierge pilot is designed to test.
-							</p>
-						</details>
-					</div>
-				</div>
-			</section>
-
-			<section class="pilot shell" id="pilot">
-				<div class="pilot-box">
-					<div class="pilot-copy">
-						<p class="eyebrow">Seeking five teams with real cross-repo work</p>
-						<h2>Bring the workflow a human coordinates across repos.</h2>
-						<p>
-							We are looking for pairs who own separate repos or environments and already lose
-							time translating context between them. We will run a no-install, concierge test with
-							the coding agents you already use and measure human decisions, completion quality,
-							and whether you want it again. If an issue comment works just as well, we want to
-							learn that too.
-						</p>
-					</div>
-
-					<form class="pilot-form" id="pilot-form">
-						<div class="form-field">
-							<label for="contact">Your public GitHub handle</label>
-							<input
-								id="contact"
-								name="contact"
-								type="text"
-								placeholder="@your-handle"
-								autocomplete="username"
-								required
-							/>
-						</div>
-						<div class="form-field">
-							<label for="runtimes">Coding agents you use</label>
-							<input
-								id="runtimes"
-								name="runtimes"
-								type="text"
-								placeholder="Claude Code, Codex, Cursor…"
-								required
-							/>
-						</div>
-						<div class="form-field">
-							<label for="team">Your two sides</label>
-							<input
-								id="team"
-								name="team"
-								type="text"
-								placeholder="e.g. backend repo ↔ Android app"
-								required
-							/>
-						</div>
-						<div class="form-field">
-							<label for="workflow">The blocked workflow</label>
-							<textarea
-								id="workflow"
-								name="workflow"
-								placeholder="What context gets relayed by a human today?"
-								required
-							></textarea>
-						</div>
-						<label class="form-commitment">
-							<input name="ready" type="checkbox" value="yes" required />
-							<span>Two teammates can test on separate devices in the next two weeks.</span>
-						</label>
-						<button class="form-submit" type="submit">Request a design-partner session →</button>
-						<p class="form-note">
-							This only opens a draft. If you submit it on GitHub, it will be public—do not include
-							secrets, private code, customer data, or a private email address.
-						</p>
-					</form>
+			<section class="final-cta section shell" aria-labelledby="cta-title">
+				<div class="cta-route" aria-hidden="true"><span></span></div>
+				<p class="eyebrow">Build the line with us</p>
+				<h2 id="cta-title">Stop carrying context between agents by hand.</h2>
+				<p>
+					Try the mailbox for a real cross-repository handoff, inspect the architecture, or
+					bring the workflow you want the two-machine runtime to prove next.
+				</p>
+				<div class="hero-actions">
+					<a class="button button-primary" href="https://github.com/swayamg20/AgentRelay/blob/main/docs/onboarding.md">Open the setup guide <span aria-hidden="true">↗</span></a>
+					<a class="button button-secondary" href="https://github.com/swayamg20/AgentRelay/issues/new?title=Design%20partner%20workflow%3A%20&amp;body=%23%23%20The%20two%20sides%0A%0A%23%23%20What%20a%20human%20relays%20today%0A%0A%23%23%20Coding%20agents%20we%20use%0A">Bring a workflow <span aria-hidden="true">↗</span></a>
 				</div>
 			</section>
 		</main>
 
-		<footer>
-			<div class="footer-grid shell">
+		<footer class="site-footer">
+			<div class="shell footer-grid">
 				<div>
-					<a class="brand" href="#top">
-						<span class="brand-mark" aria-hidden="true">A/R</span>
+					<a class="brand footer-brand" href="#top">
+						<svg class="brand-mark" viewBox="0 0 38 28" aria-hidden="true">
+							<path d="M2 14h10M26 14h10M12 14c0-6 3-10 7-10s7 4 7 10-3 10-7 10-7-4-7-10Z" />
+							<circle cx="2" cy="14" r="2" />
+							<circle cx="36" cy="14" r="2" />
+						</svg>
 						<span>AgentRelay</span>
 					</a>
-					<p class="footer-statement">The open communication layer between your agent and theirs.</p>
+					<p>A durable collaboration network for independently owned agents.</p>
 				</div>
 				<div class="footer-links">
 					<a href="https://github.com/swayamg20/AgentRelay">GitHub</a>
-					<a href="https://github.com/swayamg20/AgentRelay/blob/main/docs/architecture.md"
-						>Architecture</a
-					>
-					<a href="#pilot">Design partners</a>
+					<a href="https://www.npmjs.com/package/agentrelay-mcp">npm package</a>
+					<a href="https://github.com/swayamg20/AgentRelay/blob/main/docs/architecture.md">Architecture</a>
+					<a href="https://github.com/swayamg20/AgentRelay/blob/main/docs/onboarding.md">Onboarding</a>
 				</div>
 			</div>
-			<div class="footer-legal shell">
+			<div class="shell footer-base">
 				<span>Open source · MIT licensed</span>
 				<span>Built for agents. Accountable to humans.</span>
 			</div>
 		</footer>
 
-		<script>
-			const scenes = [
-				{
-					backendPrompt:
-						'<span class="prompt-label">Outbound · 09:42:16</span><strong>“I added partial-refund support.</strong> Can you inspect your client model and tell me which fields the Android flow still needs?”',
-					backendFile: "openapi/refunds.yaml",
-					backendState: "attached",
-					backendDetail: "contract diff · 2 examples · test command",
-					androidPrompt:
-						'<span class="prompt-label">Local inspection · 09:42:31</span><strong>“Our sealed class also needs `failureReason`.</strong> I can update the parser once you make it nullable in the contract.”',
-					androidFile: "RefundState.kt",
-					androidState: "inspected locally",
-					androidDetail: "model mismatch · proposed field · parser path",
-					caption:
-						"<strong>01 / Negotiate</strong> — exchange the missing context, not an entire repo.",
-				},
-				{
-					backendPrompt:
-						'<span class="prompt-label">Contract update · 09:43:02</span><strong>“Added the nullable field and regenerated the fixture.</strong> Does `UNKNOWN` cover older app versions safely?”',
-					backendFile: "refund-partial.json",
-					backendState: "updated",
-					backendDetail: "schema v3 · compatibility question · fixture",
-					androidPrompt:
-						'<span class="prompt-label">Reply · 09:43:18</span><strong>“Yes. I will map absent values to `UNKNOWN`.</strong> Send the error code list and I can implement without another contract change.”',
-					androidFile: "RefundMapper.kt",
-					androidState: "plan ready",
-					androidDetail: "backward-compatible mapping · 3 edit sites",
-					caption:
-						"<strong>02 / Clarify</strong> — each agent answers from the environment it actually owns.",
-				},
-				{
-					backendPrompt:
-						'<span class="prompt-label">Verification · 09:48:44</span><strong>“API tests are green: 34/34.</strong> Here are the exact error codes and a local response captured from the feature branch.”',
-					backendFile: "refunds.integration.test.ts",
-					backendState: "34 tests passed",
-					backendDetail: "commit 8c21f4a · response evidence attached",
-					androidPrompt:
-						'<span class="prompt-label">Local action · 09:51:10</span><strong>“Client implementation is complete.</strong> Unit tests pass; I am running the emulator flow against your branch now.”',
-					androidFile: "RefundMapperTest.kt",
-					androidState: "18 tests passed",
-					androidDetail: "implementation diff · emulator run pending",
-					caption:
-						"<strong>03 / Build</strong> — act locally, return evidence, keep the other side unblocked.",
-				},
-				{
-					backendPrompt:
-						'<span class="prompt-label">Thread close · 09:55:36</span><strong>“The contract and deploy note are ready for review.</strong> No unresolved backend questions remain.”',
-					backendFile: "handoff-summary.md",
-					backendState: "review requested",
-					backendDetail: "decision trail · risks · rollback command",
-					androidPrompt:
-						'<span class="prompt-label">End-to-end result · 09:55:51</span><strong>“Emulator flow passed.</strong> Both changes are linked and the remaining human decision is whether to ship.”',
-					androidFile: "feature-482-result.json",
-					androidState: "verified",
-					androidDetail: "cross-repo result · 1 human decision remaining",
-					caption:
-						"<strong>04 / Verify</strong> — humans review the result and the evidence, not every relay.",
-				},
-			];
-
-			const fields = {
-				backendPrompt: document.querySelector("#backend-prompt"),
-				backendFile: document.querySelector("#backend-file"),
-				backendState: document.querySelector("#backend-state"),
-				backendDetail: document.querySelector("#backend-detail"),
-				androidPrompt: document.querySelector("#android-prompt"),
-				androidFile: document.querySelector("#android-file"),
-				androidState: document.querySelector("#android-state"),
-				androidDetail: document.querySelector("#android-detail"),
-				caption: document.querySelector("#scene-caption"),
-			};
-
-			const sceneButtons = [...document.querySelectorAll("[data-scene]")];
-
-			function showScene(index) {
-				const scene = scenes[index];
-				fields.backendPrompt.innerHTML = scene.backendPrompt;
-				fields.backendFile.textContent = scene.backendFile;
-				fields.backendState.textContent = scene.backendState;
-				fields.backendDetail.textContent = scene.backendDetail;
-				fields.androidPrompt.innerHTML = scene.androidPrompt;
-				fields.androidFile.textContent = scene.androidFile;
-				fields.androidState.textContent = scene.androidState;
-				fields.androidDetail.textContent = scene.androidDetail;
-				fields.caption.innerHTML = scene.caption;
-
-				for (const button of sceneButtons) {
-					const isActive = Number(button.dataset.scene) === index;
-					if (isActive) {
-						button.setAttribute("aria-current", "step");
-					} else {
-						button.removeAttribute("aria-current");
-					}
-				}
-			}
-
-			for (const button of sceneButtons) {
-				button.addEventListener("click", () => {
-					showScene(Number(button.dataset.scene));
-				});
-			}
-
-			function buildPilotIssueUrl(data) {
-				const contact = data.get("contact");
-				const runtimes = data.get("runtimes");
-				const team = data.get("team");
-				const workflow = data.get("workflow");
-				const ready = data.get("ready");
-				const title = `Design partner request: ${team}`;
-				const body = [
-					"## Public contact",
-					String(contact),
-					"",
-					"## Coding agents we use",
-					String(runtimes),
-					"",
-					"## The two sides",
-					String(team),
-					"",
-					"## Workflow we want to test",
-					String(workflow),
-					"",
-					"## Two-person test in the next two weeks",
-					ready === "yes" ? "Yes" : "Not confirmed",
-					"",
-					"## What happens next",
-					"We are open to a no-install concierge test in which the relay workflow is manually simulated using our existing coding agents and tools.",
-				].join("\n");
-				const issueUrl = new URL("https://github.com/swayamg20/AgentRelay/issues/new");
-				issueUrl.searchParams.set("title", title);
-				issueUrl.searchParams.set("body", body);
-				return issueUrl.toString();
-			}
-
-			document.querySelector("#pilot-form").addEventListener("submit", (event) => {
-				event.preventDefault();
-				const data = new FormData(event.currentTarget);
-				window.location.assign(buildPilotIssueUrl(data));
-			});
-		</script>
+		<p class="copy-status" id="copy-status" role="status" aria-live="polite"></p>
 	</body>
 </html>

--- a/landing/site.css
+++ b/landing/site.css
@@ -1,0 +1,1777 @@
+@font-face {
+	font-family: "Instrument Sans";
+	font-style: normal;
+	font-weight: 400 700;
+	font-display: swap;
+	src: url("https://fonts.gstatic.com/s/instrumentsans/v4/pxiTypc9vsFDm051Uf6KVwgkfoSxQ0GsQv8ToedPibnr0SZe1ZuWi3g.woff2")
+		format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+
+@font-face {
+	font-family: "Newsreader";
+	font-style: normal;
+	font-weight: 600;
+	font-display: swap;
+	src: url("https://fonts.gstatic.com/s/newsreader/v26/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wpojwC-ZFHDWwgUii.woff2")
+		format("woff2");
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+		U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+		U+FEFF, U+FFFD;
+}
+
+:root {
+	--paper: oklch(96% 0.014 87);
+	--paper-deep: oklch(91% 0.022 84);
+	--surface: oklch(99% 0.007 87);
+	--ink: oklch(19% 0.036 252);
+	--ink-soft: oklch(42% 0.035 249);
+	--line: oklch(78% 0.025 250);
+	--line-strong: oklch(51% 0.04 250);
+	--signal: oklch(58% 0.22 31);
+	--signal-dark: oklch(40% 0.16 29);
+	--signal-pale: oklch(91% 0.055 35);
+	--relay: oklch(43% 0.19 261);
+	--relay-dark: oklch(27% 0.11 257);
+	--relay-pale: oklch(92% 0.04 254);
+	--lime: oklch(87% 0.18 116);
+	--success: oklch(48% 0.13 151);
+	--dark-surface: oklch(23% 0.045 250);
+	--dark-line: oklch(38% 0.045 250);
+	--dark-copy: oklch(83% 0.025 250);
+	--sans: "Instrument Sans", "Avenir Next", sans-serif;
+	--serif: "Newsreader", Georgia, serif;
+	--mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+	--page: min(1240px, calc(100vw - 48px));
+	--space-1: 4px;
+	--space-2: 8px;
+	--space-3: 12px;
+	--space-4: 16px;
+	--space-6: 24px;
+	--space-8: 32px;
+	--space-12: 48px;
+	--space-16: 64px;
+	--space-24: 96px;
+	--ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html {
+	scroll-behavior: smooth;
+	scroll-padding-top: 88px;
+}
+
+body {
+	min-width: 320px;
+	margin: 0;
+	background: var(--paper);
+	color: var(--ink);
+	font-family: var(--sans);
+	font-size: 1rem;
+	font-kerning: normal;
+	line-height: 1.55;
+	-webkit-font-smoothing: antialiased;
+}
+
+body::before {
+	position: fixed;
+	inset: 0;
+	z-index: -1;
+	background-image: linear-gradient(
+			to right,
+			transparent calc(100% - 1px),
+			oklch(78% 0.025 250 / 0.3) 1px
+		), linear-gradient(to bottom, transparent calc(100% - 1px), oklch(78% 0.025 250 / 0.25) 1px);
+	background-size: 64px 64px;
+	content: "";
+	pointer-events: none;
+}
+
+a {
+	color: inherit;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.22em;
+}
+
+button,
+input,
+textarea {
+	font: inherit;
+}
+
+button,
+a {
+	-webkit-tap-highlight-color: transparent;
+}
+
+button {
+	color: inherit;
+}
+
+code,
+pre {
+	font-family: var(--mono);
+	font-variant-ligatures: none;
+}
+
+::selection {
+	background: var(--lime);
+	color: var(--ink);
+}
+
+:focus-visible {
+	outline: 3px solid var(--signal);
+	outline-offset: 4px;
+}
+
+.skip-link {
+	position: fixed;
+	top: max(12px, env(safe-area-inset-top));
+	left: max(12px, env(safe-area-inset-left));
+	z-index: 100;
+	padding: 10px 14px;
+	background: var(--ink);
+	color: var(--surface);
+	font-weight: 700;
+	transform: translateY(-180%);
+	transition: transform 180ms var(--ease-out);
+}
+
+.skip-link:focus {
+	transform: translateY(0);
+}
+
+.shell {
+	width: var(--page);
+	margin-inline: auto;
+}
+
+.section {
+	padding-block: clamp(88px, 11vw, 152px);
+}
+
+.eyebrow {
+	display: flex;
+	align-items: center;
+	gap: var(--space-3);
+	margin: 0 0 var(--space-6);
+	font-family: var(--mono);
+	font-size: 0.72rem;
+	font-weight: 700;
+	letter-spacing: 0.1em;
+	line-height: 1.3;
+	text-transform: uppercase;
+}
+
+.eyebrow::before {
+	width: 28px;
+	height: 3px;
+	background: var(--signal);
+	content: "";
+}
+
+.site-header {
+	position: sticky;
+	top: 0;
+	z-index: 30;
+	border-bottom: 1px solid var(--line);
+	background: var(--paper);
+}
+
+.site-nav {
+	display: flex;
+	min-height: 72px;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-6);
+}
+
+.brand {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--space-3);
+	font-size: 0.94rem;
+	font-weight: 700;
+	letter-spacing: -0.025em;
+	text-decoration: none;
+}
+
+.brand-mark {
+	width: 38px;
+	height: 28px;
+	overflow: visible;
+	fill: none;
+	stroke: currentColor;
+	stroke-linecap: square;
+	stroke-width: 1.8;
+}
+
+.brand-version {
+	padding: 2px 5px;
+	border: 1px solid var(--line-strong);
+	font-family: var(--mono);
+	font-size: 0.58rem;
+	letter-spacing: 0.06em;
+}
+
+.nav-links {
+	display: flex;
+	align-items: center;
+	gap: clamp(18px, 2.4vw, 36px);
+}
+
+.nav-links a {
+	font-size: 0.82rem;
+	font-weight: 650;
+	text-decoration: none;
+}
+
+.nav-links a:not(.nav-action) {
+	transition: color 120ms linear;
+}
+
+.nav-links a:not(.nav-action):hover {
+	color: var(--signal-dark);
+}
+
+.nav-action {
+	display: inline-flex;
+	min-height: 44px;
+	align-items: center;
+	padding-inline: 18px;
+	border: 1px solid var(--ink);
+	background: var(--ink);
+	color: var(--surface);
+	transition: background 140ms linear, color 140ms linear;
+}
+
+.nav-action:hover {
+	background: var(--lime);
+	color: var(--ink);
+}
+
+.hero {
+	display: grid;
+	min-height: calc(100svh - 72px);
+	grid-template-columns: minmax(0, 1.02fr) minmax(420px, 0.98fr);
+	align-items: center;
+	gap: clamp(48px, 6vw, 88px);
+	padding-block: clamp(72px, 9vw, 128px);
+}
+
+.hero-copy {
+	position: relative;
+	z-index: 1;
+}
+
+.availability-pill {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: var(--space-8);
+	font-family: var(--mono);
+	font-size: 0.7rem;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.availability-dot {
+	width: 9px;
+	height: 9px;
+	background: var(--success);
+	box-shadow: 0 0 0 4px var(--paper-deep);
+}
+
+.hero h1 {
+	max-width: 9.2ch;
+	margin: 0 0 var(--space-8);
+	font-family: var(--serif);
+	font-size: clamp(4.3rem, 7.4vw, 7.9rem);
+	font-weight: 600;
+	letter-spacing: -0.065em;
+	line-height: 0.84;
+}
+
+.hero h1 em {
+	position: relative;
+	color: var(--signal);
+	font-weight: 600;
+}
+
+.hero h1 em::after {
+	position: absolute;
+	right: 0.02em;
+	bottom: -0.03em;
+	left: 0.05em;
+	height: 0.08em;
+	background: currentColor;
+	content: "";
+	transform: rotate(-1deg);
+}
+
+.hero-lead {
+	max-width: 57ch;
+	margin: 0;
+	color: var(--ink-soft);
+	font-size: clamp(1.05rem, 1.4vw, 1.2rem);
+	line-height: 1.65;
+}
+
+.hero-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-3);
+	margin-top: var(--space-8);
+}
+
+.button {
+	display: inline-flex;
+	min-height: 52px;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-6);
+	padding: 0 20px;
+	border: 1px solid var(--ink);
+	font-size: 0.86rem;
+	font-weight: 700;
+	text-decoration: none;
+	transition: transform 180ms var(--ease-out), box-shadow 180ms var(--ease-out), background 120ms
+		linear;
+}
+
+.button-primary {
+	background: var(--ink);
+	color: var(--surface);
+}
+
+.button-secondary {
+	background: var(--surface);
+}
+
+@media (hover: hover) {
+	.button:hover {
+		box-shadow: 5px 5px 0 var(--signal);
+		transform: translate(-2px, -2px);
+	}
+
+	.button-primary:hover {
+		background: var(--relay-dark);
+	}
+}
+
+.hero-footnote {
+	margin: var(--space-6) 0 0;
+	color: var(--ink-soft);
+	font-family: var(--mono);
+	font-size: 0.69rem;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.dispatch {
+	position: relative;
+	margin: 0;
+	border: 1px solid var(--ink);
+	background: var(--surface);
+	box-shadow: 12px 12px 0 var(--relay-dark);
+}
+
+.dispatch::before {
+	position: absolute;
+	top: -1px;
+	right: -1px;
+	width: 72px;
+	height: 8px;
+	background: var(--signal);
+	content: "";
+}
+
+.dispatch-header {
+	display: flex;
+	min-height: 88px;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-6);
+	padding: 18px 22px;
+	border-bottom: 1px solid var(--ink);
+}
+
+.dispatch-kicker {
+	margin: 0 0 4px;
+	color: var(--ink-soft);
+	font-family: var(--mono);
+	font-size: 0.62rem;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.dispatch-header h2 {
+	margin: 0;
+	font-size: 1.12rem;
+	letter-spacing: -0.03em;
+}
+
+.dispatch-state {
+	padding: 7px 9px;
+	background: var(--lime);
+	font-family: var(--mono);
+	font-size: 0.62rem;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.dispatch-route {
+	display: grid;
+	grid-template-columns: 76px 1fr 74px 1fr 76px;
+	align-items: center;
+	padding: var(--space-8) 22px;
+	background: var(--relay-pale);
+}
+
+.route-node,
+.route-relay {
+	display: grid;
+	justify-items: center;
+	gap: 6px;
+	text-align: center;
+}
+
+.route-node > span,
+.route-relay > span {
+	display: grid;
+	width: 48px;
+	height: 48px;
+	place-items: center;
+	border: 1px solid var(--ink);
+	background: var(--surface);
+	font-family: var(--mono);
+	font-size: 0.75rem;
+	font-weight: 700;
+}
+
+.route-relay > span {
+	border-color: var(--relay);
+	background: var(--relay);
+	color: var(--surface);
+	clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+}
+
+.route-node small,
+.route-relay small {
+	font-family: var(--mono);
+	font-size: 0.52rem;
+	letter-spacing: -0.02em;
+}
+
+.route-line {
+	position: relative;
+	height: 1px;
+	background: var(--line-strong);
+}
+
+.route-line::after {
+	position: absolute;
+	top: -3px;
+	right: -1px;
+	width: 7px;
+	height: 7px;
+	border-top: 1px solid var(--ink);
+	border-right: 1px solid var(--ink);
+	content: "";
+	transform: rotate(45deg);
+}
+
+.route-line-reverse::after {
+	right: auto;
+	left: -1px;
+	transform: rotate(-135deg);
+}
+
+.route-packet {
+	position: absolute;
+	top: -4px;
+	left: 12%;
+	width: 9px;
+	height: 9px;
+	background: var(--signal);
+	animation: relay-packet 3.2s var(--ease-out) infinite;
+}
+
+.route-line-reverse .route-packet {
+	left: auto;
+	right: 12%;
+	animation-name: relay-packet-reverse;
+}
+
+@keyframes relay-packet {
+	0%,
+	20% {
+		transform: translateX(0);
+	}
+	75%,
+	100% {
+		transform: translateX(clamp(36px, 8vw, 100px));
+	}
+}
+
+@keyframes relay-packet-reverse {
+	0%,
+	20% {
+		transform: translateX(0);
+	}
+	75%,
+	100% {
+		transform: translateX(clamp(-100px, -8vw, -36px));
+	}
+}
+
+.dispatch-log {
+	min-height: 238px;
+	padding: 26px 28px;
+	border-top: 1px solid var(--ink);
+	border-bottom: 1px solid var(--ink);
+	background: var(--dark-surface);
+	color: var(--surface);
+}
+
+.log-meta {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-4);
+	margin-bottom: var(--space-6);
+	color: var(--lime);
+	font-family: var(--mono);
+	font-size: 0.64rem;
+	font-variant-numeric: tabular-nums;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.log-message {
+	max-width: 44ch;
+	margin: 0;
+	font-family: var(--serif);
+	font-size: clamp(1.2rem, 2vw, 1.55rem);
+	font-weight: 600;
+	letter-spacing: -0.02em;
+	line-height: 1.28;
+}
+
+.log-artifact {
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	gap: 5px 12px;
+	margin-top: var(--space-6);
+	padding-top: var(--space-4);
+	border-top: 1px solid var(--dark-line);
+	font-size: 0.72rem;
+}
+
+.log-artifact .artifact-type {
+	grid-row: 1 / 3;
+	align-self: center;
+	padding: 5px 7px;
+	background: var(--signal);
+	font-family: var(--mono);
+	font-size: 0.56rem;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.log-artifact strong {
+	overflow-wrap: anywhere;
+}
+
+.log-artifact > span:last-child {
+	color: var(--dark-copy);
+}
+
+.dispatch-controls {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+}
+
+.dispatch-controls button {
+	min-height: 58px;
+	padding: 8px;
+	border: 0;
+	border-right: 1px solid var(--ink);
+	background: var(--surface);
+	cursor: pointer;
+	font-size: 0.76rem;
+	font-weight: 700;
+	transition: background 120ms linear, color 120ms linear;
+}
+
+.dispatch-controls button:last-child {
+	border-right: 0;
+}
+
+.dispatch-controls button span {
+	display: block;
+	margin-bottom: 2px;
+	font-family: var(--mono);
+	font-size: 0.56rem;
+}
+
+.dispatch-controls button[aria-pressed="true"] {
+	background: var(--lime);
+}
+
+.dispatch-controls button:hover {
+	background: var(--signal-pale);
+}
+
+.dispatch figcaption {
+	padding: 14px 18px;
+	border-top: 1px solid var(--ink);
+	color: var(--ink-soft);
+	font-size: 0.7rem;
+	line-height: 1.5;
+}
+
+.ownership-band {
+	border-block: 1px solid var(--ink);
+	background: var(--signal);
+	color: var(--surface);
+}
+
+.ownership-track {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+}
+
+.ownership-track div {
+	display: flex;
+	min-height: 64px;
+	align-items: center;
+	gap: var(--space-3);
+	padding: 10px 18px;
+	border-right: 1px solid oklch(99% 0.007 87 / 0.45);
+	font-size: 0.77rem;
+	font-weight: 700;
+}
+
+.ownership-track div:last-child {
+	border-right: 0;
+}
+
+.ownership-track span {
+	color: var(--surface);
+	font-family: var(--mono);
+	font-size: 0.62rem;
+	opacity: 1;
+}
+
+.section-heading h2,
+.status-intro h2,
+.safety-title h2,
+.final-cta h2 {
+	margin: 0;
+	font-family: var(--serif);
+	font-size: clamp(3rem, 5.4vw, 5.8rem);
+	font-weight: 600;
+	letter-spacing: -0.055em;
+	line-height: 0.92;
+}
+
+.workflow {
+	display: grid;
+	grid-template-columns: minmax(280px, 0.72fr) minmax(480px, 1.28fr);
+	align-items: start;
+	gap: clamp(64px, 9vw, 136px);
+}
+
+.workflow-heading {
+	position: sticky;
+	top: 120px;
+}
+
+.workflow-heading > p:last-child,
+.architecture-heading > p,
+.use-heading > p,
+.status-intro > p {
+	max-width: 54ch;
+	margin: var(--space-8) 0 0;
+	color: var(--ink-soft);
+	line-height: 1.7;
+}
+
+.workflow-ledger {
+	margin: 0;
+	padding: 0;
+	border-top: 1px solid var(--ink);
+	list-style: none;
+}
+
+.workflow-ledger li {
+	display: grid;
+	grid-template-columns: 108px 1fr;
+	gap: var(--space-6);
+	padding: 34px 0;
+	border-bottom: 1px solid var(--line-strong);
+}
+
+.ledger-index {
+	padding-top: 5px;
+	color: var(--signal-dark);
+	font-family: var(--mono);
+	font-size: 0.65rem;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.workflow-ledger h3 {
+	margin: 0 0 var(--space-3);
+	font-size: clamp(1.4rem, 2.1vw, 1.85rem);
+	letter-spacing: -0.035em;
+}
+
+.workflow-ledger p {
+	max-width: 55ch;
+	margin: 0;
+	color: var(--ink-soft);
+}
+
+.ledger-output {
+	grid-column: 2;
+	justify-self: start;
+	padding: 5px 8px;
+	border: 1px solid var(--line-strong);
+	font-family: var(--mono);
+	font-size: 0.57rem;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.use-section {
+	border-block: 1px solid var(--ink);
+	background: var(--surface);
+}
+
+.use-heading,
+.architecture-heading {
+	display: grid;
+	grid-template-columns: 1.08fr 0.62fr;
+	align-items: end;
+	gap: clamp(48px, 8vw, 120px);
+}
+
+.use-heading > p,
+.architecture-heading > p {
+	margin: 0 0 6px;
+}
+
+.prerequisite-line {
+	display: grid;
+	grid-template-columns: 0.7fr repeat(3, 1fr);
+	margin-top: var(--space-16);
+	border-block: 1px solid var(--ink);
+}
+
+.prerequisite-line > * {
+	display: flex;
+	min-height: 68px;
+	align-items: center;
+	padding: 12px 18px;
+	border-right: 1px solid var(--line-strong);
+	font-size: 0.75rem;
+}
+
+.prerequisite-line > *:last-child {
+	border-right: 0;
+}
+
+.prerequisite-line > span {
+	background: var(--ink);
+	color: var(--surface);
+	font-family: var(--mono);
+	font-size: 0.62rem;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.setup-rail {
+	position: relative;
+	margin: var(--space-16) 0 0;
+	padding: 0;
+	list-style: none;
+}
+
+.setup-rail::before {
+	position: absolute;
+	top: 30px;
+	bottom: 30px;
+	left: 28px;
+	width: 2px;
+	background: var(--signal);
+	content: "";
+}
+
+.setup-step {
+	display: grid;
+	grid-template-columns: 58px minmax(0, 1fr);
+	gap: clamp(30px, 6vw, 88px);
+	padding-bottom: var(--space-16);
+}
+
+.setup-step:last-child {
+	padding-bottom: 0;
+}
+
+.setup-marker {
+	position: relative;
+	z-index: 1;
+	display: grid;
+	width: 58px;
+	height: 58px;
+	place-items: center;
+	border: 2px solid var(--signal);
+	border-radius: 50%;
+	background: var(--surface);
+	color: var(--signal-dark);
+	font-family: var(--mono);
+	font-size: 0.68rem;
+	font-weight: 700;
+}
+
+.setup-copy {
+	max-width: 870px;
+}
+
+.step-label {
+	margin: 0 0 var(--space-2);
+	color: var(--signal-dark);
+	font-family: var(--mono);
+	font-size: 0.63rem;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.setup-copy h3 {
+	margin: 0 0 var(--space-3);
+	font-size: clamp(1.55rem, 2.8vw, 2.25rem);
+	letter-spacing: -0.04em;
+}
+
+.setup-copy > p:not(.step-label):not(.setup-note) {
+	max-width: 64ch;
+	margin: 0;
+	color: var(--ink-soft);
+}
+
+.code-block {
+	margin-block: var(--space-6) var(--space-4);
+	border: 1px solid var(--ink);
+	background: var(--dark-surface);
+	color: var(--surface);
+}
+
+.code-label {
+	display: flex;
+	min-height: 42px;
+	align-items: center;
+	justify-content: space-between;
+	padding-left: 16px;
+	border-bottom: 1px solid var(--dark-line);
+	color: var(--dark-copy);
+	font-family: var(--mono);
+	font-size: 0.58rem;
+	font-weight: 700;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+}
+
+.code-label button {
+	min-width: 76px;
+	min-height: 42px;
+	border: 0;
+	border-left: 1px solid var(--dark-line);
+	background: transparent;
+	color: var(--lime);
+	cursor: pointer;
+	font-family: var(--mono);
+	font-size: 0.58rem;
+	font-weight: 700;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+}
+
+.code-label button:hover {
+	background: var(--relay-dark);
+}
+
+.code-block pre {
+	margin: 0;
+	overflow-x: auto;
+	padding: 20px;
+	font-size: clamp(0.71rem, 1.5vw, 0.84rem);
+	line-height: 1.75;
+}
+
+.text-link {
+	display: inline-flex;
+	min-height: 44px;
+	align-items: center;
+	gap: 8px;
+	font-size: 0.82rem;
+	font-weight: 700;
+}
+
+.setup-note {
+	margin: var(--space-3) 0 0;
+	color: var(--ink-soft);
+	font-size: 0.78rem;
+}
+
+.setup-note code,
+.prompt-sequence code {
+	padding: 1px 4px;
+	background: var(--paper-deep);
+	font-size: 0.85em;
+}
+
+.prompt-sequence {
+	margin-top: var(--space-6);
+	border-top: 1px solid var(--ink);
+}
+
+.prompt-sequence > div {
+	display: grid;
+	grid-template-columns: 86px 1fr;
+	gap: var(--space-6);
+	padding: 20px 0;
+	border-bottom: 1px solid var(--line);
+}
+
+.prompt-sequence span {
+	padding-top: 2px;
+	color: var(--signal-dark);
+	font-family: var(--mono);
+	font-size: 0.62rem;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.prompt-sequence p {
+	margin: 0;
+	font-family: var(--serif);
+	font-size: clamp(1.05rem, 1.8vw, 1.28rem);
+	font-weight: 600;
+	line-height: 1.45;
+}
+
+.tool-chain {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	margin-top: var(--space-16);
+	padding: 24px;
+	border-block: 1px solid var(--line-strong);
+	background: var(--relay-pale);
+}
+
+.tool-chain span {
+	font-family: var(--mono);
+	font-size: 0.69rem;
+	font-weight: 700;
+}
+
+.tool-chain i {
+	color: var(--signal);
+	font-style: normal;
+}
+
+.manual-boundary {
+	display: grid;
+	grid-template-columns: 220px 1fr;
+	gap: var(--space-8);
+	margin-top: var(--space-8);
+	padding: 22px 24px;
+	border: 1px solid var(--signal-dark);
+	background: var(--signal-pale);
+}
+
+.manual-boundary strong {
+	font-family: var(--mono);
+	font-size: 0.67rem;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.manual-boundary p {
+	margin: 0;
+	color: var(--ink-soft);
+	font-size: 0.88rem;
+}
+
+.architecture-heading {
+	margin-bottom: var(--space-16);
+}
+
+.architecture-lane {
+	display: grid;
+	grid-template-columns: minmax(140px, 1fr) 48px 100px minmax(240px, 1.5fr) 100px 48px minmax(
+			140px,
+			1fr
+		);
+	align-items: stretch;
+	border: 1px solid var(--ink);
+	background: var(--surface);
+}
+
+.architecture-endpoint,
+.architecture-node,
+.architecture-relay {
+	display: flex;
+	min-height: 178px;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 20px 14px;
+	text-align: center;
+}
+
+.architecture-endpoint strong {
+	margin-top: 10px;
+	font-size: 0.88rem;
+}
+
+.architecture-endpoint p {
+	max-width: 20ch;
+	margin: 8px 0 0;
+	color: var(--ink-soft);
+	font-size: 0.66rem;
+}
+
+.architecture-owner {
+	font-family: var(--mono);
+	font-size: 0.57rem;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.architecture-node {
+	border-inline: 1px solid var(--line-strong);
+	background: var(--relay-pale);
+}
+
+.architecture-node span {
+	font-family: var(--mono);
+	font-size: 0.7rem;
+	font-weight: 700;
+}
+
+.architecture-node small {
+	margin-top: 8px;
+	font-size: 0.58rem;
+}
+
+.architecture-relay {
+	background: var(--relay-dark);
+	color: var(--surface);
+}
+
+.architecture-relay > span {
+	font-family: var(--mono);
+	font-size: 0.62rem;
+	font-weight: 700;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+}
+
+.architecture-relay strong {
+	max-width: 18ch;
+	margin: 13px 0 10px;
+	font-family: var(--serif);
+	font-size: 1.3rem;
+	font-weight: 600;
+	line-height: 1.08;
+}
+
+.architecture-relay small {
+	max-width: 32ch;
+	color: var(--dark-copy);
+	font-size: 0.58rem;
+}
+
+.architecture-arrow {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	color: var(--signal);
+	font-size: 1.15rem;
+}
+
+.architecture-arrow span {
+	display: none;
+}
+
+.status-section {
+	border-block: 1px solid var(--ink);
+	background: var(--paper-deep);
+}
+
+.status-layout {
+	display: grid;
+	grid-template-columns: minmax(260px, 0.58fr) minmax(540px, 1.42fr);
+	align-items: start;
+	gap: clamp(56px, 9vw, 136px);
+}
+
+.status-intro {
+	position: sticky;
+	top: 120px;
+}
+
+.status-intro .text-link {
+	margin-top: var(--space-6);
+}
+
+.status-ledger {
+	border-top: 1px solid var(--ink);
+}
+
+.status-row {
+	display: grid;
+	grid-template-columns: 102px 1fr 118px;
+	align-items: start;
+	gap: var(--space-6);
+	padding: 28px 0;
+	border-bottom: 1px solid var(--line-strong);
+}
+
+.status-row strong {
+	display: block;
+	margin-bottom: 8px;
+	font-size: 1.08rem;
+	letter-spacing: -0.025em;
+}
+
+.status-row p {
+	margin: 0;
+	color: var(--ink-soft);
+	font-size: 0.83rem;
+}
+
+.status-row small {
+	padding-top: 4px;
+	color: var(--ink-soft);
+	font-family: var(--mono);
+	font-size: 0.58rem;
+	text-align: right;
+	text-transform: uppercase;
+}
+
+.status-code {
+	display: inline-flex;
+	min-height: 28px;
+	align-items: center;
+	justify-content: center;
+	padding: 4px 7px;
+	border: 1px solid currentColor;
+	font-family: var(--mono);
+	font-size: 0.56rem;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.status-shipped {
+	color: var(--success);
+}
+
+.status-lab {
+	color: var(--signal-dark);
+}
+
+.status-next {
+	background: var(--relay-dark);
+	color: var(--surface);
+}
+
+.status-row-next {
+	position: relative;
+}
+
+.status-row-next::after {
+	position: absolute;
+	right: 0;
+	bottom: -1px;
+	width: 32%;
+	height: 4px;
+	background: var(--signal);
+	content: "";
+}
+
+.safety-section {
+	padding-block: clamp(88px, 11vw, 148px);
+	background: var(--dark-surface);
+	color: var(--surface);
+}
+
+.safety-layout {
+	display: grid;
+	grid-template-columns: minmax(300px, 0.9fr) minmax(420px, 1.1fr);
+	align-items: start;
+	gap: clamp(64px, 10vw, 152px);
+}
+
+.safety-title .eyebrow {
+	color: var(--lime);
+}
+
+.safety-title .eyebrow::before {
+	background: var(--lime);
+}
+
+.safety-lead {
+	max-width: 49ch;
+	margin: 0 0 var(--space-8);
+	color: var(--dark-copy);
+	font-family: var(--serif);
+	font-size: clamp(1.3rem, 2.3vw, 1.8rem);
+	font-weight: 600;
+	line-height: 1.35;
+}
+
+.safety-copy ul {
+	margin: 0;
+	padding: 0;
+	border-top: 1px solid var(--dark-line);
+	list-style: none;
+}
+
+.safety-copy li {
+	display: grid;
+	grid-template-columns: 36px 1fr;
+	gap: 0 var(--space-4);
+	padding: 19px 0;
+	border-bottom: 1px solid var(--dark-line);
+	color: var(--dark-copy);
+	font-size: 0.84rem;
+}
+
+.safety-copy li span {
+	grid-row: 1 / 3;
+	color: var(--lime);
+	font-family: var(--mono);
+	font-size: 0.62rem;
+}
+
+.safety-copy li strong {
+	color: var(--surface);
+}
+
+.final-cta {
+	position: relative;
+	display: grid;
+	justify-items: center;
+	overflow: hidden;
+	text-align: center;
+}
+
+.final-cta .eyebrow {
+	position: relative;
+	z-index: 1;
+}
+
+.final-cta h2 {
+	position: relative;
+	z-index: 1;
+	max-width: 12ch;
+}
+
+.final-cta > p:not(.eyebrow) {
+	position: relative;
+	z-index: 1;
+	max-width: 60ch;
+	margin: var(--space-8) auto 0;
+	color: var(--ink-soft);
+	font-size: 1.03rem;
+}
+
+.final-cta .hero-actions {
+	position: relative;
+	z-index: 1;
+	justify-content: center;
+}
+
+.cta-route {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: min(900px, 86vw);
+	height: min(900px, 86vw);
+	border: 1px solid var(--line);
+	border-radius: 50%;
+	transform: translate(-50%, -50%);
+}
+
+.cta-route::before,
+.cta-route::after {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	border: 1px solid var(--line);
+	border-radius: 50%;
+	content: "";
+	transform: translate(-50%, -50%);
+}
+
+.cta-route::before {
+	width: 66%;
+	height: 66%;
+}
+
+.cta-route::after {
+	width: 34%;
+	height: 34%;
+}
+
+.cta-route span {
+	position: absolute;
+	top: 50%;
+	right: -6px;
+	width: 12px;
+	height: 12px;
+	background: var(--signal);
+	transform: translateY(-50%);
+}
+
+.site-footer {
+	border-top: 1px solid var(--ink);
+	background: var(--surface);
+}
+
+.footer-grid {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: var(--space-12);
+	padding-block: 54px;
+}
+
+.footer-brand {
+	margin-bottom: var(--space-4);
+}
+
+.footer-grid p {
+	max-width: 44ch;
+	margin: 0;
+	color: var(--ink-soft);
+	font-size: 0.8rem;
+}
+
+.footer-links {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(100px, 1fr));
+	align-content: start;
+	gap: 12px 28px;
+}
+
+.footer-links a {
+	font-size: 0.78rem;
+	font-weight: 650;
+}
+
+.footer-base {
+	display: flex;
+	min-height: 58px;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-6);
+	border-top: 1px solid var(--line);
+	color: var(--ink-soft);
+	font-family: var(--mono);
+	font-size: 0.6rem;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.copy-status {
+	position: fixed;
+	right: max(18px, env(safe-area-inset-right));
+	bottom: max(18px, env(safe-area-inset-bottom));
+	z-index: 50;
+	max-width: min(340px, calc(100vw - 36px));
+	margin: 0;
+	padding: 12px 16px;
+	background: var(--ink);
+	color: var(--surface);
+	font-size: 0.78rem;
+	font-weight: 700;
+	opacity: 0;
+	pointer-events: none;
+	transform: translateY(10px);
+	transition: opacity 180ms linear, transform 180ms var(--ease-out);
+}
+
+.copy-status[data-visible="true"] {
+	opacity: 1;
+	transform: translateY(0);
+}
+
+@media (max-width: 1080px) {
+	.hero {
+		grid-template-columns: 1fr;
+	}
+
+	.hero-copy {
+		max-width: 820px;
+	}
+
+	.hero h1 {
+		max-width: 10ch;
+	}
+
+	.dispatch {
+		max-width: 760px;
+	}
+
+	.workflow {
+		grid-template-columns: 0.7fr 1.3fr;
+		gap: var(--space-16);
+	}
+
+	.architecture-lane {
+		grid-template-columns: 100px minmax(240px, 1fr) 100px;
+	}
+
+	.architecture-endpoint {
+		display: none;
+	}
+
+	.architecture-arrow {
+		display: none;
+	}
+}
+
+@media (max-width: 840px) {
+	:root {
+		--page: min(100% - 32px, 720px);
+	}
+
+	.nav-optional {
+		display: none;
+	}
+
+	.hero h1 {
+		font-size: clamp(4rem, 15vw, 6.7rem);
+	}
+
+	.ownership-track {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	.ownership-track div:nth-child(2) {
+		border-right: 0;
+	}
+
+	.ownership-track div:nth-child(-n + 2) {
+		border-bottom: 1px solid oklch(99% 0.007 87 / 0.45);
+	}
+
+	.workflow,
+	.status-layout,
+	.safety-layout {
+		grid-template-columns: 1fr;
+	}
+
+	.workflow-heading,
+	.status-intro {
+		position: static;
+	}
+
+	.workflow-heading > p:last-child {
+		max-width: 65ch;
+	}
+
+	.use-heading,
+	.architecture-heading {
+		grid-template-columns: 1fr;
+		align-items: start;
+		gap: var(--space-6);
+	}
+
+	.use-heading > p,
+	.architecture-heading > p {
+		max-width: 64ch;
+	}
+
+	.prerequisite-line {
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.prerequisite-line > *:nth-child(2) {
+		border-right: 0;
+	}
+
+	.prerequisite-line > *:nth-child(-n + 2) {
+		border-bottom: 1px solid var(--line-strong);
+	}
+
+	.architecture-lane {
+		grid-template-columns: 1fr;
+	}
+
+	.architecture-node {
+		min-height: 92px;
+		border: 0;
+		border-block: 1px solid var(--line-strong);
+	}
+
+	.architecture-relay {
+		min-height: 150px;
+	}
+
+	.status-layout,
+	.safety-layout {
+		gap: var(--space-16);
+	}
+}
+
+@media (max-width: 600px) {
+	:root {
+		--page: calc(100% - 28px);
+	}
+
+	body::before {
+		background-size: 48px 48px;
+	}
+
+	.site-nav {
+		min-height: 64px;
+	}
+
+	.brand-version,
+	.nav-links > a:not(.nav-action) {
+		display: none;
+	}
+
+	.nav-action {
+		min-height: 40px;
+		padding-inline: 13px;
+	}
+
+	.hero {
+		min-height: auto;
+		padding-block: 64px 76px;
+	}
+
+	.availability-pill {
+		font-size: 0.61rem;
+	}
+
+	.hero h1 {
+		font-size: clamp(3.65rem, 18.7vw, 5.6rem);
+	}
+
+	.hero-lead {
+		font-size: 1rem;
+	}
+
+	.button {
+		width: 100%;
+	}
+
+	.dispatch {
+		box-shadow: 7px 7px 0 var(--relay-dark);
+	}
+
+	.dispatch-header {
+		min-height: 76px;
+		padding: 14px 16px;
+	}
+
+	.dispatch-route {
+		grid-template-columns: 62px 1fr 60px 1fr 62px;
+		padding: 24px 12px;
+	}
+
+	.route-node > span,
+	.route-relay > span {
+		width: 42px;
+		height: 42px;
+	}
+
+	.route-node small,
+	.route-relay small {
+		display: none;
+	}
+
+	.dispatch-log {
+		min-height: 260px;
+		padding: 22px 18px;
+	}
+
+	.log-artifact {
+		grid-template-columns: 1fr;
+	}
+
+	.log-artifact .artifact-type {
+		grid-row: auto;
+		justify-self: start;
+	}
+
+	.dispatch-controls button {
+		min-height: 62px;
+		font-size: 0.66rem;
+	}
+
+	.ownership-track {
+		grid-template-columns: 1fr;
+	}
+
+	.ownership-track div,
+	.ownership-track div:nth-child(2) {
+		min-height: 48px;
+		border-right: 0;
+		border-bottom: 1px solid oklch(99% 0.007 87 / 0.45);
+	}
+
+	.ownership-track div:last-child {
+		border-bottom: 0;
+	}
+
+	.section-heading h2,
+	.status-intro h2,
+	.safety-title h2,
+	.final-cta h2 {
+		font-size: clamp(2.75rem, 14vw, 4.4rem);
+	}
+
+	.workflow-ledger li {
+		grid-template-columns: 1fr;
+		gap: var(--space-3);
+	}
+
+	.ledger-output {
+		grid-column: 1;
+	}
+
+	.prerequisite-line {
+		grid-template-columns: 1fr;
+	}
+
+	.prerequisite-line > *,
+	.prerequisite-line > *:nth-child(2) {
+		min-height: 52px;
+		border-right: 0;
+		border-bottom: 1px solid var(--line-strong);
+	}
+
+	.prerequisite-line > *:last-child {
+		border-bottom: 0;
+	}
+
+	.setup-rail::before {
+		left: 22px;
+	}
+
+	.setup-step {
+		grid-template-columns: 46px minmax(0, 1fr);
+		gap: 18px;
+	}
+
+	.setup-marker {
+		width: 46px;
+		height: 46px;
+	}
+
+	.code-label,
+	.code-block pre {
+		padding-left: 14px;
+	}
+
+	.prompt-sequence > div {
+		grid-template-columns: 1fr;
+		gap: 8px;
+	}
+
+	.tool-chain {
+		justify-content: flex-start;
+	}
+
+	.tool-chain i {
+		display: none;
+	}
+
+	.manual-boundary {
+		grid-template-columns: 1fr;
+		gap: var(--space-3);
+	}
+
+	.status-row {
+		grid-template-columns: 94px 1fr;
+		gap: var(--space-4);
+	}
+
+	.status-row small {
+		grid-column: 2;
+		padding: 0;
+		text-align: left;
+	}
+
+	.safety-copy li {
+		grid-template-columns: 28px 1fr;
+	}
+
+	.footer-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.footer-links {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	.footer-base {
+		align-items: flex-start;
+		flex-direction: column;
+		justify-content: center;
+		padding-block: 16px;
+	}
+}
+
+@media (pointer: coarse) {
+	.dispatch-controls button,
+	.code-label button,
+	.nav-action {
+		min-height: 48px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	html {
+		scroll-behavior: auto;
+	}
+
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+	}
+}

--- a/landing/site.js
+++ b/landing/site.js
@@ -1,0 +1,111 @@
+const scenes = [
+	{
+		state: "Negotiating",
+		time: "09:42:16",
+		direction: "backend → android",
+		message:
+			"The API now supports partial refunds. Which fields does the Android model still need?",
+		artifactType: "API contract",
+		artifact: "openapi/refunds.yaml",
+		proof: "schema diff attached",
+	},
+	{
+		state: "Revision 02",
+		time: "09:43:18",
+		direction: "android → backend",
+		message:
+			"Make failureReason nullable and keep UNKNOWN for older app versions. Then the client contract is safe.",
+		artifactType: "Proposal",
+		artifact: "refund-contract.v2",
+		proof: "revision acknowledged by both sides",
+	},
+	{
+		state: "Working locally",
+		time: "09:48:44",
+		direction: "both workspaces",
+		message:
+			"Each agent applies the accepted contract inside its own repository and returns bounded progress evidence.",
+		artifactType: "Local result",
+		artifact: "backend:34/34 · android:18/18",
+		proof: "repositories never crossed the Relay",
+	},
+	{
+		state: "Ready for review",
+		time: "09:55:51",
+		direction: "mission → owners",
+		message:
+			"The contract, implementations, and user scenario agree. The remaining decision belongs to the humans: ship or revise.",
+		artifactType: "Evidence",
+		artifact: "mission-result.json",
+		proof: "compatible changes · replayable trace",
+	},
+];
+
+const dispatchFields = {
+	state: document.querySelector("#dispatch-state"),
+	time: document.querySelector("#dispatch-time"),
+	direction: document.querySelector("#dispatch-direction"),
+	message: document.querySelector("#dispatch-message"),
+	artifactType: document.querySelector("#dispatch-artifact-type"),
+	artifact: document.querySelector("#dispatch-artifact"),
+	proof: document.querySelector("#dispatch-proof"),
+};
+
+const sceneButtons = [...document.querySelectorAll("[data-scene]")];
+
+function showScene(index) {
+	const scene = scenes[index];
+	if (!scene) return;
+
+	for (const [name, element] of Object.entries(dispatchFields)) {
+		element.textContent = scene[name];
+	}
+
+	for (const button of sceneButtons) {
+		button.setAttribute("aria-pressed", String(Number(button.dataset.scene) === index));
+	}
+}
+
+for (const button of sceneButtons) {
+	button.addEventListener("click", () => showScene(Number(button.dataset.scene)));
+}
+
+const copyStatus = document.querySelector("#copy-status");
+let copyStatusTimer;
+
+function announceCopyStatus(message) {
+	window.clearTimeout(copyStatusTimer);
+	copyStatus.textContent = message;
+	copyStatus.dataset.visible = "true";
+	copyStatusTimer = window.setTimeout(() => {
+		copyStatus.dataset.visible = "false";
+	}, 2400);
+}
+
+function selectText(element) {
+	const selection = window.getSelection();
+	const range = document.createRange();
+	range.selectNodeContents(element);
+	selection.removeAllRanges();
+	selection.addRange(range);
+}
+
+for (const button of document.querySelectorAll("[data-copy]")) {
+	button.addEventListener("click", async () => {
+		const target = document.getElementById(button.dataset.copy);
+		const text = target?.innerText.trim();
+		if (!target || !text) return;
+
+		try {
+			await navigator.clipboard.writeText(text);
+			button.textContent = "Copied";
+			announceCopyStatus("Command copied to clipboard.");
+			window.setTimeout(() => {
+				button.textContent = "Copy";
+			}, 1800);
+		} catch {
+			selectText(target);
+			announceCopyStatus("Clipboard access was unavailable. The command is selected for you.");
+		}
+	});
+}


### PR DESCRIPTION
## What changed

- rebuild the landing page as a responsive dispatch-ledger experience
- add an honest Use AgentRelay today flow with Relay, invite, join, doctor, and MCP round-trip steps
- separate the shipped mailbox and Mission control plane from the experimental Node and real-runtime path
- split the previous monolith into focused HTML, CSS, JavaScript, and favicon assets
- keep every asset relative so GitHub Pages works under /AgentRelay/

## Validation

- pnpm lint
- pnpm -r typecheck
- pnpm -r build
- html-validate landing/index.html
- Biome checks for landing CSS and JavaScript
- browser QA at 320, 390, 720, 1024, and 1440 CSS pixels
- Lighthouse desktop: 93 performance, 100 accessibility, 100 best practices, 100 SEO
- Lighthouse mobile: 99 performance, 100 accessibility, 100 best practices, 100 SEO

## Deployment

No workflow change is needed. After merge, deploy-pages.yml uploads landing/ and publishes the site through GitHub Pages.