### PR TITLE
fix(deps): remediate runtime dependency advisories

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -53,6 +53,9 @@ configuration is written to the current Claude and Codex user config locations.
 The relay stores messages durably, but pickup is explicit. A human or running agent
 must call `check_inbox` or `view_thread`.
 
+The stdio server caps each MCP JSON-RPC request at 10 MiB. For larger code artifacts,
+send a `file_ref` instead of putting a huge diff or other content inline.
+
 ## CLI
 
 - `agentrelay register`

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -46,12 +46,12 @@
 		"prepack": "pnpm run build && pnpm run test"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.0.4",
+		"@modelcontextprotocol/sdk": "^1.30.0",
 		"cac": "^6.7.14",
-		"js-yaml": "^4.1.0",
+		"js-yaml": "^4.3.1",
 		"pino": "^9.5.0",
 		"smol-toml": "^1.6.1",
-		"undici": "^7.0.0",
+		"undici": "^7.29.0",
 		"zod": "^3.23.8"
 	},
 	"devDependencies": {

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -14,6 +14,8 @@ import { registerTools } from "./tools/index.js";
 import { FALLBACK_TRUST, loadTrust } from "./trust.js";
 import { PACKAGE_VERSION } from "./version.js";
 
+const MCP_STDIO_MAX_REQUEST_BYTES = 10 * 1024 * 1024;
+
 export interface ServerHandle {
 	stop(): Promise<void>;
 }
@@ -78,7 +80,9 @@ export async function startServer(opts: {
 		}));
 	}
 
-	const transport = new StdioServerTransport();
+	const transport = new StdioServerTransport(process.stdin, process.stdout, {
+		maxBufferSize: MCP_STDIO_MAX_REQUEST_BYTES,
+	});
 	await server.connect(transport);
 
 	return {

--- a/node/package.json
+++ b/node/package.json
@@ -30,7 +30,7 @@
 		"@agentrelay/protocol": "workspace:*",
 		"cac": "^6.7.14",
 		"pino": "^9.5.0",
-		"undici": "^7.0.0",
+		"undici": "^7.29.0",
 		"zod": "^3.23.8"
 	},
 	"devDependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -6,7 +6,7 @@
 	"license": "MIT",
 	"type": "module",
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=20.18.1"
 	},
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,14 +18,14 @@ importers:
   mcp-server:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.0.4
-        version: 1.29.0(zod@3.25.76)
+        specifier: ^1.30.0
+        version: 1.30.0(zod@3.25.76)
       cac:
         specifier: ^6.7.14
         version: 6.7.14
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.1
+        specifier: ^4.3.1
+        version: 4.3.1
       pino:
         specifier: ^9.5.0
         version: 9.14.0
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1
       undici:
-        specifier: ^7.0.0
-        version: 7.25.0
+        specifier: ^7.29.0
+        version: 7.29.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -67,8 +67,8 @@ importers:
         specifier: ^9.5.0
         version: 9.14.0
       undici:
-        specifier: ^7.0.0
-        version: 7.25.0
+        specifier: ^7.29.0
+        version: 7.29.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -108,8 +108,8 @@ importers:
         specifier: workspace:*
         version: link:../protocol
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.14(hono@4.12.15)
+        specifier: ^2.0.5
+        version: 2.1.0(hono@4.13.1)
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -117,8 +117,8 @@ importers:
         specifier: ^0.36.4
         version: 0.36.4(postgres@3.4.9)
       hono:
-        specifier: ^4.6.13
-        version: 4.12.15
+        specifier: ^4.12.34
+        version: 4.13.1
       pino:
         specifier: ^9.5.0
         version: 9.14.0
@@ -151,14 +151,14 @@ importers:
         specifier: workspace:*
         version: link:../../protocol
       '@modelcontextprotocol/sdk':
-        specifier: ^1.0.4
-        version: 1.29.0(zod@3.25.76)
+        specifier: ^1.30.0
+        version: 1.30.0(zod@3.25.76)
       agentrelay-node:
         specifier: workspace:*
         version: link:../../node
       undici:
-        specifier: ^7.0.0
-        version: 7.25.0
+        specifier: ^7.29.0
+        version: 7.29.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.0
@@ -233,11 +233,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -947,17 +947,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.1.0':
+    resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -1158,8 +1158,8 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   buffer-from@1.1.2:
@@ -1196,6 +1196,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -1408,8 +1412,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.4.1:
-    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -1421,8 +1425,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -1467,8 +1471,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.13.1:
+    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -1482,8 +1486,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1499,8 +1503,8 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -1616,8 +1620,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -1767,6 +1771,10 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1775,8 +1783,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -2272,15 +2280,15 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.15)':
+  '@hono/node-server@2.1.0(hono@4.13.1)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.13.1
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.15)
+      '@hono/node-server': 2.1.0(hono@4.13.1)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2289,8 +2297,8 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
       express: 5.2.1
