### PR TITLE
feat(deploy): add Azure team pilot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,33 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Validate Azure deployment assets
+        env:
+          AGENTRELAY_AZURE_NAME_PREFIX: agentrelay
+          AGENTRELAY_AZURE_RESOURCE_SUFFIX: '0123abcd'
+          AGENTRELAY_AZURE_LOCATION: centralindia
+          AGENTRELAY_AZURE_RELAY_IMAGE: ghcr.io/swayamg20/agentrelay-relay@sha256:595586c46b66d0106d420a85148aa6624fa9b72d02235541a3634abb05cdaf54
+          AGENTRELAY_AZURE_POSTGRES_LOGIN: agentrelay_admin
+          AGENTRELAY_AZURE_DEPLOYER_PRINCIPAL_ID: '00000000-0000-0000-0000-000000000000'
+          AGENTRELAY_AZURE_POSTGRES_PASSWORD: '0123456789abcdef0123456789abcdef0123456789abcdef'
+          AGENTRELAY_AZURE_RELAY_PEPPER: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          AGENTRELAY_AZURE_RELAY_ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          AGENTRELAY_AZURE_RELAY_INVITE_SECRET: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          AGENTRELAY_AZURE_RELAY_ADMIN_TOKEN: '0123456789abcdef0123456789abcdef0123456789abcdef'
+          AGENTRELAY_AZURE_RELAY_METRICS_TOKEN: '0123456789abcdef0123456789abcdef'
+        run: |
+          bicep="$RUNNER_TEMP/bicep"
+          curl --fail --silent --show-error --location \
+            https://github.com/Azure/bicep/releases/download/v0.46.1/bicep-linux-x64 \
+            --output "$bicep"
+          printf '%s  %s\n' \
+            3e011d629ea4311b7a7dd8f0040ab2b1a072ea4ff5d02cb75e0e55a9a6703fb9 \
+            "$bicep" | sha256sum --check
+          chmod +x "$bicep"
+          bash -n infra/azure/deploy.sh infra/azure/smoke.sh
+          "$bicep" build infra/azure/main.bicep --stdout >/dev/null
+          "$bicep" build-params infra/azure/main.bicepparam --stdout >/dev/null
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm lint

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ View the AgentRelay thread <thread_id> and show me the latest reply.
 ```
 
 Full setup and current limitations are in [`docs/onboarding.md`](docs/onboarding.md).
+For a first shared team deployment on Azure, use the review-first
+[`docs/deploy-azure.md`](docs/deploy-azure.md) pilot guide.
 
 ## Run the repository locally
 
@@ -338,6 +340,7 @@ this README does not claim full A2A conformance.
 ├── mcp-server/           current MCP server and agentrelay CLI
 ├── node/                 Node, Capsule wire, fake runtime, and unactivated Codex libraries
 ├── tests/e2e/            relay + MCP and Node/Capsule process test harnesses
+├── infra/azure/          reviewable Azure team-pilot infrastructure and smoke checks
 ├── landing/              GitHub Pages landing page
 └── docs/
     ├── architecture.md   current truth and target boundaries
@@ -347,6 +350,7 @@ this README does not claim full A2A conformance.
     ├── next-steps.md     near-term engineering queue
     ├── onboarding.md     current mailbox setup
     ├── hosting.md        relay hosting survey
+    ├── deploy-azure.md   Azure Container Apps + private PostgreSQL pilot
     ├── deploy-fly.md     relay-only Fly.io example
     ├── auto-mode.md      superseded design decision record
     ├── ambient-agent.md  superseded design decision record

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       # rejects empty values at startup with a clearer error than docker's.
       RELAY_PEPPER: ${RELAY_PEPPER:-}
       RELAY_ENCRYPTION_KEY: ${RELAY_ENCRYPTION_KEY:-}
+      RELAY_INVITE_SECRET: ${RELAY_INVITE_SECRET:-}
       RELAY_ADMIN_TOKEN: ${RELAY_ADMIN_TOKEN:-}
       RELAY_METRICS_TOKEN: ${RELAY_METRICS_TOKEN:-}
       RELAY_PUBLIC_URL: ${RELAY_PUBLIC_URL:-http://localhost:8080}

--- a/docs/deploy-azure.md
+++ b/docs/deploy-azure.md
@@ -1,0 +1,215 @@
+# Deploy the AgentRelay team pilot on Azure
+
+This guide deploys the current shared Relay and PostgreSQL database. Developer agents,
+the experimental AgentRelay Node, local workspace mappings, and Mission Capsules remain
+on each teammate's machine.
+
+The template is deliberately a pilot topology:
+
+- one public-HTTPS Azure Container App pinned to a tested Relay image digest;
+- one private PostgreSQL 16 Flexible Server;
+- sticky credentials in Azure Key Vault, read by managed identity;
+- one replica while the Relay container owns startup migrations; and
+- Log Analytics with 30-day retention.
+
+High availability, geo-redundant backups, a separate migration job, and split database
+schema-owner/runtime roles are not included. Do not describe this topology as
+production-hardened.
+
+## Prerequisites
+
+You need:
+
+- an Azure subscription where you can create resources and role assignments;
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) 2.53 or newer;
+- Bash, OpenSSL, and curl; and
+- a dedicated resource group name and explicit Azure region.
+
+The account running the deployment must also be allowed to create role assignments.
+The template grants that deployment principal read access to the pilot's Key Vault so
+later deployments can safely reuse sticky credentials. The deploy script refuses to
+replace an unreadable or missing credential.
+
+Sign in and inspect the subscriptions you can actually use:
+
+```bash
+az login
+az account list --output table
+```
+
+The repository does not choose a subscription or region for you. For an India-based
+team, `centralindia` is a reasonable first region only after confirming PostgreSQL and
+Container Apps availability for your subscription.
+
+Interactive user logins are detected automatically. For a service principal or an
+account whose directory object cannot be queried, add
+`--deployer-object-id '<entra-object-id>'` to both commands.
+
+## Review the change before paying for it
+
+From the repository root, run `plan` with explicit targets:
+
+```bash
+./infra/azure/deploy.sh plan \
+  --subscription '<subscription-id>' \
+  --location centralindia \
+  --resource-group agentrelay-pilot-rg
+```
+
+`plan` validates the Bicep and runs Azure what-if. It may register the required Azure
+resource providers and create/tag the resource group, but it does not create the
+billable Container Apps or PostgreSQL workload.
+
+Read the what-if output. In particular, confirm the subscription, region, dedicated
+resource group, private PostgreSQL network, and `Standard_B1ms` database SKU.
+
+## Deploy
+
+Use the same arguments with `apply`:
+
+```bash
+./infra/azure/deploy.sh apply \
+  --subscription '<subscription-id>' \
+  --location centralindia \
+  --resource-group agentrelay-pilot-rg
+```
+
+The first deployment generates URL-safe credentials in memory and stores them in Key
+Vault. The resource group's `agentrelaySuffix` tag preserves globally unique resource
+names. Later deployments read and reuse the existing values; in particular, they never
+silently rotate `RELAY_PEPPER` or `RELAY_ENCRYPTION_KEY`.
+
+The default image is immutable:
+
+```text
+ghcr.io/swayamg20/agentrelay-relay@sha256:595586c46b66d0106d420a85148aa6624fa9b72d02235541a3634abb05cdaf54
+```
+
+Supply `--image` only for another public image that you have built and verified. The
+template intentionally has no private-registry credential path yet.
+
+## Verify service and database readiness
+
+The apply command prints the HTTPS Relay URL, Container App name, and Key Vault name.
+Check both probes:
+
+```bash
+./infra/azure/smoke.sh 'https://<relay-host>'
+```
+
+Expected results:
+
+```text
+healthz: ok
+readyz: ready (database reachable)
+```
+
+`/healthz` proves the process is serving. `/readyz` also probes PostgreSQL, so a green
+health check alone is not deployment acceptance.
+
+Inspect the single active revision and recent logs without printing application
+secrets:
+
+```bash
+az containerapp revision list \
+  --resource-group agentrelay-pilot-rg \
+  --name '<relay-app-name>' \
+  --query '[?properties.active].{name:name,health:properties.healthState,replicas:properties.replicas}' \
+  --output table
+
+az containerapp logs show \
+  --resource-group agentrelay-pilot-rg \
+  --name '<relay-app-name>' \
+  --tail 100
+```
+
+The startup log should report `migrations applied`, followed by the Relay listening on
+port 8080. The database is private and has no public firewall exception.
+
+## Connect the first two teammates
+
+Read [`onboarding.md`](onboarding.md) for the complete CLI contract. The compact pilot
+sequence is:
+
+1. On laptop A, register the first teammate with the Key Vault-backed admin token.
+2. Mint a signed invite for laptop B and share it through a trusted channel.
+3. On laptop B, run `agentrelay join`, then `agentrelay doctor`.
+4. Send and accept one handoff, reply, and view the thread from laptop A.
+5. Send a second handoff, restart the active Container App revision, then receive and
+   reply from laptop B. This proves that PostgreSQL state, not a live process, owns
+   delivery durability.
+
+Use `agentrelay-mcp@0.2.1` explicitly during the pilot so both machines test the same
+published client:
+
+```bash
+export AGENTRELAY_ADMIN_TOKEN="$(az keyvault secret show \
+  --vault-name '<key-vault-name>' \
+  --name relay-admin-token \
+  --query value \
+  --output tsv)"
+
+npx -y -p agentrelay-mcp@0.2.1 agentrelay register \
+  --relay 'https://<relay-host>' \
+  --admin-token "$AGENTRELAY_ADMIN_TOKEN" \
+  --handle 'alice@your-team' \
+  --email 'alice@example.com' \
+  --name 'Alice' \
+  --role backend
+
+unset AGENTRELAY_ADMIN_TOKEN
+npx -y -p agentrelay-mcp@0.2.1 agentrelay doctor
+```
+
+Continue with the signed invite and round-trip commands in
+[`onboarding.md`](onboarding.md). The command substitution keeps the token out of the
+command text, but it still exists briefly in the process environment; run it only on a
+trusted administrator machine and unset it immediately.
+
+## Secret handling and redeployment
+
+Never paste Key Vault values into issues, chat, shell history, or logs.
+
+- `relay-pepper` authenticates stored credentials. Changing it invalidates them.
+- `relay-encryption-key` protects encrypted webhook data. Changing it without a
+  re-encryption migration loses access to that data.
+- `relay-invite-secret` invalidates unredeemed invites when rotated.
+- `relay-admin-token` and `relay-metrics-token` are independently rotatable.
+- `postgres-admin-password` is retained separately so safe redeployment does not need
+  to parse the database URL.
+
+If `deploy.sh` cannot read an existing secret, restore the deployer's Key Vault data
+access. Do not delete the vault or generate replacement values as a workaround.
+
+Key Vault role assignments can take time to propagate on the first deployment. If
+Container App creation reports a Key Vault authorization error, wait a few minutes and
+rerun the exact same `apply` command. The resource-group suffix and any already-created
+secrets are reused.
+
+## Pilot limits and next hardening step
+
+The current image runs database migrations in its entrypoint and then runs the Relay
+with the PostgreSQL administrator credential. That is acceptable for this controlled
+pilot, not for a mature production service. Before increasing `maxReplicas` above one:
+
+1. move migrations to a separately owned deployment job;
+2. introduce distinct schema-owner and least-privilege runtime database roles;
+3. add high availability and a tested restore procedure; and
+4. decide the ingress/IP policy and monitoring alerts for your team.
+
+Azure resources incur charges while they exist. Use Azure Cost Management during the
+pilot. When the pilot is intentionally finished, review the resource group contents
+before deleting that dedicated group; deletion also removes the database and Key
+Vault and is not a rollback strategy.
+
+## Troubleshooting
+
+- **`az` is missing:** install Azure CLI, then run `az login`.
+- **Provider registration fails:** ask a subscription administrator to register the
+  provider named in the error.
+- **`CREATE EXTENSION` fails:** verify PostgreSQL parameter `azure.extensions` contains
+  both `citext` and `pgcrypto`; the Bicep configures them before app startup.
+- **`/healthz` works but `/readyz` fails:** inspect Container App logs and private DNS,
+  subnet delegation, and PostgreSQL state. Do not mark the deployment healthy.
+- **Key Vault reference fails:** confirm the Relay user-assigned identity still has the
+  `Key Vault Secrets User` role and retry after RBAC propagation.

--- a/docs/deploy-azure.md
+++ b/docs/deploy-azure.md
@@ -44,6 +44,9 @@ Container Apps availability for your subscription.
 Interactive user logins are detected automatically. For a service principal or an
 account whose directory object cannot be queried, add
 `--deployer-object-id '<entra-object-id>'` to both commands.
+Keep the same deployment principal for redeployments. Changing it fails closed at the
+stable role assignment instead of leaving the previous principal's secret access
+behind; transfer that access deliberately before changing deployment ownership.
 
 ## Review the change before paying for it
 
@@ -158,13 +161,16 @@ npx -y -p agentrelay-mcp@0.2.1 agentrelay register \
   --role backend
 
 unset AGENTRELAY_ADMIN_TOKEN
+npx -y -p agentrelay-mcp@0.2.1 agentrelay install --client all
 npx -y -p agentrelay-mcp@0.2.1 agentrelay doctor
 ```
 
 Continue with the signed invite and round-trip commands in
