### PR TITLE
fix(relay): upgrade Drizzle dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^16.4.7
         version: 16.6.1
       drizzle-orm:
-        specifier: ^0.36.4
-        version: 0.36.4(postgres@3.4.9)
+        specifier: ^0.45.2
+        version: 0.45.2(postgres@3.4.9)
       hono:
         specifier: ^4.6.13
         version: 4.12.15
@@ -133,8 +133,8 @@ importers:
         specifier: ^22.10.0
         version: 22.19.17
       drizzle-kit:
-        specifier: ^0.28.1
-        version: 0.28.1
+        specifier: ^0.31.10
+        version: 0.31.10
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -233,17 +233,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
-
-  '@esbuild/aix-ppc64@0.19.12':
-    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -253,6 +247,12 @@ packages:
 
   '@esbuild/aix-ppc64@0.23.1':
     resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -269,12 +269,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.19.12':
-    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -283,6 +277,12 @@ packages:
 
   '@esbuild/android-arm64@0.23.1':
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -299,12 +299,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.19.12':
-    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.21.5':
     resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
@@ -313,6 +307,12 @@ packages:
 
   '@esbuild/android-arm@0.23.1':
     resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -329,12 +329,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.19.12':
-    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -343,6 +337,12 @@ packages:
 
   '@esbuild/android-x64@0.23.1':
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -359,12 +359,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.19.12':
-    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
@@ -373,6 +367,12 @@ packages:
 
   '@esbuild/darwin-arm64@0.23.1':
     resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -389,12 +389,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.19.12':
-    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -403,6 +397,12 @@ packages:
 
   '@esbuild/darwin-x64@0.23.1':
     resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -419,12 +419,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.19.12':
-    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
@@ -433,6 +427,12 @@ packages:
 
   '@esbuild/freebsd-arm64@0.23.1':
     resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -449,12 +449,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.19.12':
-    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -463,6 +457,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.23.1':
     resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -479,12 +479,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.19.12':
-    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
@@ -493,6 +487,12 @@ packages:
 
   '@esbuild/linux-arm64@0.23.1':
     resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -509,12 +509,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.19.12':
-    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -523,6 +517,12 @@ packages:
 
   '@esbuild/linux-arm@0.23.1':
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -539,12 +539,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.19.12':
-    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
@@ -553,6 +547,12 @@ packages:
 
   '@esbuild/linux-ia32@0.23.1':
     resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -569,12 +569,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.19.12':
-    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -583,6 +577,12 @@ packages:
 
   '@esbuild/linux-loong64@0.23.1':
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -599,12 +599,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.19.12':
-    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
@@ -613,6 +607,12 @@ packages:
 
   '@esbuild/linux-mips64el@0.23.1':
     resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -629,12 +629,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.19.12':
-    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -643,6 +637,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.23.1':
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -659,12 +659,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.19.12':
-    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
@@ -673,6 +667,12 @@ packages:
 
   '@esbuild/linux-riscv64@0.23.1':
     resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -689,12 +689,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.19.12':
-    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -703,6 +697,12 @@ packages:
 
   '@esbuild/linux-s390x@0.23.1':
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -719,12 +719,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.19.12':
-    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
@@ -737,11 +731,23 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
@@ -751,12 +757,6 @@ packages:
 
   '@esbuild/netbsd-x64@0.18.20':
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.19.12':
-    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -773,6 +773,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.7':
     resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
@@ -781,6 +787,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -797,12 +809,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.19.12':
-    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
@@ -815,11 +821,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.27.7':
     resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
