### PR TITLE
chore: harden open-source repository controls

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,19 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -78,11 +81,11 @@ jobs:
       matrix:
         node: [20, 22]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -104,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Build relay image
         run: docker build --tag agentrelay-relay:ci --file relay/Dockerfile .
@@ -136,11 +139,11 @@ jobs:
           --health-interval 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -181,11 +184,11 @@ jobs:
           --health-interval 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,16 +29,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload landing page
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: landing
 
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy relay to Fly.io
@@ -27,10 +30,10 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Deploy
         run: flyctl deploy --remote-only

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -32,7 +32,6 @@ concurrency:
 permissions:
   contents: read
   packages: write
-  id-token: write
 
 env:
   REGISTRY: ghcr.io
@@ -45,16 +44,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -62,7 +61,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE_NAME }}
           # Tag plan:
@@ -85,7 +84,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: relay/Dockerfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,8 +179,8 @@ For docs-only changes, run at least `git diff --check` and check local links.
 - Do not mix unrelated refactoring into a product or bug-fix PR.
 
 Open PRs against `main`, or against the explicit prerequisite branch when recording a
-short-lived stacked change. Report security issues privately to the maintainer rather
-than opening a public issue.
+short-lived stacked change. Report security issues through the private process in
+[`SECURITY.md`](SECURITY.md), not through a public issue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@
 [Use it today](#use-agentrelay-today) · [Product shape](#the-product-shape) ·
 [Roadmap](docs/roadmap.md)
 
+> [!IMPORTANT]
+> **Usable today:** the published `agentrelay-mcp` 0.2.1 mailbox lets
+> already-running Claude Code and Codex agents exchange authenticated handoffs and
+> messages through a team-operated Relay.
+>
+> **Not usable today:** autonomous Missions. Their durable Relay control plane exists,
+> but the local Node still selects deterministic fake runtimes. The guarded Codex path
+> has not been activated for a real model turn, and production runtime supervision,
+> policy enforcement, OS containment, and the two-machine proof remain incomplete.
+
 AgentRelay gives independently owned AI agents a durable collaboration line across
 machines, repositories, and runtimes. They can exchange questions, contracts, and
 evidence while repositories, credentials, and local authority stay with their
@@ -169,10 +179,11 @@ and production credentials remain denied.
 
 ## Use AgentRelay today
 
-Start with the published `agentrelay-mcp` mailbox. It connects already-running Claude
-Code and Codex hosts to a Relay your team configures; no public hosted Relay is
-bundled yet. Each developer needs Node 20.18.1+ and an AgentRelay identity. Package-specific
-details live in
+Start with the published `agentrelay-mcp` mailbox. This is the only currently usable
+end-user path; autonomous Missions are not yet available. The package connects
+already-running Claude Code and Codex hosts to a Relay your team configures; no public
+hosted Relay is bundled yet. Each developer needs Node 20.18.1+ and an AgentRelay
+identity. Package-specific details live in
 [`mcp-server/README.md`](mcp-server/README.md).
 
 Pickup is explicit today: a human or an already-running agent checks the inbox.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are applied to the latest `agentrelay-mcp` 0.2.x release and the
+current `main` branch of the Relay. Older package releases and unactivated experimental
+Node/Capsule checkpoints are not maintained as separate release lines.
+
+## Report a vulnerability privately
+
+Do not open a public issue for a suspected vulnerability.
+
+Use GitHub's [private vulnerability reporting][private-reporting] to send the report to
+the maintainer. Include:
+
+- the affected package, route, command, or commit;
+- the security impact and prerequisites;
+- minimal reproduction steps or a proof of concept;
+- whether credentials, teammate content, or local workspace authority are exposed; and
+- any known workaround.
+
+Please do not include real API keys, invite tokens, webhook URLs, private repository
+content, or other people's data. Use synthetic values in reproductions.
+
+The maintainer will aim to acknowledge a report within five business days, then share
+the initial severity and remediation plan after reproducing it. Resolution and
+disclosure timing depend on impact and fix complexity. Coordinate public disclosure
+through the private advisory.
+
+## Security boundary
+
+Peer messages and artifacts are untrusted input. The published MCP mailbox does not
+grant remote content authority to push, publish, deploy, access credentials, or run
+arbitrary commands. Autonomous Missions and the real-runtime Node path are experimental
+and are not currently presented as a production security boundary.
+
+[private-reporting]: https://github.com/swayamg20/AgentRelay/security/advisories/new


### PR DESCRIPTION
## Summary

- make the shipped MCP mailbox versus unavailable autonomous Missions boundary explicit
- add a private vulnerability reporting policy
- pin every GitHub Action to an immutable commit
- add weekly Dependabot maintenance for Actions and pnpm dependencies
- reduce workflow token permissions where possible

## Repository settings already applied

- protect release tags from deletion and movement
- enable vulnerability alerts and Dependabot security updates
- enable private vulnerability reporting
- enable CodeQL default setup for JavaScript/TypeScript

## Validation

- `git diff --check`
- YAML parse for all changed workflows and Dependabot config
- all 25 action pins resolved through GitHub and contain an action manifest
- local Markdown links across 27 files
- `pnpm lint` (passes with four pre-existing unused-suppression warnings)