-[`onboarding.md`](onboarding.md). The command substitution keeps the token out of the
-command text, but it still exists briefly in the process environment; run it only on a
-trusted administrator machine and unset it immediately.
+[`onboarding.md`](onboarding.md), substituting `agentrelay-mcp@0.2.1` in every pilot
+command on both machines. The command substitution keeps the literal token out of
+shell history, but `--admin-token "$AGENTRELAY_ADMIN_TOKEN"` still exposes it briefly
+in both the process environment and the registration process arguments. Run it only
+on a trusted administrator machine and unset it immediately.
 
 ## Secret handling and redeployment
 
@@ -180,6 +186,9 @@ Never paste Key Vault values into issues, chat, shell history, or logs.
 
 If `deploy.sh` cannot read an existing secret, restore the deployer's Key Vault data
 access. Do not delete the vault or generate replacement values as a workaround.
+If every deployment credential is missing but a Relay or PostgreSQL resource already
+exists, the script also fails closed; restore the original values or deliberately
+retire that partial pilot before starting with a new resource group.
 
 Key Vault role assignments can take time to propagate on the first deployment. If
 Container App creation reports a Key Vault authorization error, wait a few minutes and

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -11,10 +11,9 @@ Mission, and delivery records. The experimental AgentRelay Node, local
 alias-to-checkout mapping, processing journal, and future coding-agent runtime
 adapters stay on each developer's machine. See [`architecture.md`](architecture.md).
 
