### PR TITLE
docs: make contribution workflow newcomer-ready

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Report reproducible behavior that differs from AgentRelay's documented contract.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve AgentRelay. The MCP mailbox is the supported user path;
+        the Node and autonomous Mission runtime remain experimental. For vulnerabilities,
+        use [private vulnerability reporting](https://github.com/swayamg20/AgentRelay/security/advisories/new).
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected area
+      options:
+        - Published MCP mailbox or agentrelay CLI
+        - Relay API or self-hosted deployment
+        - Protocol contracts
+        - Experimental Node or Mission runtime
+        - Repository tooling or CI
+        - Landing page
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Include `agentrelay --version`, the release tag, or the commit SHA.
+      placeholder: agentrelay 0.2.1 or commit abc1234
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system, Node and pnpm versions, client, and deployment method.
+      placeholder: macOS 15, Node 22, pnpm 9, Claude Code, self-hosted Relay
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest repeatable sequence, request, or repository command.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Link the documented contract when possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Redacted logs or other evidence
+      description: Remove API keys, invite tokens, webhook URLs, private content, and personal data.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues for this behavior.
+          required: true
+        - label: This is a defect report, not a feature request or security disclosure.
+          required: true
+        - label: I removed credentials, teammate content, and other sensitive data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability privately
+    url: https://github.com/swayamg20/AgentRelay/security/advisories/new
+    about: Do not disclose vulnerabilities, credentials, or private content in a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,66 @@
+name: Documentation improvement
+description: Report unclear, incorrect, or missing AgentRelay documentation.
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Documentation must distinguish shipped behavior from accepted design and experimental
+        checkpoints. A documentation issue records a problem; it does not reserve the work.
+
+  - type: input
+    id: location
+    attributes:
+      label: Page or section
+      description: Link the file, heading, command help, or public page that needs attention.
+      placeholder: https://github.com/swayamg20/AgentRelay/blob/main/docs/onboarding.md
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Documentation area
+      options:
+        - MCP mailbox or CLI
+        - Relay API or self-hosting
+        - Experimental Node or Missions
+        - Architecture, HLD, LLD, or RFC
+        - Contributor or developer setup
+        - Landing page
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is unclear or incorrect?
+      description: State what a reader is likely to misunderstand and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: improvement
+    attributes:
+      label: Suggested improvement
+      description: Describe the outcome you want; draft wording is welcome but optional.
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Evidence or verification
+      description: Point to current code, tests, command output, or another authoritative source.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues for the same documentation problem.
+          required: true
+        - label: This report contains no credentials, private repository content, or personal data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.yml
@@ -1,0 +1,93 @@
+name: Feature or design proposal
+description: Propose a product capability or contract change for maintainer review.
+title: "[Proposal]: "
+labels:
+  - enhancement
+  - ideas
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form starts a design discussion. It does **not** mean the proposal is approved,
+        scheduled, or ready to implement. Please wait for a maintainer to confirm the scope
+        before investing in a substantial pull request.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Describe the user, the current workflow, and the concrete limitation.
+      placeholder: When ..., an agent or operator cannot ..., which causes ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Product surface
+      options:
+        - Published MCP mailbox or agentrelay CLI
+        - Relay API or self-hosted operations
+        - Protocol or interoperability
+        - Experimental Node or Mission runtime
+        - Editor, agent-host, or notification integration
+        - Documentation or contributor experience
+        - Other or cross-cutting
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence of need
+      description: Share a real workflow, repeated failure, user request, or measurable constraint.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Proposed outcome
+      description: Describe externally observable behavior, not only an implementation choice.
+    validations:
+      required: true
+
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Boundaries and tradeoffs
+      description: |
+        Note non-goals and any impact on authentication, authorization, untrusted content,
+        public contracts, idempotency, audit, local authority, or backward compatibility.
+      placeholder: No new security or public-contract impact, or explain the expected impact here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include existing AgentRelay behavior or a smaller solution when applicable.
+
+  - type: dropdown
+    id: intent
+    attributes:
+      label: Contribution intent
+      options:
+        - I am seeking product or design feedback
+        - I may implement this after maintainer approval
+        - I cannot implement this but can help validate it
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open issues, pull requests, and accepted RFCs for related work.
+          required: true
+        - label: I understand this proposal is not approved or reserved until a maintainer says so.
+          required: true
+        - label: I have not included credentials, private content, or other sensitive data.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## What changed
+
+<!-- Describe the smallest coherent change in this pull request. -->
+
+## Why
+
+<!-- Link the approved issue or prior maintainer discussion. Use "Closes #123" when applicable. -->
+
+## Contract and status
+
+<!--
+Identify affected HTTP, JSON-RPC, MCP, CLI, database, config, or security contracts.
+If this changes Node or Mission behavior, distinguish shipped behavior from an experimental target.
+Write "None" when no contract changes.
+-->
+
+## Validation
+
+<!-- List the exact commands and manual checks run, plus anything not run and why. -->
+
+## Checklist
+
+- [ ] This PR addresses one concern and contains no unrelated cleanup.
+- [ ] Feature work has maintainer-approved scope; an unapproved idea belongs in a proposal issue first.
+- [ ] I traced affected producers, consumers, schemas, and tests across package boundaries.
+- [ ] I added or updated focused tests for behavioral changes.
+- [ ] I updated documentation for changed commands, contracts, security boundaries, or operations.
+- [ ] I treated peer-provided content as untrusted and preserved local authority.
+- [ ] I included no credentials, invite tokens, private content, or sensitive logs.
+- [ ] I ran the relevant checks from `CONTRIBUTING.md` and reported any omissions above.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community
+a harassment-free experience for everyone, regardless of age, body size, visible or
+invisible disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community
+include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and
+  learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any
+  kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional
+  setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in response
+to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are not
+aligned to this Code of Conduct, and will communicate reasons for moderation decisions
+when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an
+individual is officially representing the community in public spaces. Examples of
+representing our community include using an official email address, posting via an
+official social media account, or acting as an appointed representative at an online
+or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported
+privately to the project maintainer at
+[gupta.swayam123@gmail.com](mailto:gupta.swayam123@gmail.com). All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity
+around the nature of the violation and an explanation of why the behavior was
+inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction
+with the people involved, including unsolicited interaction with those enforcing the
+Code of Conduct, for a specified period of time. This includes avoiding interactions
+in community spaces as well as external channels like social media. Violating these
+terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained
+inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication
+with the community for a specified period of time. No public or private interaction
+with the people involved, including unsolicited interaction with those enforcing the
+Code of Conduct, is allowed during this period. Violating these terms may lead to a
+permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards,
+including sustained inappropriate behavior, harassment of an individual, or
+aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version
+2.1, available at the [Contributor Covenant 2.1 text][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the
+[Contributor Covenant FAQ][FAQ]. [Translations][translations] are also available.
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,33 +6,71 @@ valuable than broad rewrites or speculative framework work.
 If you use a coding agent, give it [`AGENTS.md`](AGENTS.md). Claude Code also reads
 [`CLAUDE.md`](CLAUDE.md).
 
+By participating, you agree to follow the project
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Choose and coordinate work
+
+Search the open issues and pull requests before starting so two contributors do not
+solve the same problem.
+
+- An issue labeled `ideas` is a proposal for discussion, not approved or scoped work.
+- Issues labeled `good first issue` or `help wanted` have maintainer-approved scope and
+  are ready for contributors to claim.
+- For any non-trivial change, comment on the issue with your intended scope and wait
+  for a maintainer to confirm it. An assignment or explicit maintainer reply is the
+  claim; an expression of interest alone does not reserve an issue indefinitely.
+- If no issue covers the change, open one before investing in a large implementation.
+  Small, obvious documentation or typo fixes may go directly to a pull request.
+- Link your pull request from the issue as soon as it is open. Report suspected
+  vulnerabilities privately through [`SECURITY.md`](SECURITY.md).
+
 ## Development setup
 
-Requires Node 20.18.1+, pnpm 9+, Docker, and Git. CI tests Node 20 and 22.
+Requires Git, Docker, Node 20.18.1+, and pnpm 9+. The repository-selected toolchain is
+Node 22 from `.nvmrc` and pnpm 9.15.0 from `package.json`; CI also checks the minimum
+supported Node 20 line.
+
+Fork the repository on GitHub, then clone your fork and register the main repository
+as `upstream`:
 
 ```bash
-git clone https://github.com/swayamg20/AgentRelay
+git clone https://github.com/YOUR_GITHUB_HANDLE/AgentRelay.git
 cd AgentRelay
-pnpm install
-docker compose up -d
+git remote add upstream https://github.com/swayamg20/AgentRelay.git
+git fetch upstream
+git switch -c fix/short-description upstream/main
 ```
 
-Plain `docker compose up -d` starts Postgres on port 5433. Run migrations and the
-relay on the host so source changes are easy to inspect:
+Install the repository-selected Node and pnpm versions, then install the locked
+dependencies:
 
 ```bash
-RELAY_DATABASE_URL=postgres://agentrelay:agentrelay-dev@localhost:5433/agentrelay \
-  pnpm --filter relay db:migrate
+nvm install
+nvm use
+corepack enable
+corepack prepare pnpm@9.15.0 --activate
+pnpm install --frozen-lockfile
 ```
 
-To start the full relay, provide the required values documented in `.env.example`
-and [`relay/src/config.ts`](relay/src/config.ts), then run:
+For local development, copy the safe development defaults, export them into the
+current shell, start Postgres on port 5433, and migrate it:
 
 ```bash
+cp .env.example .env
+set -a
+. ./.env
+set +a
+pnpm db:up
+pnpm --filter relay db:migrate
 pnpm --filter relay dev
 ```
 
-Start the stdio MCP server during local client work with:
+Do not reuse the values in `.env.example` in a public or production deployment. The
+full configuration contract is documented in `.env.example` and
+[`relay/src/config.ts`](relay/src/config.ts).
+
+Start the stdio MCP server in another terminal during local client work with:
 
 ```bash
 pnpm --filter agentrelay-mcp dev


### PR DESCRIPTION
## What changed

- add AgentRelay-specific bug, documentation, and feature-proposal issue forms;
- add a pull request checklist and route security disclosures to private reporting;
- adopt Contributor Covenant 2.1 with a private enforcement contact;
- document the fork/upstream workflow, task claiming, approved labels, and pinned development toolchain.

## Why

The codebase and branch protections were ready for external pull requests, but newcomers had no structured intake or clear way to distinguish approved work from the `ideas` backlog.

The accompanying tracker cleanup closed completed issue #9 and turned #11, #34, and #40 into bounded `good first issue` or `help wanted` tasks.

## Contract and status

No runtime, protocol, package, deployment, or security contract changes. This only changes contributor-facing documentation and GitHub intake templates.

## Validation

- `git diff --check`
- parsed every `.github/ISSUE_TEMPLATE/*.yml` file with Ruby/Psych
- `pnpm lint` (passes with four existing unused-suppression warnings in Relay integration tests)