@@ -829,12 +847,6 @@ packages:
 
   '@esbuild/sunos-x64@0.18.20':
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.19.12':
-    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -851,6 +863,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
@@ -859,12 +877,6 @@ packages:
 
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.19.12':
-    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -881,6 +893,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
@@ -889,12 +907,6 @@ packages:
 
   '@esbuild/win32-ia32@0.18.20':
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.19.12':
-    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -911,6 +923,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -923,12 +941,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.19.12':
-    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -937,6 +949,12 @@ packages:
 
   '@esbuild/win32-x64@0.23.1':
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1234,40 +1252,40 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
-  drizzle-kit@0.28.1:
-    resolution: {integrity: sha512-JimOV+ystXTWMgZkLHYHf2w3oS28hxiH1FR0dkmJLc7GHzdGJoJAQtQS5DRppnabsRZwE2U1F6CuezVBgmsBBQ==}
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.36.4:
-    resolution: {integrity: sha512-1OZY3PXD7BR00Gl61UUOFihslDldfH4NFRH2MbP54Yxi0G/PKn4HfO65JYZ7c16DeP3SpM3Aw+VXVG9j6CRSXA==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': '>=3'
+      '@cloudflare/workers-types': '>=4'
       '@electric-sql/pglite': '>=0.2.0'
       '@libsql/client': '>=0.10.0'
       '@libsql/client-wasm': '>=0.10.0'
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
-      '@types/react': '>=18'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
-      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -1297,9 +1315,9 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/react':
-        optional: true
       '@types/sql.js':
+        optional: true
+      '@upstash/redis':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -1310,6 +1328,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -1322,8 +1342,6 @@ packages:
       postgres:
         optional: true
       prisma:
-        optional: true
-      react:
         optional: true
       sql.js:
         optional: true
@@ -1356,18 +1374,8 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  esbuild-register@3.6.0:
-    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
-    peerDependencies:
-      esbuild: '>=0.12 <1'
-
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  esbuild@0.19.12:
-    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -1378,6 +1386,11 @@ packages:
 
   esbuild@0.23.1:
     resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1918,13 +1931,13 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.14.0
 
-  '@esbuild/aix-ppc64@0.19.12':
-    optional: true
-
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
   '@esbuild/aix-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -1933,13 +1946,13 @@ snapshots:
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
-  '@esbuild/android-arm64@0.19.12':
-    optional: true
-
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
@@ -1948,13 +1961,13 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
-  '@esbuild/android-arm@0.19.12':
-    optional: true
-
   '@esbuild/android-arm@0.21.5':
     optional: true
 
   '@esbuild/android-arm@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
@@ -1963,13 +1976,13 @@ snapshots:
   '@esbuild/android-x64@0.18.20':
     optional: true
 
-  '@esbuild/android-x64@0.19.12':
-    optional: true
-
   '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
@@ -1978,13 +1991,13 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
-  '@esbuild/darwin-arm64@0.19.12':
-    optional: true
-
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
   '@esbuild/darwin-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
@@ -1993,13 +2006,13 @@ snapshots:
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
-  '@esbuild/darwin-x64@0.19.12':
-    optional: true
-
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
@@ -2008,13 +2021,13 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.19.12':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
@@ -2023,13 +2036,13 @@ snapshots:
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/freebsd-x64@0.19.12':
-    optional: true
-
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -2038,13 +2051,13 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
-  '@esbuild/linux-arm64@0.19.12':
-    optional: true
-
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
   '@esbuild/linux-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
@@ -2053,13 +2066,13 @@ snapshots:
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
-  '@esbuild/linux-arm@0.19.12':
-    optional: true
-
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
@@ -2068,13 +2081,13 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
-  '@esbuild/linux-ia32@0.19.12':
-    optional: true
-
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
   '@esbuild/linux-ia32@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
@@ -2083,13 +2096,13 @@ snapshots:
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
-  '@esbuild/linux-loong64@0.19.12':
-    optional: true
-
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
@@ -2098,13 +2111,13 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
-  '@esbuild/linux-mips64el@0.19.12':
-    optional: true
-
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
   '@esbuild/linux-mips64el@0.23.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
@@ -2113,13 +2126,13 @@ snapshots:
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
-  '@esbuild/linux-ppc64@0.19.12':
-    optional: true
-
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -2128,13 +2141,13 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
-  '@esbuild/linux-riscv64@0.19.12':
-    optional: true
-
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
   '@esbuild/linux-riscv64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
@@ -2143,13 +2156,13 @@ snapshots:
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
-  '@esbuild/linux-s390x@0.19.12':
-    optional: true
-
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
@@ -2158,16 +2171,19 @@ snapshots:
   '@esbuild/linux-x64@0.18.20':
     optional: true
 
-  '@esbuild/linux-x64@0.19.12':
-    optional: true
-
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.23.1':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
@@ -2176,13 +2192,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/netbsd-x64@0.19.12':
-    optional: true
-
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -2191,13 +2207,13 @@ snapshots:
   '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -2206,7 +2222,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
@@ -2215,13 +2237,13 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
-  '@esbuild/sunos-x64@0.19.12':
-    optional: true
-
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
   '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
@@ -2230,13 +2252,13 @@ snapshots:
   '@esbuild/win32-arm64@0.18.20':
     optional: true
 
-  '@esbuild/win32-arm64@0.19.12':
-    optional: true
-
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
@@ -2245,13 +2267,13 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
-  '@esbuild/win32-ia32@0.19.12':
-    optional: true
-
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
   '@esbuild/win32-ia32@0.23.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
@@ -2260,13 +2282,13 @@ snapshots:
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
-  '@esbuild/win32-x64@0.19.12':
-    optional: true
-
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -2516,16 +2538,14 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  drizzle-kit@0.28.1:
+  drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
-      esbuild: 0.19.12
-      esbuild-register: 3.6.0(esbuild@0.19.12)
-    transitivePeerDependencies:
-      - supports-color
+      esbuild: 0.25.12
+      tsx: 4.21.0
 
-  drizzle-orm@0.36.4(postgres@3.4.9):
+  drizzle-orm@0.45.2(postgres@3.4.9):
     optionalDependencies:
       postgres: 3.4.9
 
@@ -2548,13 +2568,6 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-
-  esbuild-register@3.6.0(esbuild@0.19.12):
-    dependencies:
-      debug: 4.4.3
-      esbuild: 0.19.12
-    transitivePeerDependencies:
-      - supports-color
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -2580,32 +2593,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
-
-  esbuild@0.19.12:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.12
-      '@esbuild/android-arm': 0.19.12
-      '@esbuild/android-arm64': 0.19.12
-      '@esbuild/android-x64': 0.19.12
-      '@esbuild/darwin-arm64': 0.19.12
-      '@esbuild/darwin-x64': 0.19.12
-      '@esbuild/freebsd-arm64': 0.19.12
-      '@esbuild/freebsd-x64': 0.19.12
-      '@esbuild/linux-arm': 0.19.12
-      '@esbuild/linux-arm64': 0.19.12
-      '@esbuild/linux-ia32': 0.19.12
-      '@esbuild/linux-loong64': 0.19.12
-      '@esbuild/linux-mips64el': 0.19.12
-      '@esbuild/linux-ppc64': 0.19.12
-      '@esbuild/linux-riscv64': 0.19.12
-      '@esbuild/linux-s390x': 0.19.12
-      '@esbuild/linux-x64': 0.19.12
-      '@esbuild/netbsd-x64': 0.19.12
-      '@esbuild/openbsd-x64': 0.19.12
-      '@esbuild/sunos-x64': 0.19.12
-      '@esbuild/win32-arm64': 0.19.12
-      '@esbuild/win32-ia32': 0.19.12
-      '@esbuild/win32-x64': 0.19.12
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2659,6 +2646,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.7:
     optionalDependencies:

--- a/relay/package.json
+++ b/relay/package.json
@@ -31,7 +31,7 @@
 		"@agentrelay/protocol": "workspace:*",
 		"@hono/node-server": "^1.13.7",
 		"dotenv": "^16.4.7",
-		"drizzle-orm": "^0.36.4",
+		"drizzle-orm": "^0.45.2",
 		"hono": "^4.6.13",
 		"pino": "^9.5.0",
 		"postgres": "^3.4.5",
@@ -39,7 +39,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.0",
-		"drizzle-kit": "^0.28.1",
+		"drizzle-kit": "^0.31.10",
 		"tsx": "^4.19.2",
 		"typescript": "^5.7.2",
 		"vitest": "^2.1.8"

--- a/relay/src/db/schema.test.ts
+++ b/relay/src/db/schema.test.ts
@@ -53,7 +53,7 @@ d("db schema integration", () => {
 				role: "r",
 				status: "sideways",
 			}),
-		).rejects.toThrow(/agents_status_chk/);
+		).rejects.toMatchObject({ cause: { message: expect.stringMatching(/agents_status_chk/) } });
 	});
 
 	it("agent_cards: round-trips with array + jsonb defaults", async () => {
@@ -78,7 +78,9 @@ d("db schema integration", () => {
 		// duplicate active hash blocked
 		await expect(
 			handle.db.insert(apiKeys).values({ agentId, keyHash: hash, salt }),
-		).rejects.toThrow(/idx_api_keys_active_hash/);
+		).rejects.toMatchObject({
+			cause: { message: expect.stringMatching(/idx_api_keys_active_hash/) },
+		});
 
 		// revoking the original allows reissuing
 		await handle.db
@@ -98,7 +100,9 @@ d("db schema integration", () => {
 				recipientId: agentId,
 				summary: "self-talk",
 			}),
-		).rejects.toThrow(/handoffs_sender_not_recipient/);
+		).rejects.toMatchObject({
+			cause: { message: expect.stringMatching(/handoffs_sender_not_recipient/) },
+		});
 	});
 
 	it("handoffs: enforces intent enum", async () => {
@@ -121,7 +125,9 @@ d("db schema integration", () => {
 				summary: "hi",
 				intent: "demand",
 			}),
-		).rejects.toThrow(/handoffs_intent_valid/);
+		).rejects.toMatchObject({
+			cause: { message: expect.stringMatching(/handoffs_intent_valid/) },
+		});
 	});
 
 	it("handoffs: enforces proposed_action invariant", async () => {
@@ -146,7 +152,9 @@ d("db schema integration", () => {
 				intent: "inform",
 				proposedAction: { description: "no", target_files: [], rationale: "no" },
 			}),
-		).rejects.toThrow(/handoffs_proposed_action_invariant/);
+		).rejects.toMatchObject({
+			cause: { message: expect.stringMatching(/handoffs_proposed_action_invariant/) },
+		});
 
 		// intent='propose_action' without proposed_action → fail
 		await expect(
@@ -156,7 +164,9 @@ d("db schema integration", () => {
 				summary: "x",
 				intent: "propose_action",
 			}),
-		).rejects.toThrow(/handoffs_proposed_action_invariant/);
+		).rejects.toMatchObject({
+			cause: { message: expect.stringMatching(/handoffs_proposed_action_invariant/) },
+		});
 
 		// intent='propose_action' with proposed_action → ok
 		const [ok] = await handle.db
