### PR TITLE
docs(community): add Discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for helping improve AgentRelay. The MCP mailbox is the supported user path;
         the Node and autonomous Mission runtime remain experimental. For setup and usage
-        questions, ask the [Discord community](https://discord.gg/PHcB9qsS2). For
+        questions, ask the [Discord community](https://discord.gg/r2R9v3cret). For
         vulnerabilities, use [private vulnerability reporting](https://github.com/swayamg20/AgentRelay/security/advisories/new).
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,8 +8,9 @@ body:
     attributes:
       value: |
         Thanks for helping improve AgentRelay. The MCP mailbox is the supported user path;
-        the Node and autonomous Mission runtime remain experimental. For vulnerabilities,
-        use [private vulnerability reporting](https://github.com/swayamg20/AgentRelay/security/advisories/new).
+        the Node and autonomous Mission runtime remain experimental. For setup and usage
+        questions, ask the [Discord community](https://discord.gg/PHcB9qsS2). For
+        vulnerabilities, use [private vulnerability reporting](https://github.com/swayamg20/AgentRelay/security/advisories/new).
 
   - type: dropdown
     id: component

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,8 @@ contact_links:
   - name: Report a security vulnerability privately
     url: https://github.com/swayamg20/AgentRelay/security/advisories/new
     about: Do not disclose vulnerabilities, credentials, or private content in a public issue.
+  - name: Ask the AgentRelay community
+    url: https://discord.gg/PHcB9qsS2
+    about: >-
+      Get setup help or discuss an idea before opening an issue. Do not share secrets
+      or security reports.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/swayamg20/AgentRelay/security/advisories/new
     about: Do not disclose vulnerabilities, credentials, or private content in a public issue.
   - name: Ask the AgentRelay community
-    url: https://discord.gg/PHcB9qsS2
+    url: https://discord.gg/r2R9v3cret
     about: >-
       Get setup help or discuss an idea before opening an issue. Do not share secrets
       or security reports.

--- a/.github/ISSUE_TEMPLATE/feature_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.yml
@@ -11,7 +11,7 @@ body:
         This form starts a design discussion. It does **not** mean the proposal is approved,
         scheduled, or ready to implement. Please wait for a maintainer to confirm the scope
         before investing in a substantial pull request. Informal exploration can start in the
-        [Discord community](https://discord.gg/PHcB9qsS2), but decisions and approved scope
+        [Discord community](https://discord.gg/r2R9v3cret), but decisions and approved scope
         must be recorded here.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.yml
@@ -10,7 +10,9 @@ body:
       value: |
         This form starts a design discussion. It does **not** mean the proposal is approved,
         scheduled, or ready to implement. Please wait for a maintainer to confirm the scope
-        before investing in a substantial pull request.
+        before investing in a substantial pull request. Informal exploration can start in the
+        [Discord community](https://discord.gg/PHcB9qsS2), but decisions and approved scope
+        must be recorded here.
 
   - type: textarea
     id: problem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ By participating, you agree to follow the project
 Search the open issues and pull requests before starting so two contributors do not
 solve the same problem.
 
+Use the [AgentRelay Discord community](https://discord.gg/PHcB9qsS2) for questions and
+early design discussion. GitHub issues remain the source of truth for approved scope
+and ownership; a Discord conversation does not reserve an issue.
+
 - An issue labeled `ideas` is a proposal for discussion, not approved or scoped work.
 - Issues labeled `good first issue` or `help wanted` have maintainer-approved scope and
   are ready for contributors to claim.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ By participating, you agree to follow the project
 Search the open issues and pull requests before starting so two contributors do not
 solve the same problem.
 
-Use the [AgentRelay Discord community](https://discord.gg/PHcB9qsS2) for questions and
+Use the [AgentRelay Discord community](https://discord.gg/r2R9v3cret) for questions and
 early design discussion. GitHub issues remain the source of truth for approved scope
 and ownership; a Discord conversation does not reserve an issue.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p align="center">
   <a href="https://swayamg20.github.io/AgentRelay/">Live site</a> ·
-  <a href="https://discord.gg/PHcB9qsS2">Discord community</a> ·
+  <a href="https://discord.gg/r2R9v3cret">Discord community</a> ·
   <a href="#use-agentrelay-today">Use it today</a> ·
   <a href="#the-product-shape">Product shape</a> ·
   <a href="docs/roadmap.md">Roadmap</a>
@@ -405,7 +405,7 @@ simple: understand the complete contract before editing, write the smallest clea
 solution, preserve security and public boundaries, and do not add speculative bloat.
 
 Questions and early design discussions are welcome in the
-[AgentRelay Discord community](https://discord.gg/PHcB9qsS2). GitHub issues remain the
+[AgentRelay Discord community](https://discord.gg/r2R9v3cret). GitHub issues remain the
 source of truth for scoped and claimed contribution work.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 <p align="center">
   <a href="https://swayamg20.github.io/AgentRelay/">Live site</a> ·
+  <a href="https://discord.gg/PHcB9qsS2">Discord community</a> ·
   <a href="#use-agentrelay-today">Use it today</a> ·
   <a href="#the-product-shape">Product shape</a> ·
   <a href="docs/roadmap.md">Roadmap</a>
@@ -402,6 +403,10 @@ this README does not claim full A2A conformance.
 Read [`AGENTS.md`](AGENTS.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md). The core rule is
 simple: understand the complete contract before editing, write the smallest clear
 solution, preserve security and public boundaries, and do not add speculative bloat.
+
+Questions and early design discussions are welcome in the
+[AgentRelay Discord community](https://discord.gg/PHcB9qsS2). GitHub issues remain the
+source of truth for scoped and claimed contribution work.
 
 ## License
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -238,7 +238,7 @@ Inspect host settings, local trust, the thread, and relay audit before continuin
 ## 9. Get help
 
 Ask setup and usage questions in the
-[AgentRelay Discord community](https://discord.gg/PHcB9qsS2). Never paste API keys,
+[AgentRelay Discord community](https://discord.gg/r2R9v3cret). Never paste API keys,
 invite URLs, webhook URLs, private message content, or unredacted logs. Report suspected
 vulnerabilities through the repository's
 [private security process](../SECURITY.md), not Discord.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -234,3 +234,11 @@ secret instead of retaining it unencrypted. The relay accepts only exact
 
 Reject it. Remote content is untrusted and the current trust overlay is advisory.
 Inspect host settings, local trust, the thread, and relay audit before continuing.
+
+## 9. Get help
+
+Ask setup and usage questions in the
+[AgentRelay Discord community](https://discord.gg/PHcB9qsS2). Never paste API keys,
+invite URLs, webhook URLs, private message content, or unredacted logs. Report suspected
+vulnerabilities through the repository's
+[private security process](../SECURITY.md), not Discord.

--- a/landing/index.html
+++ b/landing/index.html
@@ -40,7 +40,7 @@
 				<div class="nav-links">
 					<a class="nav-optional" href="#workflow">The workflow</a>
 					<a class="nav-optional" href="#status">Build status</a>
-					<a href="https://discord.gg/PHcB9qsS2">Discord <span aria-hidden="true">↗</span></a>
+					<a href="https://discord.gg/r2R9v3cret">Discord <span aria-hidden="true">↗</span></a>
 					<a href="https://github.com/swayamg20/AgentRelay">GitHub <span aria-hidden="true">↗</span></a>
 					<a class="nav-action" href="#use">Use it today</a>
 				</div>
@@ -425,7 +425,7 @@ npx -y -p agentrelay-mcp agentrelay doctor</code></pre>
 				</p>
 				<div class="hero-actions">
 					<a class="button button-primary" href="https://github.com/swayamg20/AgentRelay/blob/main/docs/onboarding.md">Open the setup guide <span aria-hidden="true">↗</span></a>
-					<a class="button button-secondary" href="https://discord.gg/PHcB9qsS2">Join the Discord <span aria-hidden="true">↗</span></a>
+					<a class="button button-secondary" href="https://discord.gg/r2R9v3cret">Join the Discord <span aria-hidden="true">↗</span></a>
 					<a class="button button-secondary" href="https://github.com/swayamg20/AgentRelay/issues/new?template=feature_proposal.yml">Propose a workflow <span aria-hidden="true">↗</span></a>
 				</div>
 			</section>
@@ -446,7 +446,7 @@ npx -y -p agentrelay-mcp agentrelay doctor</code></pre>
 				</div>
 				<div class="footer-links">
 					<a href="https://github.com/swayamg20/AgentRelay">GitHub</a>
-					<a href="https://discord.gg/PHcB9qsS2">Discord community</a>
+					<a href="https://discord.gg/r2R9v3cret">Discord community</a>
 					<a href="https://www.npmjs.com/package/agentrelay-mcp">npm package</a>
 					<a href="https://github.com/swayamg20/AgentRelay/blob/main/docs/architecture.md">Architecture</a>
 					<a href="https://github.com/swayamg20/AgentRelay/blob/main/docs/onboarding.md">Onboarding</a>

--- a/landing/index.html
+++ b/landing/index.html
@@ -40,6 +40,7 @@
 				<div class="nav-links">
 					<a class="nav-optional" href="#workflow">The workflow</a>
 					<a class="nav-optional" href="#status">Build status</a>
+					<a href="https://discord.gg/PHcB9qsS2">Discord <span aria-hidden="true">↗</span></a>
 					<a href="https://github.com/swayamg20/AgentRelay">GitHub <span aria-hidden="true">↗</span></a>
 					<a class="nav-action" href="#use">Use it today</a>
 				</div>
@@ -424,7 +425,8 @@ npx -y -p agentrelay-mcp agentrelay doctor</code></pre>
 				</p>
 				<div class="hero-actions">
 					<a class="button button-primary" href="https://github.com/swayamg20/AgentRelay/blob/main/docs/onboarding.md">Open the setup guide <span aria-hidden="true">↗</span></a>
-					<a class="button button-secondary" href="https://github.com/swayamg20/AgentRelay/issues/new?title=Design%20partner%20workflow%3A%20&amp;body=%23%23%20The%20two%20sides%0A%0A%23%23%20What%20a%20human%20relays%20today%0A%0A%23%23%20Coding%20agents%20we%20use%0A">Bring a workflow <span aria-hidden="true">↗</span></a>
+					<a class="button button-secondary" href="https://discord.gg/PHcB9qsS2">Join the Discord <span aria-hidden="true">↗</span></a>
+					<a class="button button-secondary" href="https://github.com/swayamg20/AgentRelay/issues/new?template=feature_proposal.yml">Propose a workflow <span aria-hidden="true">↗</span></a>
 				</div>
 			</section>
 		</main>
@@ -444,6 +446,7 @@ npx -y -p agentrelay-mcp agentrelay doctor</code></pre>
 				</div>
 				<div class="footer-links">
 					<a href="https://github.com/swayamg20/AgentRelay">GitHub</a>
+					<a href="https://discord.gg/PHcB9qsS2">Discord community</a>
 					<a href="https://www.npmjs.com/package/agentrelay-mcp">npm package</a>
 					<a href="https://github.com/swayamg20/AgentRelay/blob/main/docs/architecture.md">Architecture</a>
 					<a href="https://github.com/swayamg20/AgentRelay/blob/main/docs/onboarding.md">Onboarding</a>

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -101,7 +101,7 @@ The target enforcement model is documented in
 
 ## Community and help
 
-Join the [AgentRelay Discord community](https://discord.gg/PHcB9qsS2) for setup and
+Join the [AgentRelay Discord community](https://discord.gg/r2R9v3cret) for setup and
 usage questions. Do not post credentials, invite URLs, private message content,
 unredacted logs, or security reports. Use the repository's
 [private security process](https://github.com/swayamg20/AgentRelay/security/advisories/new)

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -99,6 +99,14 @@ run arbitrary commands.
 The target enforcement model is documented in
 [`RFC 001`](https://github.com/swayamg20/AgentRelay/blob/main/docs/rfcs/001-agentrelay-node-and-missions.md).
 
+## Community and help
+
+Join the [AgentRelay Discord community](https://discord.gg/PHcB9qsS2) for setup and
+usage questions. Do not post credentials, invite URLs, private message content,
+unredacted logs, or security reports. Use the repository's
+[private security process](https://github.com/swayamg20/AgentRelay/security/advisories/new)
+for suspected vulnerabilities.
+
 ## Development
 
 From the repository root:


### PR DESCRIPTION
## Summary

- add the official AgentRelay Discord to the README and public landing page
- expose community help to npm users, onboarding readers, and GitHub issue authors
- keep GitHub issues authoritative for contribution scope and ownership
- keep credentials, private content, and security reports out of Discord
- route the landing-page workflow proposal button through the existing issue form

## Validation

- permanent Discord invite resolves to the Agent Relay server with HTTP 200 and `expires_at: null`
- all 11 public references use the permanent invite; the temporary invite is absent
- GitHub issue-form YAML parses successfully
- README renders through the GitHub Markdown API with the Discord link intact
- `pnpm lint` passes with four pre-existing unrelated suppression warnings
- `git diff --check`