-      express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.15
+      express-rate-limit: 8.6.2(express@5.2.1)
+      hono: 4.13.1
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2437,7 +2445,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2447,17 +2455,17 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2490,6 +2498,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -2705,15 +2715,18 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.4.1(express@5.2.1):
+  express-rate-limit@8.6.2(express@5.2.1):
     dependencies:
+      debug: 4.4.3
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -2732,7 +2745,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -2745,7 +2758,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.5: {}
 
   finalhandler@2.1.1:
     dependencies:
@@ -2797,7 +2810,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.15: {}
+  hono@4.13.1: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2813,7 +2826,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -2823,7 +2836,7 @@ snapshots:
 
   jose@6.2.2: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2918,7 +2931,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -3106,11 +3119,17 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
-  undici@7.25.0: {}
+  undici@7.29.0: {}
 
   unpipe@1.0.0: {}
 

--- a/relay/package.json
+++ b/relay/package.json
@@ -29,10 +29,10 @@
 	},
 	"dependencies": {
 		"@agentrelay/protocol": "workspace:*",
-		"@hono/node-server": "^1.13.7",
+		"@hono/node-server": "^2.0.5",
 		"dotenv": "^16.4.7",
 		"drizzle-orm": "^0.36.4",
-		"hono": "^4.6.13",
+		"hono": "^4.12.34",
 		"pino": "^9.5.0",
 		"postgres": "^3.4.5",
 		"zod": "^3.23.8"

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -11,9 +11,9 @@
 	},
 	"dependencies": {
 		"@agentrelay/protocol": "workspace:*",
-		"@modelcontextprotocol/sdk": "^1.0.4",
+		"@modelcontextprotocol/sdk": "^1.30.0",
 		"agentrelay-node": "workspace:*",
-		"undici": "^7.0.0"
+		"undici": "^7.29.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

- Raise the direct runtime dependency floors to `@modelcontextprotocol/sdk ^1.30.0`, `@hono/node-server ^2.0.5`, `hono ^4.12.34`, `undici ^7.29.0`, and `js-yaml ^4.3.1`.
- Refresh the nested MCP runtime graph so `fast-uri` is 3.1.5, `ip-address` is 10.3.1, `body-parser` is 2.3.0, and `qs` is 6.15.2.
- Make the MCP stdio boundary's 10 MiB JSON-RPC request cap explicit and direct larger artifacts to `file_ref` rather than huge inline diffs.
- Avoid a persistent package override; the lockfile carries the safe transitive resolutions.
- Supersedes #68, which only updates the Relay's direct Hono dependency and leaves the SDK's older Hono/runtime graph in the lockfile.

The lock currently resolves the compatible ranges to `@hono/node-server` 2.1.0 and Hono 4.13.1. The requested safe versions remain the declared minimums.

## Security result

`pnpm audit --prod --json` now reports one production advisory:

- High: `drizzle-orm` `GHSA-gpj5-g38j-94v9` (`0.36.4`, fixed in `0.45.2`)

That independent ORM upgrade is intentionally left to the focused Drizzle remediation PR. The full audit still reports 1 critical, 6 high, 7 moderate, and 1 low finding, all in the separate Drizzle or development-toolchain work.

## Validation

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint` (passes; four existing unused-suppression warnings)
- [x] `pnpm -r typecheck`
- [x] `pnpm -r build`
- [x] Package unit suites: 544 passed
- [x] Relay integration suite: 163 passed
- [x] End-to-end suite: 7 passed
- [x] MCP focused checks: Biome, typecheck, build, and 164 tests
- [x] Packed `agentrelay-mcp@0.2.1` consumer smoke after the stdio-boundary change
- [x] Relay production Docker image build
- [x] `git diff --check`

## Compatibility notes

- `@hono/node-server` moves across a major version, but its `serve` API used by the Relay compiles and passed the real Relay/E2E paths.
- `undici` 7.29.0 requires Node 20.18.1+, matching the repository's declared runtime floor.
- The MCP server deliberately pins the SDK's current 10 MiB stdio request ceiling as a product boundary instead of silently inheriting the dependency default.