@@ -206,7 +216,7 @@ d("db schema integration", () => {
 			handle.db
 				.insert(messages)
 				.values({ handoffId: h.id, authorId: senderId, body: "dup", sequenceNo: 1 }),
-		).rejects.toThrow(/idx_messages_seq/);
+		).rejects.toMatchObject({ cause: { message: expect.stringMatching(/idx_messages_seq/) } });
 	});
 
 	it("audit_log: round-trips typed actors and bigserial id auto-increments", async () => {
@@ -253,7 +263,9 @@ d("db schema integration", () => {
 				resourceType: "agent",
 				resourceId: agentId,
 			}),
-		).rejects.toThrow(/audit_log_actor_identity_chk/);
+		).rejects.toMatchObject({
+			cause: { message: expect.stringMatching(/audit_log_actor_identity_chk/) },
+		});
 	});
 
 	it("updated_at trigger advances timestamp on UPDATE", async () => {

--- a/relay/src/logger.test.ts
+++ b/relay/src/logger.test.ts
@@ -57,6 +57,47 @@ describe("relay logger", () => {
 		});
 	});
 
+	it("removes query details from a wrapped Drizzle error", () => {
+		const sensitiveBody = "sentinel-wrapped-message-body";
+		const drizzleError = new DrizzleQueryError(
+			"insert into messages (body) values ($1)",
+			[sensitiveBody],
+			Object.assign(new Error(`database rejected ${sensitiveBody}`), {
+				code: "23514",
+				severity: "ERROR",
+			}),
+		);
+		const entry = captureError(new Error("outer request diagnostic", { cause: drizzleError }));
+		const serialized = JSON.stringify(entry);
+
+		expect(entry.err).toEqual({
+			type: "DrizzleQueryError",
+			code: "23514",
+			severity: "ERROR",
+		});
+		expect(serialized).not.toContain(sensitiveBody);
+		expect(serialized).not.toContain("insert into messages");
+		expect(serialized).not.toContain("database rejected");
+	});
+
+	it("removes query details from an aggregated Drizzle error", () => {
+		const sensitiveBody = "sentinel-aggregated-message-body";
+		const drizzleError = new DrizzleQueryError(
+			"update messages set body = $1",
+			[sensitiveBody],
+			new Error(`database rejected ${sensitiveBody}`),
+		);
+		const entry = captureError(
+			new AggregateError([new Error("ordinary batch error"), drizzleError], "batch failed"),
+		);
+		const serialized = JSON.stringify(entry);
+
+		expect(entry.err).toEqual({ type: "DrizzleQueryError" });
+		expect(serialized).not.toContain(sensitiveBody);
+		expect(serialized).not.toContain("update messages");
+		expect(serialized).not.toContain("database rejected");
+	});
+
 	it("omits unrecognized Drizzle cause metadata", () => {
 		const sensitiveMetadata = "sentinel-arbitrary-cause-value";
 		const error = new DrizzleQueryError(

--- a/relay/src/logger.test.ts
+++ b/relay/src/logger.test.ts
@@ -98,6 +98,26 @@ describe("relay logger", () => {
 		expect(serialized).not.toContain("database rejected");
 	});
 
+	it("removes query details from a Drizzle error in a standard error array", () => {
+		const sensitiveBody = "sentinel-custom-error-array-body";
+		const drizzleError = new DrizzleQueryError(
+			"delete from messages where body = $1",
+			[sensitiveBody],
+			new Error(`database rejected ${sensitiveBody}`),
+		);
+		const entry = captureError(
+			Object.assign(new Error("custom batch failed"), {
+				errors: [new Error("ordinary batch error"), drizzleError],
+			}),
+		);
+		const serialized = JSON.stringify(entry);
+
+		expect(entry.err).toEqual({ type: "DrizzleQueryError" });
+		expect(serialized).not.toContain(sensitiveBody);
+		expect(serialized).not.toContain("delete from messages");
+		expect(serialized).not.toContain("database rejected");
+	});
+
 	it("omits unrecognized Drizzle cause metadata", () => {
 		const sensitiveMetadata = "sentinel-arbitrary-cause-value";
 		const error = new DrizzleQueryError(

--- a/relay/src/logger.test.ts
+++ b/relay/src/logger.test.ts
@@ -15,11 +15,40 @@ function captureError(error: unknown): Record<string, unknown> {
 		output += chunk.toString("utf8");
 	});
 
-	createLogger(LOG_CONFIG, destination)
-		.child({ request_id: "req_test" })
-		.error({ err: error }, "request failed");
+	const logger = createLogger(LOG_CONFIG, destination);
+	logger.child({ request_id: "req_test" }).error({ err: error }, "request failed");
 	return JSON.parse(output) as Record<string, unknown>;
 }
+
+type ErrorWrapper = (error: DrizzleQueryError) => unknown;
+
+const DRIZZLE_ERROR_WRAPPERS: Array<[string, ErrorWrapper]> = [
+	["standard cause", (error) => new Error("outer request diagnostic", { cause: error })],
+	[
+		"native aggregate",
+		(error) => new AggregateError([new Error("ordinary batch error"), error], "batch failed"),
+	],
+	[
+		"standard Error errors array",
+		(error) => Object.assign(new Error("custom batch failed"), { errors: [error] }),
+	],
+	[
+		"VError-style cause function",
+		(error) => Object.assign(new Error("legacy wrapper failed"), { cause: () => error }),
+	],
+	[
+		"enumerable nested property",
+		(error) => Object.assign(new Error("nested failure"), { context: { failure: error } }),
+	],
+	[
+		"cyclic errors array",
+		(error) => {
+			const outer = Object.assign(new Error("cyclic batch failed"), { errors: [] as unknown[] });
+			outer.errors.push(outer, error);
+			return outer;
+		},
+	],
+];
 
 describe("relay logger", () => {
 	it("removes query text and bound values from Drizzle errors", () => {
@@ -48,17 +77,13 @@ describe("relay logger", () => {
 		expect(serialized).not.toContain("database rejected");
 	});
 
-	it("preserves standard serialization for other errors", () => {
+	it("preserves only inert fields for other errors", () => {
 		const entry = captureError(new Error("ordinary diagnostic"));
-
-		expect(entry.err).toMatchObject({
-			type: "Error",
-			message: "ordinary diagnostic",
-		});
+		expect(entry.err).toEqual({ type: "Error", message: "ordinary diagnostic" });
 	});
 
-	it("removes query details from a wrapped Drizzle error", () => {
-		const sensitiveBody = "sentinel-wrapped-message-body";
+	it.each(DRIZZLE_ERROR_WRAPPERS)("removes query details from a %s", (_name, wrap) => {
+		const sensitiveBody = "sentinel-nested-message-body";
 		const drizzleError = new DrizzleQueryError(
 			"insert into messages (body) values ($1)",
 			[sensitiveBody],
@@ -67,55 +92,119 @@ describe("relay logger", () => {
 				severity: "ERROR",
 			}),
 		);
-		const entry = captureError(new Error("outer request diagnostic", { cause: drizzleError }));
+		const entry = captureError(wrap(drizzleError));
 		const serialized = JSON.stringify(entry);
 
-		expect(entry.err).toEqual({
-			type: "DrizzleQueryError",
-			code: "23514",
-			severity: "ERROR",
-		});
+		expect(entry.err).toMatchObject({ type: "Error" });
 		expect(serialized).not.toContain(sensitiveBody);
 		expect(serialized).not.toContain("insert into messages");
 		expect(serialized).not.toContain("database rejected");
 	});
 
-	it("removes query details from an aggregated Drizzle error", () => {
-		const sensitiveBody = "sentinel-aggregated-message-body";
-		const drizzleError = new DrizzleQueryError(
-			"update messages set body = $1",
-			[sensitiveBody],
-			new Error(`database rejected ${sensitiveBody}`),
-		);
-		const entry = captureError(
-			new AggregateError([new Error("ordinary batch error"), drizzleError], "batch failed"),
-		);
-		const serialized = JSON.stringify(entry);
+	it("does not invoke dynamic serialization hooks", () => {
+		let hookCalls = 0;
+		const error = Object.assign(new Error("safe outer diagnostic"), {
+			cause: () => {
+				hookCalls += 1;
+				throw new Error("cause hook must not run");
+			},
+			context: {
+				get failure() {
+					hookCalls += 1;
+					throw new Error("getter must not run");
+				},
+				toJSON() {
+					hookCalls += 1;
+					throw new Error("toJSON hook must not run");
+				},
+			},
+		});
+		Object.defineProperty(error, "stack", {
+			configurable: true,
+			get() {
+				hookCalls += 1;
+				throw new Error("stack getter must not run");
+			},
+		});
 
-		expect(entry.err).toEqual({ type: "DrizzleQueryError" });
-		expect(serialized).not.toContain(sensitiveBody);
-		expect(serialized).not.toContain("update messages");
-		expect(serialized).not.toContain("database rejected");
+		const entry = captureError(error);
+
+		expect(hookCalls).toBe(0);
+		expect(entry.err).toEqual({ type: "Error", message: "safe outer diagnostic" });
 	});
 
-	it("removes query details from a Drizzle error in a standard error array", () => {
-		const sensitiveBody = "sentinel-custom-error-array-body";
-		const drizzleError = new DrizzleQueryError(
-			"delete from messages where body = $1",
-			[sensitiveBody],
-			new Error(`database rejected ${sensitiveBody}`),
-		);
-		const entry = captureError(
-			Object.assign(new Error("custom batch failed"), {
-				errors: [new Error("ordinary batch error"), drizzleError],
-			}),
-		);
-		const serialized = JSON.stringify(entry);
+	it("does not invoke a dynamic error display property", () => {
+		let nameGetterCalls = 0;
+		const error = new Error("safe display diagnostic");
+		Object.defineProperty(error, "name", {
+			configurable: true,
+			get() {
+				nameGetterCalls += 1;
+				return "sentinel-dynamic-name";
+			},
+		});
 
-		expect(entry.err).toEqual({ type: "DrizzleQueryError" });
-		expect(serialized).not.toContain(sensitiveBody);
-		expect(serialized).not.toContain("delete from messages");
-		expect(serialized).not.toContain("database rejected");
+		const entry = captureError(error);
+
+		expect(nameGetterCalls).toBe(0);
+		expect(entry.err).toEqual({ type: "Error", message: "safe display diagnostic" });
+		expect(JSON.stringify(entry)).not.toContain("sentinel-dynamic-name");
+	});
+
+	it("does not invoke a dynamic error message", () => {
+		let messageGetterCalls = 0;
+		const error = new Error("initial message");
+		Object.defineProperty(error, "message", {
+			configurable: true,
+			get() {
+				messageGetterCalls += 1;
+				return "sentinel-dynamic-message";
+			},
+		});
+
+		const entry = captureError(error);
+
+		expect(messageGetterCalls).toBe(0);
+		expect(entry.err).toEqual({ type: "Error" });
+		expect(JSON.stringify(entry)).not.toContain("sentinel-dynamic-message");
+	});
+
+	it("omits a lazy stack formatted before logging", () => {
+		const originalDescriptor = Object.getOwnPropertyDescriptor(Error, "prepareStackTrace");
+		const error = new Error("safe cached diagnostic");
+		Object.defineProperty(Error, "prepareStackTrace", {
+			configurable: true,
+			value: () => "sentinel-cached-stack",
+		});
+
+		try {
+			expect(error.stack).toBe("sentinel-cached-stack");
+		} finally {
+			if (originalDescriptor) {
+				Object.defineProperty(Error, "prepareStackTrace", originalDescriptor);
+			} else {
+				Reflect.deleteProperty(Error, "prepareStackTrace");
+			}
+		}
+
+		const entry = captureError(error);
+		expect(entry.err).toEqual({ type: "Error", message: "safe cached diagnostic" });
+		expect(JSON.stringify(entry)).not.toContain("sentinel-cached-stack");
+	});
+
+	it("fails closed for non-Error objects", () => {
+		let toJsonCalls = 0;
+		const entry = captureError({
+			message: "plain object",
+			toJSON() {
+				toJsonCalls += 1;
+				return { secret: "sentinel-plain-object-secret" };
+			},
+		});
+
+		expect(toJsonCalls).toBe(0);
+		expect(entry.err).toEqual({ type: "NonError" });
+		expect(JSON.stringify(entry)).not.toContain("sentinel-plain-object-secret");
 	});
 
 	it("omits unrecognized Drizzle cause metadata", () => {

--- a/relay/src/logger.test.ts
+++ b/relay/src/logger.test.ts
@@ -1,0 +1,75 @@
+import { PassThrough } from "node:stream";
+import { DrizzleQueryError } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { createLogger } from "./logger.js";
+
+const LOG_CONFIG = {
+	RELAY_ENV: "test" as const,
+	RELAY_LOG_LEVEL: "info" as const,
+};
+
+function captureError(error: unknown): Record<string, unknown> {
+	const destination = new PassThrough();
+	let output = "";
+	destination.on("data", (chunk: Buffer) => {
+		output += chunk.toString("utf8");
+	});
+
+	createLogger(LOG_CONFIG, destination)
+		.child({ request_id: "req_test" })
+		.error({ err: error }, "request failed");
+	return JSON.parse(output) as Record<string, unknown>;
+}
+
+describe("relay logger", () => {
+	it("removes query text and bound values from Drizzle errors", () => {
+		const sensitiveBody = "sentinel-private-message-body";
+		const cause = Object.assign(new Error(`database rejected ${sensitiveBody}`), {
+			code: "23514",
+			severity: "ERROR",
+		});
+		const error = new DrizzleQueryError(
+			"insert into messages (body) values ($1)",
+			[sensitiveBody],
+			cause,
+		);
+
+		const entry = captureError(error);
+		const serialized = JSON.stringify(entry);
+
+		expect(entry.err).toEqual({
+			type: "DrizzleQueryError",
+			code: "23514",
+			severity: "ERROR",
+		});
+		expect(entry.request_id).toBe("req_test");
+		expect(serialized).not.toContain(sensitiveBody);
+		expect(serialized).not.toContain("insert into messages");
+		expect(serialized).not.toContain("database rejected");
+	});
+
+	it("preserves standard serialization for other errors", () => {
+		const entry = captureError(new Error("ordinary diagnostic"));
+
+		expect(entry.err).toMatchObject({
+			type: "Error",
+			message: "ordinary diagnostic",
+		});
+	});
+
+	it("omits unrecognized Drizzle cause metadata", () => {
+		const sensitiveMetadata = "sentinel-arbitrary-cause-value";
+		const error = new DrizzleQueryError(
+			"select 1",
+			[],
+			Object.assign(new Error("failed"), {
+				code: sensitiveMetadata,
+				severity: sensitiveMetadata,
+			}),
+		);
+
+		const entry = captureError(error);
+		expect(entry.err).toEqual({ type: "DrizzleQueryError" });
+		expect(JSON.stringify(entry)).not.toContain(sensitiveMetadata);
+	});
+});

--- a/relay/src/logger.ts
+++ b/relay/src/logger.ts
@@ -14,46 +14,51 @@ const POSTGRES_SEVERITIES = new Set([
 	"LOG",
 ]);
 
-function stringProperty(value: unknown, key: string): string | undefined {
+function ownDataProperty(value: unknown, key: string): unknown {
 	if (typeof value !== "object" || value === null) return undefined;
-	const candidate = (value as Record<string, unknown>)[key];
+	try {
+		const descriptor = Object.getOwnPropertyDescriptor(value, key);
+		return descriptor && "value" in descriptor ? descriptor.value : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function ownStringProperty(value: unknown, key: string): string | undefined {
+	const candidate = ownDataProperty(value, key);
 	return typeof candidate === "string" ? candidate : undefined;
 }
 
-function findDrizzleQueryError(
-	value: unknown,
-	seen = new Set<object>(),
-): DrizzleQueryError | undefined {
-	if (value instanceof DrizzleQueryError) return value;
-	if (!(value instanceof Error) || seen.has(value)) return undefined;
-
-	seen.add(value);
-	const causedByDrizzle = findDrizzleQueryError(value.cause, seen);
-	if (causedByDrizzle) return causedByDrizzle;
-
-	const nestedErrors = (value as Error & { errors?: unknown }).errors;
-	if (Array.isArray(nestedErrors)) {
-		for (const nestedError of nestedErrors) {
-			const aggregatedDrizzleError = findDrizzleQueryError(nestedError, seen);
-			if (aggregatedDrizzleError) return aggregatedDrizzleError;
-		}
-	}
-	return undefined;
+function serializeStandardError(error: Error): Record<string, string> {
+	// Pino traverses causes, while Node stacks can run or cache format hooks. Keep an inert snapshot.
+	const serialized: Record<string, string> = { type: "Error" };
+	const message = ownStringProperty(error, "message");
+	if (message) serialized.message = message;
+	return serialized;
 }
 
 function serializeDrizzleQueryError(error: DrizzleQueryError): Record<string, string> {
 	const serialized: Record<string, string> = { type: "DrizzleQueryError" };
-	const code = stringProperty(error.cause, "code");
-	const severity = stringProperty(error.cause, "severity");
+	const cause = ownDataProperty(error, "cause");
+	const code = ownStringProperty(cause, "code");
+	const severity = ownStringProperty(cause, "severity");
 	if (code && POSTGRES_ERROR_CODE.test(code)) serialized.code = code;
 	if (severity && POSTGRES_SEVERITIES.has(severity)) serialized.severity = severity;
 	return serialized;
 }
 
 function serializeLogError(error: unknown): unknown {
-	const drizzleError = findDrizzleQueryError(error);
-	if (drizzleError) return serializeDrizzleQueryError(drizzleError);
-	return error instanceof Error ? pino.stdSerializers.err(error) : error;
+	if (error instanceof DrizzleQueryError) return serializeDrizzleQueryError(error);
+	if (error instanceof Error) return serializeStandardError(error);
+	if (
+		error === null ||
+		typeof error === "string" ||
+		typeof error === "number" ||
+		typeof error === "boolean"
+	) {
+		return error;
+	}
+	return { type: "NonError" };
 }
 
 export function createLogger(

--- a/relay/src/logger.ts
+++ b/relay/src/logger.ts
@@ -31,8 +31,9 @@ function findDrizzleQueryError(
 	const causedByDrizzle = findDrizzleQueryError(value.cause, seen);
 	if (causedByDrizzle) return causedByDrizzle;
 
-	if (value instanceof AggregateError) {
-		for (const nestedError of value.errors) {
+	const nestedErrors = (value as Error & { errors?: unknown }).errors;
+	if (Array.isArray(nestedErrors)) {
+		for (const nestedError of nestedErrors) {
 			const aggregatedDrizzleError = findDrizzleQueryError(nestedError, seen);
 			if (aggregatedDrizzleError) return aggregatedDrizzleError;
 		}

--- a/relay/src/logger.ts
+++ b/relay/src/logger.ts
@@ -20,17 +20,39 @@ function stringProperty(value: unknown, key: string): string | undefined {
 	return typeof candidate === "string" ? candidate : undefined;
 }
 
-function serializeLogError(error: unknown): unknown {
-	if (!(error instanceof DrizzleQueryError)) {
-		return error instanceof Error ? pino.stdSerializers.err(error) : error;
-	}
+function findDrizzleQueryError(
+	value: unknown,
+	seen = new Set<object>(),
+): DrizzleQueryError | undefined {
+	if (value instanceof DrizzleQueryError) return value;
+	if (!(value instanceof Error) || seen.has(value)) return undefined;
 
+	seen.add(value);
+	const causedByDrizzle = findDrizzleQueryError(value.cause, seen);
+	if (causedByDrizzle) return causedByDrizzle;
+
+	if (value instanceof AggregateError) {
+		for (const nestedError of value.errors) {
+			const aggregatedDrizzleError = findDrizzleQueryError(nestedError, seen);
+			if (aggregatedDrizzleError) return aggregatedDrizzleError;
+		}
+	}
+	return undefined;
+}
+
+function serializeDrizzleQueryError(error: DrizzleQueryError): Record<string, string> {
 	const serialized: Record<string, string> = { type: "DrizzleQueryError" };
 	const code = stringProperty(error.cause, "code");
 	const severity = stringProperty(error.cause, "severity");
 	if (code && POSTGRES_ERROR_CODE.test(code)) serialized.code = code;
 	if (severity && POSTGRES_SEVERITIES.has(severity)) serialized.severity = severity;
 	return serialized;
+}
+
+function serializeLogError(error: unknown): unknown {
+	const drizzleError = findDrizzleQueryError(error);
+	if (drizzleError) return serializeDrizzleQueryError(drizzleError);
+	return error instanceof Error ? pino.stdSerializers.err(error) : error;
 }
 
 export function createLogger(

--- a/relay/src/logger.ts
+++ b/relay/src/logger.ts
@@ -1,22 +1,61 @@
-import pino, { type Logger } from "pino";
+import { DrizzleQueryError } from "drizzle-orm";
+import pino, { type DestinationStream, type Logger } from "pino";
 import type { RelayConfig } from "./config.js";
 
-export function createLogger(config: Pick<RelayConfig, "RELAY_LOG_LEVEL" | "RELAY_ENV">): Logger {
-	return pino({
-		level: config.RELAY_LOG_LEVEL,
-		base: { env: config.RELAY_ENV, service: "relay" },
-		timestamp: pino.stdTimeFunctions.isoTime,
-		redact: {
-			paths: [
-				"req.headers.authorization",
-				"req.headers.cookie",
-				"*.api_key",
-				"*.password",
-				"*.notification_webhook_url",
-			],
-			censor: "[redacted]",
+const POSTGRES_ERROR_CODE = /^[0-9A-Z]{5}$/;
+const POSTGRES_SEVERITIES = new Set([
+	"ERROR",
+	"FATAL",
+	"PANIC",
+	"WARNING",
+	"NOTICE",
+	"DEBUG",
+	"INFO",
+	"LOG",
+]);
+
+function stringProperty(value: unknown, key: string): string | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+	const candidate = (value as Record<string, unknown>)[key];
+	return typeof candidate === "string" ? candidate : undefined;
+}
+
+function serializeLogError(error: unknown): unknown {
+	if (!(error instanceof DrizzleQueryError)) {
+		return error instanceof Error ? pino.stdSerializers.err(error) : error;
+	}
+
+	const serialized: Record<string, string> = { type: "DrizzleQueryError" };
+	const code = stringProperty(error.cause, "code");
+	const severity = stringProperty(error.cause, "severity");
+	if (code && POSTGRES_ERROR_CODE.test(code)) serialized.code = code;
+	if (severity && POSTGRES_SEVERITIES.has(severity)) serialized.severity = severity;
+	return serialized;
+}
+
+export function createLogger(
+	config: Pick<RelayConfig, "RELAY_LOG_LEVEL" | "RELAY_ENV">,
+	destination?: DestinationStream,
+): Logger {
+	return pino(
+		{
+			level: config.RELAY_LOG_LEVEL,
+			base: { env: config.RELAY_ENV, service: "relay" },
+			timestamp: pino.stdTimeFunctions.isoTime,
+			serializers: { err: serializeLogError },
+			redact: {
+				paths: [
+					"req.headers.authorization",
+					"req.headers.cookie",
+					"*.api_key",
+					"*.password",
+					"*.notification_webhook_url",
+				],
+				censor: "[redacted]",
+			},
 		},
-	});
+		destination,
+	);
 }
 
 export type { Logger };

--- a/relay/src/services/mission-ledger.test.ts
+++ b/relay/src/services/mission-ledger.test.ts
@@ -897,7 +897,9 @@ d("durable Mission ledger", () => {
 						"accept:rollback:android",
 					),
 				}),
-			).rejects.toThrow(/forced delivery failure/);
+			).rejects.toMatchObject({
+				cause: { message: expect.stringMatching(/forced delivery failure/) },
+			});
 		} finally {
 			await handle.sql.unsafe(`
 				DROP TRIGGER IF EXISTS reject_node_delivery_test ON node_deliveries;


### PR DESCRIPTION
## Summary

- Upgrade Relay `drizzle-orm` from 0.36.4 to 0.45.2, resolving `GHSA-gpj5-g38j-94v9`.
- Align `drizzle-kit` from 0.28.1 to 0.31.10 and regenerate the pnpm lockfile on top of runtime-security PR #83.
- Update database failure assertions for the Drizzle 0.45 `DrizzleQueryError` wrapper while continuing to verify the underlying PostgreSQL constraint or trigger error.
- Use a fail-closed Relay error serializer: direct Drizzle errors retain only validated PostgreSQL code/severity, while generic errors retain only their own inert message. Nested values, dynamic hooks, subclass fields, and stacks are intentionally omitted.

No production schema, SQL migration, HTTP, JSON-RPC, MCP, or database contract changes are included.

## Validation

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint` (passes with four existing unused-suppression warnings)
- [x] `pnpm -r typecheck`
- [x] `pnpm -r build`
- [x] All database-free package suites pass
- [x] Logger regressions pass on Node 20, 22, and 26, including direct and nested Drizzle data, aggregate/custom error arrays, dynamic causes/getters/`toJSON`, cycles, cached stack hooks, metadata allowlisting, and ordinary Error messages
- [x] Relay integration: 163 passed against PostgreSQL 16
- [x] End to end: 7 passed
- [x] Relay migrations applied successfully
- [x] Relay image build and runtime protocol/ORM import smoke
- [x] Live `/healthz` and `/readyz`: HTTP 200
- [x] `git diff --check`
- [x] Independent adversarial review approved the exact serializer design

The migration generator produced no schema or migration file changes. Both the previous 0.28.1 toolchain and 0.31.10 report the same pre-existing snapshot-parent collision in `relay/drizzle/meta`; this upgrade introduces no generator drift but does not repair that existing metadata issue.

## Audit result after runtime PR #83

- Production audit: zero advisories across 120 dependencies.
- Full audit: 13 development-only findings — 1 critical, 5 high, 6 moderate, and 1 low.

This removes the Drizzle ORM production advisory and the direct Drizzle Kit `esbuild@0.19.12` occurrence. The critical/high findings belong to the separate Vitest/toolchain work in PR #81.

## Residual Drizzle tooling chain

`drizzle-kit@0.31.10 > @esbuild-kit/esm-loader@2.6.5 > @esbuild-kit/core-utils@3.3.2 > esbuild@0.18.20`

That deprecated path retains one moderate development-server advisory. Drizzle Kit's direct esbuild is patched at 0.25.12. No global override is added because the old loader pins its esbuild version and forcing an unverified replacement would exceed this compatibility-focused fix.
