### PR TITLE
ci: gate Railway production deployments

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -1,0 +1,90 @@
+name: Deploy Railway production
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-railway-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: railway-production
+      url: ${{ vars.RELAY_PUBLIC_URL }}
+
+    steps:
+      - name: Checkout tested revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Reject a superseded revision
+        env:
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          current_sha=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
+            --jq '.object.sha')
+          if [[ "$current_sha" != "$EXPECTED_SHA" ]]; then
+            echo '::error::A newer main revision exists; refusing a stale deployment.'
+            exit 1
+          fi
+
+      - name: Install verified Railway CLI
+        env:
+          RAILWAY_CLI_VERSION: 4.58.0
+          RAILWAY_CLI_SHA256: 6695f3864f00a5518af33676a73436e7e70f9e96324d0f0405c2c3f76effec6c
+        run: |
+          archive="$RUNNER_TEMP/railway.tar.gz"
+          install_dir="$RUNNER_TEMP/railway-bin"
+          curl --fail --silent --show-error --location \
+            "https://github.com/railwayapp/cli/releases/download/v${RAILWAY_CLI_VERSION}/railway-v${RAILWAY_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$RAILWAY_CLI_SHA256" "$archive" | sha256sum --check
+          mkdir -p "$install_dir"
+          tar --extract --gzip --file "$archive" --directory "$install_dir" railway
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Deploy tested revision
+        env:
+          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+        run: |
+          railway up \
+            --ci \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --service "$RAILWAY_SERVICE_ID" \
+            --message "GitHub Actions ${DEPLOY_SHA}"
+
+      - name: Verify public Relay
+        env:
+          RELAY_PUBLIC_URL: ${{ vars.RELAY_PUBLIC_URL }}
+        run: |
+          relay_url=${RELAY_PUBLIC_URL%/}
+          health=$(curl --fail --silent --show-error --max-time 15 "$relay_url/healthz")
+          [[ "$health" == '{"status":"ok"}' ]]
+          ready=$(curl --fail --silent --show-error --max-time 15 "$relay_url/readyz")
+          [[ "$ready" == '{"status":"ready"}' ]]

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ View the AgentRelay thread <thread_id> and show me the latest reply.
 Full setup and current limitations are in [`docs/onboarding.md`](docs/onboarding.md).
 For a first shared team deployment on Azure, use the review-first
 [`docs/deploy-azure.md`](docs/deploy-azure.md) pilot guide.
+For Railway, use the protected-environment
+[`docs/deploy-railway.md`](docs/deploy-railway.md) deployment guide.
 
 ## Run the repository locally
 
@@ -362,6 +364,7 @@ this README does not claim full A2A conformance.
     ├── onboarding.md     current mailbox setup
     ├── hosting.md        relay hosting survey
     ├── deploy-azure.md   Azure Container Apps + private PostgreSQL pilot
+    ├── deploy-railway.md Railway deployment with CI and approval gates
     ├── deploy-fly.md     relay-only Fly.io example
     ├── auto-mode.md      superseded design decision record
     ├── ambient-agent.md  superseded design decision record

--- a/docs/deploy-railway.md
+++ b/docs/deploy-railway.md
@@ -1,0 +1,85 @@
+# Deploy the Relay to Railway with production approval
+
+This is the repository's guarded Railway path for a shared Relay. A successful
+`CI` run on `main` creates a deployment for the `railway-production` GitHub
+environment. Railway receives the code only after an approved reviewer releases
+that job.
+
+The workflow deploys the exact commit tested by CI and refuses it if a newer
+`main` commit already exists. Railway's native GitHub auto-deploy must remain
+disabled; otherwise a push can still reach production before the approval gate.
+
+## 1. Create the Railway services
+
+Create a Railway project with:
+
+- a Postgres service;
+- a Relay service built from `relay/Dockerfile`, with the repository root as the
+  build context;
+- `RELAY_DATABASE_URL=${{Postgres.DATABASE_URL}}`, replacing `Postgres` if the
+  database service has a different name;
+- fresh production values for every required Relay secret in
+  [`.env.example`](../.env.example), rather than its committed development
+  examples; and
+- `/readyz` as the service healthcheck path.
+
+Generate `RELAY_PEPPER`, `RELAY_ENCRYPTION_KEY`, `RELAY_INVITE_SECRET`,
+`RELAY_ADMIN_TOKEN`, and `RELAY_METRICS_TOKEN` with the commands documented in
+`.env.example`. Keep the pepper and encryption key stable after launch; see
+[`hosting.md`](hosting.md) before rotating either value.
+
+Set `RELAY_PUBLIC_URL` to the public HTTPS origin. Confirm both endpoints before
+changing deployment automation:
+
+```bash
+curl https://relay.example.com/healthz
+curl https://relay.example.com/readyz
+```
+
+## 2. Protect the GitHub environment
+
+Create a GitHub environment named `railway-production` under **Settings →
+Environments**. Configure it as follows:
+
+- require an approval from a maintainer;
+- restrict deployments to the protected `main` branch; and
+- disallow administrators from bypassing the protection rules.
+
+If the repository has only one maintainer, allow self-review. Turn on prevention
+of self-review only after a second trusted reviewer exists, or deployments will
+deadlock.
+
+Add these environment variables:
+
+| Name | Value |
+|---|---|
+| `RAILWAY_PROJECT_ID` | Railway project ID |
+| `RAILWAY_ENVIRONMENT_ID` | Railway production environment ID |
+| `RAILWAY_SERVICE_ID` | Railway Relay service ID |
+| `RELAY_PUBLIC_URL` | Public HTTPS origin, without a trailing slash |
+
+Create a Railway project token scoped to the production environment. Save it as
+the environment secret `RAILWAY_TOKEN`; never place it in a repository variable,
+workflow file, issue, or log.
+
+## 3. Cut over from native auto-deploy
+
+Before disabling anything, make sure the current production deployment is
+healthy and the workflow pull request is green. Then freeze merges briefly and:
+
+1. Disable **GitHub auto-deploy** for the Relay service in Railway. Keep the
+   source repository connected.
+2. Merge the workflow change.
+3. Wait for `CI` on `main` to pass.
+4. Review the pending `railway-production` deployment in GitHub Actions and
+   select **Approve and deploy**.
+5. Verify the workflow and both public health endpoints.
+
+Disabling auto-deploy does not stop the active container. If the gated workflow
+cannot deploy, re-enable auto-deploy temporarily while fixing the GitHub
+environment or token. If a new release is unhealthy, redeploy a specifically
+known-good Railway deployment; do not assume the newest deployment is safe.
+
+Database migrations run when the Relay starts. Keep migrations backward
+compatible so the previous image remains a valid rollback while a release is in
+flight.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -20,7 +20,7 @@ platform — pick what matches your team's posture.
 | Platform | Realistic monthly | Free tier? | Setup effort | Notes |
 |---|---|---|---|---|
 | **Your own VPS** (Hetzner, DigitalOcean, OVH, Linode, etc.) | €4–6 / $5–6 | ❌ | medium | Manual Linux ops; `docker compose --profile selfhost up -d`; reverse proxy via Caddy. Cheapest reliable path. |
