### PR TITLE
docs: mark agentrelay-mcp 0.2.1 shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ repositories is the first proof, not the final product boundary.
 
 | Status | Layer | Current boundary |
 | --- | --- | --- |
-| **Shipped** | Authenticated MCP mailbox | `agentrelay-mcp` 0.2.0: identities, invites, typed handoffs, messages, blocks, trust, and audit |
+| **Shipped** | Authenticated MCP mailbox | `agentrelay-mcp` 0.2.1: identities, invites, typed handoffs, messages, blocks, trust, and audit |
 | **Shipped** | Durable Mission control plane | Relay + Postgres: Mission state, delivery leases, fencing, retries, recovery, and revocation |
 | **Experimental** | Node and persistent Capsule | Local policy and crash-recovery foundations, currently exercised with deterministic fake runtimes |
 | **Next gate** | Guarded real Codex activation | One contained real turn, then a two-machine backend ↔ Android Mission |

--- a/landing/index.html
+++ b/landing/index.html
@@ -372,7 +372,7 @@ npx -y -p agentrelay-mcp agentrelay doctor</code></pre>
 						<div class="status-row">
 							<span class="status-code status-shipped">Shipped</span>
 							<div><strong>Authenticated MCP mailbox</strong><p>Invites, identities, typed handoffs, messages, blocks, trust, and audit.</p></div>
-							<small>agentrelay-mcp 0.2.0</small>
+							<small>agentrelay-mcp 0.2.1</small>
 						</div>
 						<div class="status-row">
 							<span class="status-code status-shipped">Shipped</span>


### PR DESCRIPTION
## Summary

- update the root README shipped-version status to 0.2.1
- update the landing-page shipped-version status to 0.2.1

The npm registry, clean registry install, and GitHub package release were verified before making this public status change.

## Verification

- `git diff --check`
- npm `latest` resolves to 0.2.1