-This doc is a quick survey of common options as of **May 2026** so you
-don't have to research each one. Pricing changes; verify before
-committing. The project does not endorse any specific platform — pick
-what matches your team's posture.
+This doc is a quick survey of common options. Pricing and free-tier terms change;
+verify each platform before committing. The project does not endorse any specific
+platform — pick what matches your team's posture.
 
 ## Quick comparison
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -11,11 +11,6 @@ Mission, and delivery records. The experimental AgentRelay Node, local
 alias-to-checkout mapping, processing journal, and future coding-agent runtime
 adapters stay on each developer's machine. See [`architecture.md`](architecture.md).
 
-> **Current Compose caveat:** the self-host profile does not yet forward the required
-> `RELAY_INVITE_SECRET` into the relay container. Correct that deployment environment
-> before relying on signed invite onboarding, or use the host-run flow in
-> [`onboarding.md`](onboarding.md).
-
 This doc is a quick survey of common options as of **May 2026** so you
 don't have to research each one. Pricing changes; verify before
 committing. The project does not endorse any specific platform — pick
@@ -29,6 +24,7 @@ what matches your team's posture.
 | **Railway Hobby** | $5 (flat sub + $5 usage credit) | trial only ($5 credit) | low | Push to GitHub, auto-detect Dockerfile, one-click Postgres add-on, custom domain + auto SSL. AgentRelay's tiny load fits inside the included credit. |
 | **Fly.io** | ~$5–10 | ❌ (retired Oct 2024) | medium | Pay-as-you-go: ~$2 VM + ~$5 Postgres dev cluster. New signups need a credit card. Fast deploy via `flyctl`. |
 | **Render Starter** | ~$7 per service | free web service sleeps after 15min | low | Always-on at Starter tier. Postgres add-on extra. Free tier's idle-sleep makes inbox checks slow. |
+| **Azure Container Apps + PostgreSQL** | usage-based | limited grants vary | medium | Managed HTTPS compute plus private managed Postgres. See the repository's explicit pilot template and limitations. |
 | **Oracle Cloud Always Free** | $0 forever | ✅ (4 ARM cores, 24 GB RAM) | high | Most generous free hardware in the industry, but capacity errors during signup are common and Oracle has been known to reclaim idle accounts. |
 | **Self-hosted on your own hardware** (NUC, Pi, NAS) | $0 (you own it) | ✅ | varies | DDNS or Cloudflare Tunnel for the public URL. Fine for a small team. |
 
@@ -69,8 +65,9 @@ The repo ships some reference configs you may find useful, but they're
 not the primary path:
 
 - **`fly.toml`** at the repo root and **`docs/deploy-fly.md`** — a complete Fly walkthrough, kept as a reference for users who already use Fly.
+- **`infra/azure/`** and **`docs/deploy-azure.md`** — a reviewable Azure Container Apps + private PostgreSQL team-pilot deployment.
 - **`.github/workflows/deploy.yml`** — auto-deploy to Fly on `v*.*.*` tag push. Adapt the steps for your platform if it's different.
-- **`docker-compose.yml`** with the `selfhost` profile — the canonical "everything on one box" setup. Use it on any VPS.
+- **`docker-compose.yml`** with the `selfhost` profile — the canonical "everything on one box" setup. It forwards all required Relay secrets from `.env`; use it on any VPS.
 
 If you write a guide for a platform that isn't in this list, PRs are
 welcome. Keep cost notes honest and dated.

--- a/docs/lld.md
+++ b/docs/lld.md
@@ -532,10 +532,9 @@ Some configured values are not yet wired to behavior: there is no metrics route,
 rate-limit middleware, audit-retention job, or OpenTelemetry pipeline in the current
 server.
 
-The self-host Docker profile currently does not forward the required
-`RELAY_INVITE_SECRET` into the relay container. Until that configuration gap is
-fixed, use the host-run contributor flow or explicitly correct the deployment config
-before relying on invite onboarding.
+The self-host Docker profile forwards every required Relay secret from `.env`,
+including `RELAY_INVITE_SECRET`. Its runtime config validation still rejects empty or
+development-only values before the server starts.
 
 ## Validation commands
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -41,14 +41,11 @@ outstanding invites.
 
 ### Team deployment
 
