### PR TITLE
fix(actions): pin privileged workflow tools

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
+      - name: Install verified flyctl
+        env:
+          FLYCTL_VERSION: 0.4.80
+          FLYCTL_ARCHIVE_SHA256: 6444747d922f1763152d665d378c98bb21aa9b0aa773c4318a9a2c10b2ff54da
+        run: |
+          archive="$RUNNER_TEMP/flyctl.tar.gz"
+          install_dir="$RUNNER_TEMP/flyctl-bin"
+          curl --fail --silent --show-error --location \
+            "https://github.com/superfly/flyctl/releases/download/v${FLYCTL_VERSION}/flyctl_${FLYCTL_VERSION}_Linux_x86_64.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$FLYCTL_ARCHIVE_SHA256" "$archive" | sha256sum --check
+          mkdir -p "$install_dir"
+          tar --extract --gzip --file "$archive" --directory "$install_dir" flyctl
+          echo "$install_dir" >> "$GITHUB_PATH"
 
       - name: Deploy
         run: flyctl deploy --remote-only

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -48,6 +48,9 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        with:
+          image: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3


### PR DESCRIPTION
## Summary

- replace the mutable flyctl installer path with an exact v0.4.80 archive and verified SHA-256
- pin the privileged QEMU binfmt image to an immutable OCI digest
- install only arm64 emulation, the sole non-native target in the image matrix

## Validation

- parsed both changed workflow YAML files
- independently downloaded and verified the official flyctl Linux x86_64 archive checksum
- resolved the pinned binfmt OCI index by digest
- `git diff --check`