### PR TITLE
fix: harden repository and app-server transport

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Keep every repository change under maintainer review.
+* @swayamg20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 concurrency:

--- a/node/src/codex-app-server-failures.test.ts
+++ b/node/src/codex-app-server-failures.test.ts
@@ -46,6 +46,16 @@ describe("Codex app-server failure boundaries", () => {
 			reason: "transport",
 		});
 	});
+
+	it("fails closed when app-server input closes before the process exits", async () => {
+		const fixture = await fakeAppServer({ closeInputAfterRead: true });
+		const client = await openClient(fixture);
+		expect(await client.readThread("thread-1")).toMatchObject({ id: "thread-1" });
+		await expect(client.startThread()).rejects.toMatchObject({
+			name: "CodexAppServerError",
+			reason: "transport",
+		});
+	});
 });
 
 async function fakeAppServer(

--- a/node/src/codex-app-server-process.ts
+++ b/node/src/codex-app-server-process.ts
@@ -27,6 +27,7 @@ export interface CodexAppServerProcess {
 	readonly cwd: string;
 	readonly exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
 	readonly closed: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+	readonly inputError: Promise<Error>;
 }
 
 export class CodexAppServerError extends Error {
@@ -64,6 +65,7 @@ export async function startCodexAppServerProcess(
 		stdio: ["pipe", "pipe", "pipe"],
 		shell: false,
 	});
+	const inputError = writableError(child.stdin);
 	const exited = childExit(child);
 	const closed = childClose(child);
 	try {
@@ -74,7 +76,7 @@ export async function startCodexAppServerProcess(
 		});
 	}
 	child.stderr.resume();
-	return { child, cwd, exited, closed };
+	return { child, cwd, exited, closed, inputError };
 }
 
 export function stopCodexAppServerProcess(processRef: CodexAppServerProcess): Promise<void> {
@@ -224,6 +226,10 @@ function childClose(
 	child: ChildProcess,
 ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
 	return new Promise((resolve) => child.once("close", (code, signal) => resolve({ code, signal })));
+}
+
+function writableError(stream: Writable): Promise<Error> {
+	return new Promise((resolve) => stream.once("error", resolve));
 }
 
 function childExit(

--- a/node/src/codex-app-server-transport.ts
+++ b/node/src/codex-app-server-transport.ts
@@ -89,6 +89,15 @@ export class CodexAppServerTransport {
 		this.#requestTimeoutMs = requestTimeoutMs;
 		this.#handleServerRequest = handleServerRequest;
 		void this.readLoop();
+		void processRef.inputError.then((error) => {
+			if (!this.#closing && this.#failure === null) {
+				this.fail(
+					new CodexAppServerError("transport", "Cannot write to Codex app-server", {
+						cause: error,
+					}),
+				);
+			}
+		});
 		void processRef.exited.then(() => {
 			if (!this.#closing && this.#failure === null) {
 				void stopCodexAppServerProcess(processRef).catch((error) =>

--- a/node/test-support/fake-codex-app-server.ts
+++ b/node/test-support/fake-codex-app-server.ts
@@ -16,6 +16,7 @@ export interface FakeAppServerOptions {
 	readonly initializedFailure?: "invalid_json" | "incomplete_frame" | "stdout_eof";
 	readonly ignoreRead?: boolean;
 	readonly exitAfterRead?: boolean;
+	readonly closeInputAfterRead?: boolean;
 	readonly unsafePolicy?: boolean;
 	readonly requestApproval?: boolean;
 	readonly spawnDescendant?: boolean;
@@ -54,6 +55,7 @@ export async function createFakeAppServer(
 			initializedFailure: options.initializedFailure ?? "",
 			ignoreRead: options.ignoreRead ?? false,
 			exitAfterRead: options.exitAfterRead ?? false,
+			closeInputAfterRead: options.closeInputAfterRead ?? false,
 			unsafePolicy: options.unsafePolicy ?? false,
 			requestApproval: options.requestApproval ?? false,
 			spawnDescendant: options.spawnDescendant ?? false,
@@ -153,7 +155,7 @@ export function isProcessAlive(pid: number): boolean {
 
 const FAKE_APP_SERVER_SOURCE = `
 import { spawn } from "node:child_process";
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, closeSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import readline from "node:readline";
 
@@ -177,6 +179,7 @@ const notificationMode = config.notificationMode;
 const initializedFailure = config.initializedFailure;
 const ignoreRead = config.ignoreRead;
 const exitAfterRead = config.exitAfterRead;
+const closeInputAfterRead = config.closeInputAfterRead;
 const unsafePolicy = config.unsafePolicy;
 const requestApproval = config.requestApproval;
 if (config.spawnDescendant) {
@@ -275,6 +278,12 @@ rl.on("line", (line) => {
       ]) } };
       if (exitAfterRead) {
         process.stdout.write(JSON.stringify(readResponse) + "\\n", () => process.exit(0));
+        return;
+      }
+      if (closeInputAfterRead) {
+        setInterval(() => {}, 1_000);
+        closeSync(0);
+        send(readResponse);
         return;
       }
       send(readResponse);


### PR DESCRIPTION
## Summary
- capture child stdin errors as fail-closed Codex transport failures
- add a deterministic regression for input closing before process exit
- add repository-wide CODEOWNERS coverage
- avoid duplicate push and pull-request CI runs

## Validation
- Node 20: flaky scenario 40/40 and 204 tests passed
- Node 22: flaky scenario 40/40 and 204 tests passed
- pnpm lint
- pnpm -r typecheck
- pnpm -r build
- database-free workspace tests (544 passed)
- protocol export check
- packed agentrelay-mcp@0.2.1 smoke test

After this lands, the repository rulesets will be tightened to require all six CI contexts, dismiss stale approvals, and require resolved review threads.