-The relay is a container plus Postgres. See [`hosting.md`](hosting.md) for options and
-[`deploy-fly.md`](deploy-fly.md) for one relay-only worked example.
-
-Current configuration caveat: the repository's `docker compose --profile selfhost`
-service does not forward the required `RELAY_INVITE_SECRET` into the relay container.
-Until that code gap is fixed, do not rely on that profile unchanged for invite-based
-onboarding. Run the relay on the host as above or correct the deployment environment
-explicitly.
+The relay is a container plus Postgres. See [`hosting.md`](hosting.md) for options,
+[`deploy-azure.md`](deploy-azure.md) for the Azure team pilot, and
+[`deploy-fly.md`](deploy-fly.md) for a relay-only Fly example. The repository's
+`docker compose --profile selfhost` service forwards every required Relay secret from
+`.env`, including `RELAY_INVITE_SECRET`.
 
 Set `RELAY_PUBLIC_URL` to the externally reachable HTTPS origin before minting
 invites. The URL is embedded in invite links.

--- a/infra/azure/deploy.sh
+++ b/infra/azure/deploy.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly DEFAULT_IMAGE='ghcr.io/swayamg20/agentrelay-relay@sha256:595586c46b66d0106d420a85148aa6624fa9b72d02235541a3634abb05cdaf54'
+readonly DEFAULT_PREFIX='agentrelay'
+readonly POSTGRES_LOGIN='agentrelay_admin'
+
+usage() {
+	cat <<'EOF'
+Usage:
+  ./infra/azure/deploy.sh plan  --subscription ID --location REGION --resource-group NAME [options]
+  ./infra/azure/deploy.sh apply --subscription ID --location REGION --resource-group NAME [options]
+
+Required:
+  --subscription ID       Azure subscription ID or name
+  --location REGION       Azure region, for example centralindia
+  --resource-group NAME   Dedicated resource group for the pilot
+
+Options:
+  --name-prefix PREFIX    Lowercase resource prefix (default: agentrelay)
+  --image IMAGE           Public Relay image pinned by digest
+  --deployer-object-id ID Override the signed-in user's Entra object ID
+  -h, --help              Show this help
+
+The plan command registers required providers and creates/tags the resource group
+when necessary. It does not create the billable workload. The apply command creates
+or updates the workload. Existing deployments reuse every sticky secret from Key
+Vault; they are never silently regenerated.
+EOF
+}
+
+fail() {
+	printf 'error: %s\n' "$*" >&2
+	exit 1
+}
+
+require_command() {
+	command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+new_hex_secret() {
+	openssl rand -hex "$1"
+}
+
+read_existing_secret() {
+	local secret_name=$1
+	local value
+
+	if ! value=$(az keyvault secret show \
+		--only-show-errors \
+		--vault-name "$key_vault_name" \
+		--name "$secret_name" \
+		--query value \
+		--output tsv); then
+		fail "cannot read '$secret_name' from Key Vault '$key_vault_name'. Do not redeploy until secret-read access is restored; regenerating sticky secrets would break existing credentials."
+	fi
+
+	[[ -n "$value" ]] || fail "Key Vault secret '$secret_name' is empty"
+	printf '%s' "$value"
+}
+
+clear_sensitive_environment() {
+	unset AGENTRELAY_AZURE_POSTGRES_PASSWORD
+	unset AGENTRELAY_AZURE_RELAY_PEPPER
+	unset AGENTRELAY_AZURE_RELAY_ENCRYPTION_KEY
+	unset AGENTRELAY_AZURE_RELAY_INVITE_SECRET
+	unset AGENTRELAY_AZURE_RELAY_ADMIN_TOKEN
+	unset AGENTRELAY_AZURE_RELAY_METRICS_TOKEN
+}
+
+[[ $# -gt 0 ]] || {
+	usage >&2
+	exit 2
+}
+
+case "$1" in
+	plan | apply)
+		mode=$1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		usage >&2
+		fail "first argument must be 'plan' or 'apply'"
+		;;
+esac
+
+subscription=''
+location=''
+resource_group=''
+name_prefix=$DEFAULT_PREFIX
+relay_image=$DEFAULT_IMAGE
+deployer_principal_id=''
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--subscription | --location | --resource-group | --name-prefix | --image | --deployer-object-id)
+			[[ $# -ge 2 ]] || fail "$1 requires a value"
+			case "$1" in
+				--subscription) subscription=$2 ;;
+				--location) location=$2 ;;
+				--resource-group) resource_group=$2 ;;
+				--name-prefix) name_prefix=$2 ;;
+				--image) relay_image=$2 ;;
+				--deployer-object-id) deployer_principal_id=$2 ;;
+			esac
+			shift 2
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*) fail "unknown argument: $1" ;;
+	esac
+done
+
+[[ -n "$subscription" ]] || fail '--subscription is required'
+[[ -n "$location" ]] || fail '--location is required'
+[[ -n "$resource_group" ]] || fail '--resource-group is required'
+[[ "$name_prefix" =~ ^[a-z][a-z0-9]{2,11}$ ]] || fail '--name-prefix must be 3-12 lowercase alphanumeric characters and start with a letter'
+[[ "$location" =~ ^[a-z0-9]+$ ]] || fail '--location must be an Azure region name such as centralindia'
+[[ "$relay_image" =~ ^[A-Za-z0-9./_-]+@sha256:[a-f0-9]{64}$ ]] || fail '--image must be a container image pinned by sha256 digest'
+object_id_pattern='^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+[[ -z "$deployer_principal_id" || "$deployer_principal_id" =~ $object_id_pattern ]] || fail '--deployer-object-id must be an Entra object ID'
+
+require_command az
+require_command openssl
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+trap clear_sensitive_environment EXIT
+
+az account show --only-show-errors >/dev/null 2>&1 || fail 'Azure CLI is not authenticated; run az login first'
+az account set --subscription "$subscription" --only-show-errors
+
+printf 'Validating Bicep...\n'
+if ! az bicep version >/dev/null 2>&1; then
+	printf 'Installing Bicep through Azure CLI...\n'
+	az bicep install --only-show-errors
+fi
+az bicep build --file "$script_dir/main.bicep" --stdout >/dev/null
+
+account_name=$(az account show --query name --output tsv)
+account_id=$(az account show --query id --output tsv)
+
+if [[ -z "$deployer_principal_id" ]]; then
+	deployer_principal_id=$(az ad signed-in-user show --query id --output tsv 2>/dev/null || true)
+	[[ "$deployer_principal_id" =~ $object_id_pattern ]] || fail 'could not resolve the signed-in user object ID; pass --deployer-object-id explicitly (required for service-principal deployments)'
+fi
+
+printf 'Azure subscription: %s (%s)\n' "$account_name" "$account_id"
+printf 'Region: %s\nResource group: %s\n' "$location" "$resource_group"
+
+for provider in \
+	Microsoft.App \
+	Microsoft.DBforPostgreSQL \
+	Microsoft.KeyVault \
+	Microsoft.ManagedIdentity \
+	Microsoft.Network \
+	Microsoft.OperationalInsights; do
+	state=$(az provider show --namespace "$provider" --query registrationState --output tsv 2>/dev/null || true)
+	if [[ "$state" != 'Registered' ]]; then
+		printf 'Registering provider %s...\n' "$provider"
+		az provider register --namespace "$provider" --wait --only-show-errors
+	fi
+done
+
+if ! az group show --name "$resource_group" --only-show-errors >/dev/null 2>&1; then
+	printf 'Creating resource group %s...\n' "$resource_group"
+	az group create \
+		--name "$resource_group" \
+		--location "$location" \
+		--tags application=AgentRelay environment=pilot \
+		--only-show-errors \
+		--output none
+fi
+
+resource_suffix=$(az group show \
+	--name "$resource_group" \
+	--query tags.agentrelaySuffix \
+	--output tsv 2>/dev/null || true)
+
+if [[ ! "$resource_suffix" =~ ^[a-f0-9]{8}$ ]]; then
+	[[ -z "$resource_suffix" || "$resource_suffix" == 'None' ]] || fail "resource group tag agentrelaySuffix has invalid value '$resource_suffix'"
+	resource_suffix=$(new_hex_secret 4)
+	az group update \
+		--name "$resource_group" \
+		--set \
+			tags.application=AgentRelay \
+			tags.environment=pilot \
+			tags.agentrelayPrefix="$name_prefix" \
+			tags.agentrelaySuffix="$resource_suffix" \
+		--only-show-errors \
+		--output none
+fi
+
+stored_prefix=$(az group show \
+	--name "$resource_group" \
+	--query tags.agentrelayPrefix \
+	--output tsv 2>/dev/null || true)
+
+if [[ -z "$stored_prefix" || "$stored_prefix" == 'None' ]]; then
+	az group update \
+		--name "$resource_group" \
+		--set tags.agentrelayPrefix="$name_prefix" \
+		--only-show-errors \
+		--output none
+elif [[ "$stored_prefix" != "$name_prefix" ]]; then
+	fail "resource group is already bound to name prefix '$stored_prefix'; reuse it instead of creating a second pilot"
+fi
+
+key_vault_name="${name_prefix}-${resource_suffix}-kv"
+if az keyvault show --name "$key_vault_name" --resource-group "$resource_group" --only-show-errors >/dev/null 2>&1; then
+	if ! secret_names=$(az keyvault secret list \
+		--vault-name "$key_vault_name" \
+		--query '[].name' \
+		--output tsv \
+		--only-show-errors); then
+		fail "cannot list Key Vault '$key_vault_name'. Restore secret-read access before redeploying."
+	fi
+
+	expected_secrets=(
+		postgres-admin-password
+		relay-pepper
+		relay-encryption-key
+		relay-invite-secret
+		relay-admin-token
+		relay-metrics-token
+	)
+	present_secret_count=0
+	for secret_name in "${expected_secrets[@]}"; do
+		if grep -Fxq "$secret_name" <<<"$secret_names"; then
+			present_secret_count=$((present_secret_count + 1))
+		fi
+	done
+
+	if [[ "$present_secret_count" -eq 0 ]]; then
+		printf 'Key Vault exists without deployment credentials; recovering first-deployment secret generation.\n'
+		postgres_password=$(new_hex_secret 24)
+		relay_pepper=$(new_hex_secret 32)
+		relay_encryption_key=$(new_hex_secret 32)
+		relay_invite_secret=$(new_hex_secret 32)
+		relay_admin_token=$(new_hex_secret 24)
+		relay_metrics_token=$(new_hex_secret 16)
+	elif [[ "$present_secret_count" -ne "${#expected_secrets[@]}" ]]; then
+		fail "Key Vault '$key_vault_name' contains only $present_secret_count of ${#expected_secrets[@]} deployment credentials. Restore the missing values; partial secret replacement is unsafe."
+	else
+		printf 'Reusing sticky secrets from Key Vault %s.\n' "$key_vault_name"
+		postgres_password=$(read_existing_secret postgres-admin-password)
+		relay_pepper=$(read_existing_secret relay-pepper)
+		relay_encryption_key=$(read_existing_secret relay-encryption-key)
+		relay_invite_secret=$(read_existing_secret relay-invite-secret)
+		relay_admin_token=$(read_existing_secret relay-admin-token)
+		relay_metrics_token=$(read_existing_secret relay-metrics-token)
+	fi
+else
+	printf 'Generating first-deployment secrets in memory.\n'
+	postgres_password=$(new_hex_secret 24)
+	relay_pepper=$(new_hex_secret 32)
+	relay_encryption_key=$(new_hex_secret 32)
+	relay_invite_secret=$(new_hex_secret 32)
+	relay_admin_token=$(new_hex_secret 24)
+	relay_metrics_token=$(new_hex_secret 16)
+fi
+
+export AGENTRELAY_AZURE_NAME_PREFIX=$name_prefix
+export AGENTRELAY_AZURE_RESOURCE_SUFFIX=$resource_suffix
+export AGENTRELAY_AZURE_LOCATION=$location
+export AGENTRELAY_AZURE_RELAY_IMAGE=$relay_image
+export AGENTRELAY_AZURE_POSTGRES_LOGIN=$POSTGRES_LOGIN
+export AGENTRELAY_AZURE_DEPLOYER_PRINCIPAL_ID=$deployer_principal_id
+export AGENTRELAY_AZURE_POSTGRES_PASSWORD=$postgres_password
+export AGENTRELAY_AZURE_RELAY_PEPPER=$relay_pepper
+export AGENTRELAY_AZURE_RELAY_ENCRYPTION_KEY=$relay_encryption_key
+export AGENTRELAY_AZURE_RELAY_INVITE_SECRET=$relay_invite_secret
+export AGENTRELAY_AZURE_RELAY_ADMIN_TOKEN=$relay_admin_token
+export AGENTRELAY_AZURE_RELAY_METRICS_TOKEN=$relay_metrics_token
+
+if [[ "$mode" == 'plan' ]]; then
+	printf 'Running Azure what-if (secure values are masked)...\n'
+	az deployment group what-if \
+		--name agentrelay-pilot-plan \
+		--resource-group "$resource_group" \
+		--parameters "$script_dir/main.bicepparam" \
+		--only-show-errors
+	exit 0
+fi
+
+deployment_name="agentrelay-pilot-$(date -u +%Y%m%d%H%M%S)"
+printf 'Applying deployment %s...\n' "$deployment_name"
+relay_url=$(az deployment group create \
+	--name "$deployment_name" \
+	--resource-group "$resource_group" \
+	--parameters "$script_dir/main.bicepparam" \
+	--only-show-errors \
+	--query properties.outputs.relayUrl.value \
+	--output tsv)
+
+[[ "$relay_url" == https://* ]] || fail 'deployment completed without an HTTPS Relay URL output'
+relay_name="${name_prefix}-${resource_suffix}-relay"
+printf '\nRelay deployed: %s\n' "$relay_url"
+printf 'Container App: %s\nKey Vault: %s\n' "$relay_name" "$key_vault_name"
+printf 'Verify it with: %q %q\n' "$script_dir/smoke.sh" "$relay_url"

--- a/infra/azure/deploy.sh
+++ b/infra/azure/deploy.sh
@@ -213,6 +213,8 @@ elif [[ "$stored_prefix" != "$name_prefix" ]]; then
 fi
 
 key_vault_name="${name_prefix}-${resource_suffix}-kv"
+relay_name="${name_prefix}-${resource_suffix}-relay"
+postgres_server_name="${name_prefix}-${resource_suffix}-pg"
 if az keyvault show --name "$key_vault_name" --resource-group "$resource_group" --only-show-errors >/dev/null 2>&1; then
 	if ! secret_names=$(az keyvault secret list \
 		--vault-name "$key_vault_name" \
@@ -238,6 +240,31 @@ if az keyvault show --name "$key_vault_name" --resource-group "$resource_group" 
 	done
 
 	if [[ "$present_secret_count" -eq 0 ]]; then
+		if ! relay_count=$(az resource list \
+			--resource-group "$resource_group" \
+			--name "$relay_name" \
+			--resource-type Microsoft.App/containerApps \
+			--query 'length(@)' \
+			--output tsv \
+			--only-show-errors); then
+			fail 'cannot prove whether an existing Relay depends on the missing credentials'
+		fi
+		if ! postgres_count=$(az resource list \
+			--resource-group "$resource_group" \
+			--name "$postgres_server_name" \
+			--resource-type Microsoft.DBforPostgreSQL/flexibleServers \
+			--query 'length(@)' \
+			--output tsv \
+			--only-show-errors); then
+			fail 'cannot prove whether an existing PostgreSQL server depends on the missing credentials'
+		fi
+		[[ "$relay_count" =~ ^[0-9]+$ ]] || fail 'Azure returned an invalid Relay inventory result'
+		[[ "$postgres_count" =~ ^[0-9]+$ ]] || fail 'Azure returned an invalid PostgreSQL inventory result'
+		if [[ "$relay_count" -ne 0 || "$postgres_count" -ne 0 ]]; then
+			fail \
+				"Key Vault '$key_vault_name' has no deployment credentials, but an existing workload may depend on them." \
+				'Restore the original values; regeneration would break stored credentials or encrypted data.'
+		fi
 		printf 'Key Vault exists without deployment credentials; recovering first-deployment secret generation.\n'
 		postgres_password=$(new_hex_secret 24)
 		relay_pepper=$(new_hex_secret 32)
@@ -300,7 +327,6 @@ relay_url=$(az deployment group create \
 	--output tsv)
 
 [[ "$relay_url" == https://* ]] || fail 'deployment completed without an HTTPS Relay URL output'
-relay_name="${name_prefix}-${resource_suffix}-relay"
 printf '\nRelay deployed: %s\n' "$relay_url"
 printf 'Container App: %s\nKey Vault: %s\n' "$relay_name" "$key_vault_name"
 printf 'Verify it with: %q %q\n' "$script_dir/smoke.sh" "$relay_url"

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -1,0 +1,495 @@
+targetScope = 'resourceGroup'
+
+@description('Lowercase product prefix used in resource names.')
+@minLength(3)
+@maxLength(12)
+param namePrefix string
+
+@description('Stable eight-character lowercase hexadecimal suffix for globally unique names.')
+@minLength(8)
+@maxLength(8)
+param resourceSuffix string
+
+@description('Azure region for every regional resource.')
+param location string = resourceGroup().location
+
+@description('Pinned public Relay container image. Prefer an immutable digest.')
+param relayImage string
+
+@description('PostgreSQL administrator login used by the pilot migration runner and Relay.')
+param postgresAdministratorLogin string = 'agentrelay_admin'
+
+@description('Object ID of the human or service principal running deployments.')
+param deployerPrincipalId string
+
+@secure()
+param postgresAdminPassword string
+
+@secure()
+param relayPepper string
+
+@secure()
+param relayEncryptionKey string
+
+@secure()
+param relayInviteSecret string
+
+@secure()
+param relayAdminToken string
+
+@secure()
+param relayMetricsToken string
+
+var stem = '${namePrefix}-${resourceSuffix}'
+var relayName = '${stem}-relay'
+var keyVaultName = '${stem}-kv'
+var privateDnsZoneName = '${stem}.postgres.database.azure.com'
+var tags = {
+  application: 'AgentRelay'
+  environment: 'pilot'
+  managedBy: 'Bicep'
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+  name: '${stem}-vnet'
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.42.0.0/24'
+      ]
+    }
+  }
+}
+
+resource containerAppsSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
+  parent: virtualNetwork
+  name: 'container-apps'
+  properties: {
+    addressPrefix: '10.42.0.0/27'
+    delegations: [
+      {
+        name: 'Microsoft.App-environments'
+        properties: {
+          serviceName: 'Microsoft.App/environments'
+        }
+      }
+    ]
+  }
+}
+
+resource postgresSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
+  parent: virtualNetwork
+  name: 'postgres'
+  properties: {
+    addressPrefix: '10.42.0.32/28'
+    delegations: [
+      {
+        name: 'Microsoft.DBforPostgreSQL-flexibleServers'
+        properties: {
+          serviceName: 'Microsoft.DBforPostgreSQL/flexibleServers'
+        }
+      }
+    ]
+  }
+}
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+  name: privateDnsZoneName
+  location: 'global'
+  tags: tags
+}
+
+resource privateDnsLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+  parent: privateDnsZone
+  name: 'agentrelay-vnet'
+  location: 'global'
+  tags: tags
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: virtualNetwork.id
+    }
+  }
+}
+
+resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
+  name: '${stem}-pg'
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
+  }
+  properties: {
+    administratorLogin: postgresAdministratorLogin
+    administratorLoginPassword: postgresAdminPassword
+    version: '16'
+    backup: {
+      backupRetentionDays: 7
+      geoRedundantBackup: 'Disabled'
+    }
+    highAvailability: {
+      mode: 'Disabled'
+    }
+    network: {
+      delegatedSubnetResourceId: postgresSubnet.id
+      privateDnsZoneArmResourceId: privateDnsZone.id
+      publicNetworkAccess: 'Disabled'
+    }
+    storage: {
+      storageSizeGB: 32
+    }
+  }
+  dependsOn: [
+    privateDnsLink
+  ]
+}
+
+resource postgresDatabase 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
+  parent: postgres
+  name: 'agentrelay'
+  properties: {
+    charset: 'UTF8'
+    collation: 'en_US.utf8'
+  }
+}
+
+// Azure blocks CREATE EXTENSION until each extension is explicitly allowlisted.
+resource postgresExtensions 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = {
+  parent: postgres
+  name: 'azure.extensions'
+  properties: {
+    source: 'user-override'
+    value: 'citext,pgcrypto'
+  }
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: '${stem}-logs'
+  location: location
+  tags: tags
+  properties: {
+    retentionInDays: 30
+  }
+  sku: {
+    name: 'PerGB2018'
+  }
+}
+
+resource relayIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${stem}-identity'
+  location: location
+  tags: tags
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: keyVaultName
+  location: location
+  tags: tags
+  properties: {
+    tenantId: subscription().tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    enableRbacAuthorization: true
+    enablePurgeProtection: false
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 7
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+var keyVaultSecretsUserRole = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions'
+  '4633458b-17de-408a-b874-0445c86b69e6'
+)
+
+resource relayKeyVaultAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, relayIdentity.id, keyVaultSecretsUserRole)
+  scope: keyVault
+  properties: {
+    principalId: relayIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: keyVaultSecretsUserRole
+  }
+}
+
+resource deployerKeyVaultAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, deployerPrincipalId, keyVaultSecretsUserRole)
+  scope: keyVault
+  properties: {
+    principalId: deployerPrincipalId
+    roleDefinitionId: keyVaultSecretsUserRole
+  }
+}
+
+var databaseUrl = 'postgresql://${postgresAdministratorLogin}:${postgresAdminPassword}@${postgres.properties.fullyQualifiedDomainName}:5432/agentrelay?sslmode=verify-full'
+
+resource databaseUrlSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'relay-database-url'
+  properties: {
+    value: databaseUrl
+  }
+}
+
+// Retained separately so deploy.sh can reuse the database credential without
+// parsing the connection URL during a safe redeployment.
+resource postgresPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'postgres-admin-password'
+  properties: {
+    value: postgresAdminPassword
+  }
+}
+
+resource pepperSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'relay-pepper'
+  properties: {
+    value: relayPepper
+  }
+}
+
+resource encryptionKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'relay-encryption-key'
+  properties: {
+    value: relayEncryptionKey
+  }
+}
+
+resource inviteSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'relay-invite-secret'
+  properties: {
+    value: relayInviteSecret
+  }
+}
+
+resource adminTokenSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'relay-admin-token'
+  properties: {
+    value: relayAdminToken
+  }
+}
+
+resource metricsTokenSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'relay-metrics-token'
+  properties: {
+    value: relayMetricsToken
+  }
+}
+
+resource containerEnvironment 'Microsoft.App/managedEnvironments@2025-01-01' = {
+  name: '${stem}-cae'
+  location: location
+  tags: tags
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+    vnetConfiguration: {
+      infrastructureSubnetId: containerAppsSubnet.id
+      internal: false
+    }
+    zoneRedundant: false
+  }
+}
+
+var relayPublicUrl = 'https://${relayName}.${containerEnvironment.properties.defaultDomain}'
+
+resource relay 'Microsoft.App/containerApps@2025-01-01' = {
+  name: relayName
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${relayIdentity.id}': {}
+    }
+  }
+  properties: {
+    environmentId: containerEnvironment.id
+    workloadProfileName: 'Consumption'
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        allowInsecure: false
+        external: true
+        targetPort: 8080
+        transport: 'auto'
+      }
+      secrets: [
+        {
+          identity: relayIdentity.id
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/${databaseUrlSecret.name}'
+          name: 'database-url'
+        }
+        {
+          identity: relayIdentity.id
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/${pepperSecret.name}'
+          name: 'pepper'
+        }
+        {
+          identity: relayIdentity.id
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/${encryptionKeySecret.name}'
+          name: 'encryption-key'
+        }
+        {
+          identity: relayIdentity.id
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/${inviteSecret.name}'
+          name: 'invite-secret'
+        }
+        {
+          identity: relayIdentity.id
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/${adminTokenSecret.name}'
+          name: 'admin-token'
+        }
+        {
+          identity: relayIdentity.id
+          keyVaultUrl: '${keyVault.properties.vaultUri}secrets/${metricsTokenSecret.name}'
+          name: 'metrics-token'
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'relay'
+          image: relayImage
+          env: [
+            {
+              name: 'RELAY_DATABASE_URL'
+              secretRef: 'database-url'
+            }
+            {
+              name: 'RELAY_PEPPER'
+              secretRef: 'pepper'
+            }
+            {
+              name: 'RELAY_ENCRYPTION_KEY'
+              secretRef: 'encryption-key'
+            }
+            {
+              name: 'RELAY_INVITE_SECRET'
+              secretRef: 'invite-secret'
+            }
+            {
+              name: 'RELAY_ADMIN_TOKEN'
+              secretRef: 'admin-token'
+            }
+            {
+              name: 'RELAY_METRICS_TOKEN'
+              secretRef: 'metrics-token'
+            }
+            {
+              name: 'RELAY_PUBLIC_URL'
+              value: relayPublicUrl
+            }
+            {
+              name: 'RELAY_ENV'
+              value: 'production'
+            }
+            {
+              name: 'RELAY_LOG_LEVEL'
+              value: 'info'
+            }
+            {
+              name: 'RELAY_PORT'
+              value: '8080'
+            }
+            {
+              name: 'RELAY_AUDIT_RETENTION_DAYS'
+              value: '90'
+            }
+            {
+              name: 'RELAY_RATE_LIMIT_PER_MIN'
+              value: '60'
+            }
+            {
+              name: 'RELAY_DB_POOL_SIZE'
+              value: '5'
+            }
+          ]
+          probes: [
+            {
+              type: 'Startup'
+              httpGet: {
+                path: '/healthz'
+                port: 8080
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 20
+              periodSeconds: 10
+              timeoutSeconds: 3
+              failureThreshold: 10
+              successThreshold: 1
+            }
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/healthz'
+                port: 8080
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 3
+              failureThreshold: 3
+              successThreshold: 1
+            }
+            {
+              type: 'Readiness'
+              httpGet: {
+                path: '/readyz'
+                port: 8080
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 5
+              periodSeconds: 5
+              timeoutSeconds: 3
+              failureThreshold: 10
+              successThreshold: 1
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+  dependsOn: [
+    postgresDatabase
+    postgresExtensions
+    databaseUrlSecret
+    pepperSecret
+    encryptionKeySecret
+    inviteSecret
+    adminTokenSecret
+    metricsTokenSecret
+    relayKeyVaultAccess
+  ]
+}
+
+output relayUrl string = relayPublicUrl
+output relayName string = relay.name
+output containerEnvironmentName string = containerEnvironment.name
+output keyVaultName string = keyVault.name
+output postgresServerName string = postgres.name
+output deployedRelayImage string = relayImage

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -172,9 +172,9 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   tags: tags
   properties: {
     retentionInDays: 30
-  }
-  sku: {
-    name: 'PerGB2018'
+    sku: {
+      name: 'PerGB2018'
+    }
   }
 }
 
@@ -203,7 +203,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
 }
 
 var keyVaultSecretsUserRole = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions'
+  'Microsoft.Authorization/roleDefinitions',
   '4633458b-17de-408a-b874-0445c86b69e6'
 )
 
@@ -218,7 +218,9 @@ resource relayKeyVaultAccess 'Microsoft.Authorization/roleAssignments@2022-04-01
 }
 
 resource deployerKeyVaultAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(keyVault.id, deployerPrincipalId, keyVaultSecretsUserRole)