-| **Railway Hobby** | $5 (flat sub + $5 usage credit) | trial only ($5 credit) | low | Push to GitHub, auto-detect Dockerfile, one-click Postgres add-on, custom domain + auto SSL. AgentRelay's tiny load fits inside the included credit. |
+| **Railway Hobby** | $5 (flat sub + $5 usage credit) | trial only ($5 credit) | low | Auto-detect Dockerfile, one-click Postgres add-on, custom domain + auto SSL. Use the guarded workflow rather than native auto-deploy for production. |
 | **Fly.io** | ~$5–10 | ❌ (retired Oct 2024) | medium | Pay-as-you-go: ~$2 VM + ~$5 Postgres dev cluster. New signups need a credit card. Fast deploy via `flyctl`. |
 | **Render Starter** | ~$7 per service | free web service sleeps after 15min | low | Always-on at Starter tier. Postgres add-on extra. Free tier's idle-sleep makes inbox checks slow. |
 | **Azure Container Apps + PostgreSQL** | usage-based | limited grants vary | medium | Managed HTTPS compute plus private managed Postgres. See the repository's explicit pilot template and limitations. |
@@ -65,6 +65,7 @@ not the primary path:
 
 - **`fly.toml`** at the repo root and **`docs/deploy-fly.md`** — a complete Fly walkthrough, kept as a reference for users who already use Fly.
 - **`infra/azure/`** and **`docs/deploy-azure.md`** — a reviewable Azure Container Apps + private PostgreSQL team-pilot deployment.
+- **`.github/workflows/deploy-railway.yml`** and **`docs/deploy-railway.md`** — a Railway deployment path that runs only after `main` CI and a protected-environment approval.
 - **`.github/workflows/deploy.yml`** — auto-deploy to Fly on `v*.*.*` tag push. Adapt the steps for your platform if it's different.
 - **`docker-compose.yml`** with the `selfhost` profile — the canonical "everything on one box" setup. It forwards all required Relay secrets from `.env`; use it on any VPS.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -43,6 +43,7 @@ outstanding invites.
 
 The relay is a container plus Postgres. See [`hosting.md`](hosting.md) for options,
 [`deploy-azure.md`](deploy-azure.md) for the Azure team pilot, and
+[`deploy-railway.md`](deploy-railway.md) for guarded Railway production, or
 [`deploy-fly.md`](deploy-fly.md) for a relay-only Fly example. The repository's
 `docker compose --profile selfhost` service forwards every required Relay secret from
 `.env`, including `RELAY_INVITE_SECRET`.


### PR DESCRIPTION
## What changed

- deploy Railway only after successful CI on main
- require approval through the railway-production GitHub environment
- deploy the exact tested SHA and reject superseded revisions
- pin and checksum the Railway CLI
- document setup, secret handling, cutover, health checks, and rollback

## Verification

- actionlint v1.7.12
- shell syntax validation for every workflow run block
- pnpm lint
- pnpm -r typecheck
- verified Railway CLI v4.58.0 archive checksum and binary in Linux

## Cutover

Native Railway auto-deploy remains enabled until this PR is green and the scoped environment token is installed. The running Relay is unchanged by this PR.