### PR TITLE
fix(pages): allow deployment service more time

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     name: Deploy landing page
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

- increase the Pages deployment job timeout from 10 to 20 minutes

The 0.2.1 landing deployment built and uploaded successfully but GitHub Pages remained in the deploy step until the repository-level 10-minute timeout canceled it. A fresh dispatch using the same canceled build SHA was then canceled by Pages. This creates a fresh build SHA and gives the deployment service enough time to complete.

## Verification

- `git diff --check`
- failure evidence: run `31095089768` timed out in the Deploy step after 10 minutes