+  // A stable name makes a principal change fail closed instead of silently
+  // retaining the old deployer's secret access in incremental deployments.
+  name: guid(keyVault.id, 'agentrelay-deployer-secrets-user', keyVaultSecretsUserRole)
   scope: keyVault
   properties: {
     principalId: deployerPrincipalId
@@ -477,12 +479,6 @@ resource relay 'Microsoft.App/containerApps@2025-01-01' = {
   dependsOn: [
     postgresDatabase
     postgresExtensions
-    databaseUrlSecret
-    pepperSecret
-    encryptionKeySecret
-    inviteSecret
-    adminTokenSecret
-    metricsTokenSecret
     relayKeyVaultAccess
   ]
 }

--- a/infra/azure/main.bicepparam
+++ b/infra/azure/main.bicepparam
@@ -1,0 +1,14 @@
+using './main.bicep'
+
+param namePrefix = readEnvironmentVariable('AGENTRELAY_AZURE_NAME_PREFIX')
+param resourceSuffix = readEnvironmentVariable('AGENTRELAY_AZURE_RESOURCE_SUFFIX')
+param location = readEnvironmentVariable('AGENTRELAY_AZURE_LOCATION')
+param relayImage = readEnvironmentVariable('AGENTRELAY_AZURE_RELAY_IMAGE')
+param postgresAdministratorLogin = readEnvironmentVariable('AGENTRELAY_AZURE_POSTGRES_LOGIN')
+param deployerPrincipalId = readEnvironmentVariable('AGENTRELAY_AZURE_DEPLOYER_PRINCIPAL_ID')
+param postgresAdminPassword = readEnvironmentVariable('AGENTRELAY_AZURE_POSTGRES_PASSWORD')
+param relayPepper = readEnvironmentVariable('AGENTRELAY_AZURE_RELAY_PEPPER')
+param relayEncryptionKey = readEnvironmentVariable('AGENTRELAY_AZURE_RELAY_ENCRYPTION_KEY')
+param relayInviteSecret = readEnvironmentVariable('AGENTRELAY_AZURE_RELAY_INVITE_SECRET')
+param relayAdminToken = readEnvironmentVariable('AGENTRELAY_AZURE_RELAY_ADMIN_TOKEN')
+param relayMetricsToken = readEnvironmentVariable('AGENTRELAY_AZURE_RELAY_METRICS_TOKEN')

--- a/infra/azure/smoke.sh
+++ b/infra/azure/smoke.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: ./infra/azure/smoke.sh https://your-relay-host
+
+Checks the Relay process and its database-backed readiness endpoint. This does not
+replace the two-machine invite, send, restart, receive, and reply pilot described in
+docs/deploy-azure.md.
+EOF
+}
+
+fail() {
+	printf 'error: %s\n' "$*" >&2
+	exit 1
+}
+
+[[ $# -eq 1 ]] || {
+	usage >&2
+	exit 2
+}
+
+relay_url=${1%/}
+[[ "$relay_url" == https://* ]] || fail 'Relay URL must use HTTPS'
+command -v curl >/dev/null 2>&1 || fail 'required command not found: curl'
+
+health=$(curl --fail --silent --show-error --max-time 15 "$relay_url/healthz")
+[[ "$health" == '{"status":"ok"}' ]] || fail "unexpected /healthz response: $health"
+printf 'healthz: ok\n'
+
+ready=$(curl --fail --silent --show-error --max-time 15 "$relay_url/readyz")
+[[ "$ready" == '{"status":"ready"}' ]] || fail "unexpected /readyz response: $ready"
+printf 'readyz: ready (database reachable)\n'
+
+printf '\nRelay smoke check passed: %s\n' "$relay_url"
+printf 'Next: complete the two-machine durability pilot in docs/deploy-azure.md.\n'


### PR DESCRIPTION
## Summary

- add a review-first Azure Container Apps + private PostgreSQL pilot
- keep Relay credentials in Key Vault and preserve sticky secrets on redeploy
- pin the public Relay image by digest, keep migrations single-replica, and probe both process and database readiness
- forward RELAY_INVITE_SECRET in the self-host Compose profile
- add the Azure runbook and update onboarding, hosting, LLD, and README links

## Validation

- Bicep 0.46.1 builds the template and parameter file with zero warnings/errors
- bash syntax and Docker Compose config pass
- pnpm lint, recursive typecheck, recursive build, and protocol export checks pass
- 544 database-free package tests pass locally
- two independent read-only Azure/security reviews report no remaining blocker

## Deployment boundary

No Azure resources are provisioned by this PR. The local machine has no authenticated Azure CLI context. The first live step is an explicit subscription/region/resource-group what-if, followed by apply only after review.
