### PR TITLE
feat: reconcile terminal Mission state

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ but no current descriptor or CLI activates Codex for a real model turn.
   start, renew, complete, or release a delivery.
 - Relay-issued 60-second leases bounded by Mission expiry, monotonic attempt fencing,
   exact operation replay, transactional result completion, retries, cancellation,
-  dead-lettering, and audit evidence. Delivery discovery excludes expired or
-  non-runnable Missions; current block and routing state fence later Mission work.
+  dead-lettering, and audit evidence. Delivery discovery lazily reconciles eligible
+  `active` or `verifying` Missions before reading work. The database deadline produces
+  `expired`; otherwise the earliest unsettled dead letter produces `failed`. One
+  system event, remaining-work cancellations, exact receipts, and audit evidence
+  commit transactionally; current block and routing state fence later Mission work.
 - Separately revocable Node credentials plus authenticated enrollment, credential
   rotation, Node revocation, and logical workspace registration routes. Agent and
   Node credentials are different key types; rotation is generation-fenced, and
@@ -127,9 +130,6 @@ but no current descriptor or CLI activates Codex for a real model turn.
 - A production provider-process guardian, heartbeat/liveness ownership, and
   OS-enforced workspace and secret containment for Codex; then a Claude runtime
   adapter.
-- Mission-level expiry and dead-letter reconciliation that transitions the Mission
-  and cancels remaining work instead of only hiding expired work from discovery or
-  terminating one delivery.
 - A real two-machine, two-repository proof using the public control plane.
 
 The design is in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,8 @@ durable coordination foundations:
   renew, complete, and release operations. The relay issues bounded leases and
   monotonic fencing tokens, persists exact operation receipts and audit rows, and
   commits a completion with its Mission result and downstream work atomically.
+  Delivery discovery and delivery operations lazily reconcile eligible expired or
+  dead-lettered Missions under the same Mission lock.
 - A public identity surface that lets an authenticated agent enroll and revoke its
   Nodes, rotate separately scoped Node credentials, and lets an authenticated Node
   register or revoke relay-visible logical workspace bindings. It never accepts a
@@ -87,9 +89,6 @@ system does not contain:
 - OS-enforced Codex workspace/read-root and secret containment, plus guardian-owned
   provider generation and owner-death behavior. Environment filtering and output
   redaction do not provide that containment.
-- Mission-level expiry or dead-letter reconciliation that moves the Mission to a
-  terminal state and cancels its remaining work. Discovery hides expired Missions,
-  while delivery expiry is reconciled only when that delivery is reclaimed.
 - A real two-machine execution proof through the public control plane.
 - Enforcement of the returned per-teammate trust overlay inside a runtime.
 - A current A2A v1 Agent Card endpoint or verified A2A compatibility.
@@ -261,9 +260,13 @@ source settlement, acknowledgement, downstream deliveries, receipt, and audit.
 
 Cursor polling discovers only newly due stored work. A separate cursorless recovery
 scan returns due retries plus leased or executing work, so advancing a cursor cannot
-lose a retry. Both discovery paths require an active or verifying, unexpired Mission.
-They do not lazily transition an expired Mission or reconcile a dead-lettered
-delivery into Mission-wide failure.
+lose a retry. Before either scan returns, the Relay lazily reconciles eligible
+Missions under the Mission lock. Database deadline wins and transitions `active` or
+`verifying` to `expired`; otherwise the earliest unsettled dead letter by cursor
+transitions it to `failed`. The same transaction appends the system terminal event,
+updates the projection, cancels remaining runnable work, and writes Relay receipts
+and audit evidence. Every delivery operation crosses the same reconciliation fence
+before fresh authority or exact-replay validation. There is no background scheduler.
 
 Delivery is at least once. Exact receipts make relay mutations retry-safe; the Node's
 atomic journal suppresses duplicate fake-host effects across runner reconstruction
@@ -323,8 +326,6 @@ Remote agent content is untrusted data. The receiving owner controls local autho
   kind without inventing an Agent identity.
 - `trust_overlay` is returned as JSON but is not dynamically applied to the host.
 - Relay audit does not record local commands, edits, tests, or policy decisions.
-- Expired Missions and dead-lettered deliveries have no background or lazy
-  Mission-terminal reconciler.
 - The notification queue is process-local and can drop work on overflow or restart.
 - Local and relay revocation behavior is not one atomic, continuously observed policy;
   successful CLI block/unblock converges both stores but cannot transactionally commit

--- a/docs/hld.md
+++ b/docs/hld.md
@@ -62,7 +62,8 @@ The relay is a Node/TypeScript Hono service backed by Postgres and Drizzle. It o
 - Node-authenticated cursor polling and recovery discovery, followed by fenced claim,
   start, renew, complete, and release operations. Completion commits the Mission
   result, source settlement, acknowledgement, downstream deliveries, receipt, and
-  audit consequences in one transaction.
+  audit consequences in one transaction. Delivery discovery and delivery operations
+  lazily reconcile eligible terminal causes under the same Mission lock.
 - Agent-authenticated Node enrollment, credential rotation, and revocation routes,
   plus Node-authenticated logical workspace registration and revocation. These
   operations are audited in the same transaction as their state changes.
@@ -167,7 +168,8 @@ Agent 1---N Node ---N NodeCredential
 - `NodeCredential` stores only the hashed, separately revocable credential used by
   one active Node. Its raw token is returned only when enrolled or rotated.
 - `Mission` stores the immutable coordinator config plus a reducer projection;
-  `MissionEvent` is append-only and ordered within that Mission.
+  `MissionEvent` is append-only and ordered within that Mission. Events have explicit
+  `agent` or `system` actors; Relay-owned `mission_terminal` has no Agent actor.
 - `NodeDelivery` points one Node cursor to work derived from a committed Mission
   event. It moves through `stored`, `leased`, `executing`, `acknowledged`,
   `cancelled`, or `dead_lettered`, with attempt, fencing, lease, availability, and
@@ -249,6 +251,10 @@ and the relay-owned idempotency key is not exposed to the model.
 - New-work cursor polling plus a separate recovery scan; relay-issued bounded leases,
   monotonic attempt fencing, exact operation receipts, retry/dead-letter transitions,
   relay cancellation, and atomic Mission-result completion.
+- Deterministic lazy terminal reconciliation: deadline maps eligible Missions to
+  `expired`, otherwise the earliest unsettled dead letter maps them to `failed`, with
+  one system event, remaining-work cancellations, receipts, and audits committed
+  atomically.
 - Node enrollment, credential rotation/revocation, logical workspace registration,
   exact workspace replay, and atomic Node-to-credential/workspace revocation. Node,
   workspace, and owner revocation also cancel active work across affected Missions.
@@ -279,9 +285,6 @@ and the relay-owned idempotency key is not exposed to the model.
 - Automatic worktree isolation and complete per-Mission command/network mediation.
 - Contract-acknowledgement and registered verification-command delivery handlers.
 - Local command, edit, test, and permission-decision audit.
-- Background or lazy Mission-level expiry/dead-letter reconciliation. Expired
-  Missions are filtered from delivery discovery, but their row and all remaining
-  deliveries are not automatically moved to terminal states.
 - A real two-machine, two-repository execution proof.
 - A current A2A compatibility proof.
 
@@ -350,8 +353,12 @@ section of [`architecture.md`](architecture.md).
   aggregate activation event and first turn. A failed delivery insert rolls back that
   entire mutation.
 - Cursor reads discover only newly due stored work; the separate recovery scan finds
-  due retried work and active or expired leases regardless of cursor age. Both hide
-  work for expired or non-runnable Missions, but do not transition the Mission.
+  due retried work and active or expired leases regardless of cursor age. Both
+  reconcile before reading. Every delivery operation also reconciles before applying
+  fresh authority or validating exact replay. Deadline wins over dead letter;
+  otherwise the earliest unsettled dead-letter cursor is authoritative. Reconciliation
+  is serialized with normal Mission mutation, no-ops after terminalization, cancels
+  remaining `stored`/`leased`/`executing` work, and fences delayed output.
 - Claim uses relay database time to issue a 60-second lease bounded by Mission expiry,
   increments the attempt, and uses that attempt as the fence. A stale holder cannot
   start, renew, release, or complete after re-lease. New mutations re-check current
@@ -362,8 +369,8 @@ section of [`architecture.md`](architecture.md).
   work to `stored` with relay backoff; permanent, policy, exhausted, or Mission-bound
   failure dead-letters it. Reclaiming a non-final expired lease records Relay expiry
   evidence before issuing the next claim; an expired final attempt instead produces
-  one terminal Node claim receipt with `claim_outcome: dead_lettered`. No process
-  promotes that terminal delivery outcome to a Mission-wide terminal state.
+  one terminal Node claim receipt with `claim_outcome: dead_lettered`, which then
+  reconciles the Mission to `failed` when the deadline has not already expired it.
 - Node credential rotation is a compare-and-swap against the owner-visible active
   credential ID and serializes with workspace mutations. Concurrent rotations from
   one credential generation cannot both succeed. Node revocation atomically disables
@@ -380,5 +387,4 @@ API with either an in-process fake or a detached persistent fake Capsule. A pinn
 Codex client and injected runner now pass the provider-neutral Capsule wire with fake
 app-server clients, but remain unactivated. The next runtime checkpoint is
 guardian-owned, OS-contained CLI activation and a real model turn, followed by a
-two-machine run; Mission-level expiry/dead-letter reconciliation remains a separate
-relay gap.
+two-machine run.

--- a/docs/lld.md
+++ b/docs/lld.md
@@ -39,8 +39,9 @@ prove execution on two machines.
   new-work cursor, recovery-page, delivery-operation input/result, lease, fencing,
   cancellation, and receipt contracts;
 - pure Mission lifecycle and fenced-delivery reducers;
-- a replayable four-event coordinator boundary for participant acceptance, completed
-  turns, explicit contract acknowledgement, and local verification evidence;
+- a replayable five-event coordinator boundary for participant acceptance, completed
+  turns, explicit contract acknowledgement, local verification evidence, and the
+  Relay-owned terminal Mission event;
 - one-current-participant routing, consecutive contract revision pause/activation,
   contract-scoped readiness, required local command IDs, turn limits, terminal-event
   rejection, verification-round fencing, and exact event/idempotency/delivery replay
@@ -77,7 +78,7 @@ the committed Drizzle migrations.
 | `workspace_bindings` | A Node-local logical alias represented at the relay by repository URL and allowed base refs. It deliberately has no checkout path. |
 | `missions` | Immutable coordinator config, current reducer projection/status/contract version, sequence, creator, and expiry. |
 | `mission_participants` | The exact agent, Node, and workspace binding selected for each two-party Mission, plus that participant's idempotent contract and opaque local-policy-grant acceptance receipt. |
-| `mission_events` | Append-only type-specific coordinator payload with relay-generated event ID, Mission sequence/time, service-supplied actor, source delivery, idempotency key, and causal parent. |
+| `mission_events` | Append-only type-specific coordinator payload with relay-generated event ID, Mission sequence/time, explicit `agent`/`system` actor kind, nullable Agent actor ID, source delivery, idempotency key, and causal parent. Only `mission_terminal` is system-authored. |
 | `node_deliveries` | Per-Node opaque cursor pointing to one Mission event, with `stored`, `leased`, `executing`, `acknowledged`, `cancelled`, or `dead_lettered` state; attempts, relay lease/fence, retry availability, settlement, and terminal evidence. |
 | `delivery_operation_receipts` | Append-only Node `claim`/`start`/`renew`/`complete`/`release` and relay `lease_expired`/`cancel` evidence, including idempotency identity, attempt, lease/fence, transition, input, output, and database timestamp. |
 
@@ -113,8 +114,8 @@ journal.
 
 ## Mission and delivery ledger
 
-`relay/src/services/mission-ledger.ts` and `delivery-ledger.ts` back public agent and
-Node routes.
+`relay/src/services/mission-ledger.ts`, `delivery-ledger.ts`, and
+`mission-reconciliation.ts` back public agent and Node routes.
 
 - Mission creation validates the shared protocol config, resolves every participant
   to exactly one active `agent + Node + workspace alias + repository URL`, stores
@@ -130,8 +131,8 @@ Node routes.
   public path for publishing a runtime result; there is no raw event-append route.
 - New-work polling reads strictly increasing global-`bigserial` cursors and only due,
   unsettled `stored` work. Recovery is cursorless and returns due stored retries plus
-  `leased` or `executing` work. Both join the Mission and require `active` or
-  `verifying` state with `expires_at` later than the relay database clock.
+  `leased` or `executing` work. Both first reconcile eligible `active` or `verifying`
+  Missions, then return only unexpired runnable state.
 - Claim issues a relay-generated lease for 60 seconds or the remaining Mission
   lifetime, whichever is shorter. It increments `attempt_count`, uses that attempt as
   the fencing token, and records a receipt. Start, renew, complete, and release
@@ -148,9 +149,13 @@ Node routes.
 - Reclaiming an expired lease below the attempt limit records a Relay
   `lease_expired` receipt and audit row before issuing the next claim. Reclaiming an
   expired final attempt records the terminal Node `claim` receipt with
-  `claim_outcome: dead_lettered` and no separate expiry receipt. Expired Missions are
-  not advertised, but no background or lazy reconciler changes the Mission row to
-  `expired` or turns one dead letter into Mission-wide failure and cancellation.
+  `claim_outcome: dead_lettered` and no separate expiry receipt. Final dead letters
+  reconcile immediately. Expired or previously dead-lettered Missions also reconcile
+  lazily from both delivery discovery routes and before every delivery operation.
+  Fresh authority and exact receipt replay are validated only after that fence. For
+  `active` or `verifying`, deadline maps to
+  `expired/deadline_exceeded/null`; otherwise the earliest unsettled dead-letter
+  cursor maps to `failed/delivery_dead_lettered/<delivery-id>`.
 
 ## HTTP surface
 
@@ -209,8 +214,8 @@ A2A well-known discovery URL.
 | `GET` | `/node/v1/missions` | List assignments for this Node with newest-first `after_cursor`/`next_cursor` keyset pagination. An unfiltered list is assignment history; `status=awaiting_acceptance` is the live acceptance view and excludes expired Missions using Relay database time. This is not delivery discovery. |
 | `GET` | `/node/v1/missions/:missionId` | Return this Node's exact Mission assignment and acceptance state. |
 | `POST` | `/node/v1/missions/:missionId/accept` | Store or exactly replay this participant's contract and local-policy acceptance receipt; the second participant activates the Mission. |
-| `GET` | `/node/v1/deliveries` | Cursor-page newly due, unsettled `stored` work for active/verifying, unexpired Missions. Reading does not claim it. |
-| `GET` | `/node/v1/deliveries/recoverable` | Cursorless scan for due retried `stored` work plus `leased` or `executing` work on active/verifying, unexpired Missions. |
+| `GET` | `/node/v1/deliveries` | Lazily reconcile eligible Mission terminal causes, then cursor-page newly due, unsettled `stored` work. Reading does not claim it. |
+| `GET` | `/node/v1/deliveries/recoverable` | Lazily reconcile eligible Mission terminal causes, then scan due retried `stored` work plus `leased` or `executing` work without a cursor. |
 | `POST` | `/node/v1/deliveries/:deliveryId/claim` | Issue or exactly replay a relay lease, incremented attempt, and fencing token; lazily reconcile an expired lease before reclaim. |
 | `POST` | `/node/v1/deliveries/:deliveryId/start` | Move the exact active lease from `leased` to `executing`. |
 | `POST` | `/node/v1/deliveries/:deliveryId/renew` | Retain lease/fence and extend its deadline from relay database time, bounded by Mission expiry; at that cap, confirm current authority with a fresh receipt without shortening the deadline. |
@@ -223,6 +228,10 @@ the same Node transaction lock used by rotation and revocation, so a completed
 revocation fences later mutations. Delivery operations use relay-issued authority;
 the wire cannot choose Node identity, server time, lease duration, lease expiry,
 working directory, runtime policy, or command permission.
+
+The two delivery `GET` routes may write terminal reconciliation state. Mission
+assignment list and detail routes remain read-only and do not reconcile. There is no
+background scheduler.
 
 ## JSON-RPC surface
 
@@ -492,12 +501,15 @@ Important limits:
 Relay audit rows cover invite mint/redeem, handoff create/accept/complete/cancel,
 message append, block/unblock, Node enroll/credential-rotate/revoke, workspace
 register/revoke, Mission create/participant accept/event append, every public Node
-delivery mutation, and relay lease-expiry/cancellation transitions. The matching
-`delivery_operation_receipts` retain exact Node-operation results and relay-owned
-transport history. Audit actors are explicit: authenticated Agent mutations retain an
-Agent ID, while admin and relay-system mutations use a typed actor with no fabricated
-Agent identity. Agent registration, card updates, and agent-key rotation still write
-no audit row. Audit also does not record commands, tool arguments/results, file edits,
+delivery mutation, `mission.terminal`, and relay lease-expiry/cancellation transitions.
+Each terminal reconciliation writes a system Mission audit plus Relay `cancel`
+receipts and audits tied to the terminal event for every remaining runnable delivery.
+The matching `delivery_operation_receipts` retain exact Node-operation results and
+relay-owned transport history. Audit actors are explicit: authenticated Agent
+mutations retain an Agent ID, while admin and relay-system mutations use a typed actor
+with no fabricated Agent identity. Agent registration, card updates, and agent-key
+rotation still write no audit row. Audit also does not record commands, tool
+arguments/results, file edits,
 tests, or permission decisions performed by a local coding-agent host.
 
 The relay has authenticated block endpoints. CLI `block`/`unblock` writes the relay
@@ -572,6 +584,5 @@ both the journaled in-process fake-turn boundary and detached fake-Capsule recov
 after Node-process death. The provider-neutral server and injected Codex runner add an
 unactivated wire-level checkpoint. The next slices are deterministic verification and
 contract handling, guardian-owned and OS-contained Codex CLI activation, a real model
-turn, and a two-machine proof. Mission-level expiry and dead-letter terminal
-reconciliation is still a separate relay gap; the mailbox API remains a compatibility
-and inspection surface.
+turn, and a two-machine proof. The mailbox API remains a compatibility and inspection
+surface.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -74,8 +74,8 @@ in-memory scripted proof, not durable relay or real-runtime evidence.
   without a second fake-host turn.
 - [x] Prove Relay-process restart plus Node reconnect through cursor/recovery polling;
   leave SSE out of this slice.
-- [ ] Reconcile delivery expiry/dead-letter outcomes into an explicit terminal or
-  blocked Mission transition instead of only hiding expired/terminal Mission work.
+- [x] Reconcile active/verifying deadlines to `expired` and unsettled dead-lettered
+  work to `failed`, cancelling remaining runnable deliveries transactionally.
 - [x] Add stable Node-scoped keyset pagination to Mission assignment discovery. The
   foreground Node persists its continuation and advances one bounded page only after
   servicing delivery work; it rejects immediate cursor loops, and the Relay excludes
@@ -103,9 +103,9 @@ WebSocket, or the process-local notification queue. Its exact failure matrix is:
 | A transient release becomes due behind the cursor | Postgres returns the delivery to `stored` with database-time backoff; the journal cursor already exceeds its creation cursor. | Cursor polling cannot rediscover it. The cursorless recovery route returns it when due, and the next claim advances the fence. |
 | Old or terminal work publishes late output | Postgres has either a newer active fence or a terminal Mission and acknowledged source delivery. | The old fence is rejected with `state_changed`; a fresh completion after the terminal max-turn transition is rejected with `invalid_transition`. Neither creates a second Mission turn. |
 
-The remaining delivery-control-plane gap is lifecycle reconciliation: delivery expiry
-or final dead-lettering still does not itself drive an explicit terminal or blocked
-Mission transition.
+Deterministic terminal reconciliation now closes the remaining delivery-control-plane
+gap. The next cross-device product proof is a real two-machine, two-repository run
+through the public control plane.
 
 ## 4. Build the local Node
 

--- a/docs/research/001-delivery-lease-control-plane.md
+++ b/docs/research/001-delivery-lease-control-plane.md
@@ -1,9 +1,9 @@
 # Delivery lease control plane
 
-- **Date:** 2026-08-02
+- **Date:** 2026-08-14
 - **Status:** Implemented and covered at the Relay service/HTTP boundary; foreground
-  Node journaling and detached fake-Capsule recovery are implemented, while Relay
-  restart, a real runtime, and two-machine proof remain pending.
+  Node journaling, detached fake-Capsule recovery, and Relay-process restart/replay
+  are implemented. A guarded real runtime and two-machine proof remain pending.
 - **Decision:** Build a database-backed Node delivery API before starting a local
   runtime.
 - **Scope:** Poll, claim, start, renew, complete, release, retry discovery, and
@@ -33,8 +33,7 @@ receipts for every state-changing delivery operation.
 - `release` returns transient work to stored state with relay-controlled backoff or
   dead-letters terminal and exhausted work.
 - Relay-owned cancellation closes work invalidated by sibling settlement, workspace
-  revocation, or Node revocation. Mission-wide terminal reconciliation remains a
-  separate pending control-plane responsibility.
+  revocation, Node revocation, or Mission terminal reconciliation.
 
 The wire never accepts Node identity, participant identity, server time, lease expiry,
 lease duration, a local path, or runtime policy. Those values come from authentication,
@@ -43,7 +42,10 @@ stored Mission routing, relay policy, and the database clock.
 ## Implemented surface
 
 Migration `relay/drizzle/0007_delivery_claims.sql` extends the durable delivery
-projection and adds append-only operation receipts. The authenticated routes are:
+projection and adds append-only operation receipts. Migration
+`relay/drizzle/0009_mission_terminal_reconciliation.sql` adds system-authored terminal
+Mission events while preserving the historical agent-event rows. The authenticated
+routes are:
 
 - `POST /agents/me/missions` for participant-owned Mission creation;
 - `GET /node/v1/missions`, `GET /node/v1/missions/:missionId`, and
@@ -66,17 +68,19 @@ rewrite the historical ledger.
 Each Node mutation uses this lock order:
 
 1. Serialize with Node credential rotation and revocation.
-2. Revalidate the exact active credential, Node, owner, participant, and workspace.
+2. Revalidate the exact active credential, Node, and owner.
 3. Resolve the Mission ID only through the exact Node-scoped delivery.
-4. Lock the Mission, revalidate all participant routing, then lock the exact delivery
-   row with `SELECT ... FOR UPDATE`.
-5. Resolve the exact Node-scoped idempotency receipt under those locks. Replay still
-   checks routing/revocation and cancellation; claim/start/renew replay also checks
-   current mutual trust, while complete/release returns only historical evidence.
-6. For a fresh mutation, lock and revalidate the Mission trust boundary.
-7. Read `clock_timestamp()` after blocking locks are held, then recheck Mission
-   status/expiry, delivery status/settlement, lease ID, fence, and deadline.
-8. Commit the delivery projection, any resulting Mission event, receipt, and audit
+4. Lock the Mission, read `clock_timestamp()`, and reconcile an eligible deadline or
+   unresolved dead letter before locking the exact delivery row with
+   `SELECT ... FOR UPDATE`.
+5. Revalidate participant routing, then resolve the exact Node-scoped idempotency
+   receipt under those locks. Replay still checks routing/revocation and cancellation;
+   claim/start/renew replay also checks current mutual trust, while complete/release
+   returns only historical evidence.
+6. For a fresh mutation, reject any just-reconciled terminal outcome, revalidate the
+   Mission trust boundary, and check Mission status/expiry, delivery
+   status/settlement, lease ID, fence, and deadline against the same database time.
+7. Commit the delivery projection, any resulting Mission event, receipt, and audit
    evidence together.
 
 PostgreSQL documents that `FOR UPDATE` blocks competing writers and lockers on the
@@ -129,12 +133,14 @@ These cases have deterministic Postgres coverage in
 `relay/src/db/migration-0007.test.ts`. They prove the in-process Relay boundary, not a
 real Node journal, a killed Relay process, or two-machine execution.
 
-## Remaining lifecycle work
+## Lifecycle follow-up
 
-- Expired and terminal Mission deliveries are excluded from discovery, so stale rows
-  cannot consume a bounded recovery page. The Relay does not yet append an explicit
-  `expired`, `blocked`, or `failed` Mission transition when expiry or dead-lettering
-  makes progress impossible.
+- Delivery discovery now lazily reconciles eligible Mission deadlines to `expired`
+  and unsettled dead letters to `failed`; every delivery operation crosses the same
+  Mission-lock fence before fresh authority or exact-replay validation. The
+  transaction appends one system terminal event,
+  cancels remaining runnable work, and records receipts and audits. There is no
+  background scheduler.
 - Mission assignment discovery is newest-first with a stable Node-scoped keyset
   cursor. The foreground Node durably advances one bounded page after servicing
   delivery work, while the Relay uses database time to exclude expired
@@ -142,10 +148,10 @@ real Node journal, a killed Relay process, or two-machine execution.
   recovery at the start of a cycle.
 - The foreground Node now persists its cursor, exact operation intent, lease/fence,
   Mission session, and host-turn mapping in an atomic local journal. Its detached
-  fake Capsule persists the exact start input, turn, and event stream independently;
-  the Node-process kill/restart test proves one recovered fake-host result. Relay
-  restart, real-runtime recovery, and two-machine correctness remain unproved end to
-  end.
+  fake Capsule persists the exact start input, turn, and event stream independently.
+  Process-level tests now prove both Node/Capsule recovery and Relay restart/reconnect
+  through public cursor and recovery polling. Real-runtime recovery and two-machine
+  correctness remain unproved end to end.
 
 The local checkpoint and its deliberate nonclaims are recorded in
 [`002-foreground-node-runtime.md`](002-foreground-node-runtime.md) and

--- a/docs/rfcs/001-agentrelay-node-and-missions.md
+++ b/docs/rfcs/001-agentrelay-node-and-missions.md
@@ -308,7 +308,10 @@ stored | leased | executing -> cancelled  (Relay-owned revocation/invalidation)
 
 Delivery is at least once. Each retry increments attempt count and applies bounded
 backoff. A true terminal delivery failure becomes `dead_lettered`; Mission policy then
-moves the Mission to `blocked` or `failed`.
+moves an eligible Mission deterministically. Its database deadline produces
+`expired`; otherwise its earliest unsettled dead-lettered delivery produces `failed`.
+These causes never select `blocked` or `cancelled`. Reconciliation cancels remaining
+runnable deliveries and rejects delayed output.
 
 Each new lease also advances a monotonic fencing token. Node-owned start, renewal,
 release, and result publication must present the active lease ID and token before the
@@ -427,8 +430,8 @@ The evaluation harness then runs one hidden end-to-end check that agents did not
    workspace-binding, and run schemas with state-machine tests.
 3. **Implemented at the Relay boundary:** transactional event/delivery append, Node
    cursor polling, leases, acknowledgement, retry, exact replay, and revocation.
-   A journaled client now covers runner reconstruction; Relay-process restart still
-   belongs to later control-plane evidence.
+   A journaled client covers runner reconstruction, and a real Relay-process restart
+   proof converges public cursor polling, recovery discovery, and exact receipt replay.
 4. **In progress:** the foreground `node/` daemon now consumes a pre-issued device
    credential, registers logical workspaces, journals cursor/operation/session/event
    state, enforces repository and local-profile preflight, and drives the fake adapter

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> **Updated:** 2026-08-03. This roadmap replaces the old mailbox -> Auto Mode ->
+> **Updated:** 2026-08-14. This roadmap replaces the old mailbox -> Auto Mode ->
 > Ambient Agent release sequence. The architectural contract is
 > [`RFC 001: AgentRelay Node and Missions`](rfcs/001-agentrelay-node-and-missions.md).
 
@@ -61,12 +61,13 @@ receipts, source-bound result settlement, verification generations, joined curso
 recovery scans, separately revocable Node credentials, public Mission routes, and
 fenced claim/start/renew/complete/release operations with exact durable receipts.
 Postgres tests cover concurrent claims, stale fences, expiry after lock waits, lost
-response replay, retry discovery, dead-lettering, blocks, and revocation races. A
-journaled client now proves runner reconstruction and duplicate polling without a
-second fake-host turn. A Postgres E2E now restarts the real Relay process before
-claim, after claim, and after a committed completion response is lost; it reopens the
-Node journal, converges cursor polling with cursorless recovery, and rejects stale or
-terminal output without a second effect. This proof uses no notification transport.
+response replay, retry discovery, dead-lettering, terminal reconciliation, blocks,
+and revocation races. A journaled client now proves runner reconstruction and duplicate
+polling without a second fake-host turn. A Postgres E2E restarts the real Relay process
+before claim, after claim, and after a committed completion response is lost; it
+reopens the Node journal, converges cursor polling with cursorless recovery, and
+rejects stale or terminal output without a second effect. This proof uses no
+notification transport.
 
 - Add Node identity, workspace-binding, Mission, event, delivery, claim, and
   acknowledgement persistence. Relay-visible run persistence remains part of the
@@ -77,14 +78,13 @@ terminal output without a second effect. This proof uses no notification transpo
 - Start with cursor polling over the durable ledger.
 - Defer authenticated SSE until replay, claims, and recovery are already correct.
 
-**Exit gate:** forced disconnects, relay restarts, expired leases, and duplicate
-notifications cause no lost event and no duplicated effect.
+**Exit gate:** passed. Forced disconnects, relay restarts, expired leases, and
+duplicate discovery/polling cause no lost event and no duplicated effect in the
+durable fake-runtime proof.
 
-Stable Mission-assignment pagination and the replay/restart evidence are implemented.
-The remaining lifecycle follow-up is to reconcile Mission state when delivery expiry
-or dead-lettering makes further progress impossible. Current discovery excludes
-expired and terminal Mission work so stale rows cannot starve runnable work, but
-filtering is not lifecycle reconciliation.
+Stable assignment pagination, restart/replay evidence, and deterministic terminal
+reconciliation are implemented. Reconciliation is lazy at delivery discovery and
+delivery-operation boundaries; it does not require a scheduler.
 
 ## Stage 3: AgentRelay Node
 

--- a/protocol/src/delivery-operations.test.ts
+++ b/protocol/src/delivery-operations.test.ts
@@ -425,6 +425,24 @@ describe("delivery operation results", () => {
 		expect(
 			deliveryCompleteResultSchema.safeParse({
 				...result,
+				events: [
+					{
+						event_id: event.event_id,
+						idempotency_key: event.idempotency_key,
+						mission_id: event.mission_id,
+						sequence_no: event.sequence_no,
+						created_at: event.created_at,
+						type: "mission_terminal",
+						terminal_status: "expired",
+						reason: "deadline_exceeded",
+						triggering_delivery_id: null,
+					},
+				],
+			}).success,
+		).toBe(false);
+		expect(
+			deliveryCompleteResultSchema.safeParse({
+				...result,
 				delivery: {
 					...acknowledgedDelivery,
 					logical_settlement: { ...settlement, settled_by_event_id: IDS.derived },

--- a/protocol/src/delivery-operations.ts
+++ b/protocol/src/delivery-operations.ts
@@ -199,16 +199,20 @@ export const deliveryCompleteResultSchema = z
 	.strict()
 	.superRefine((result, ctx) => {
 		validateOperationResult(result, ctx);
-		if (result.events.some((event) => event.type === "participants_accepted")) {
+		if (
+			result.events.some(
+				(event) => event.type === "participants_accepted" || event.type === "mission_terminal",
+			)
+		) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
-				message: "A Node completion cannot publish participant acceptance",
+				message: "A Node completion cannot publish Relay-owned Mission events",
 				path: ["events"],
 			});
 			return;
 		}
 		for (const [index, event] of result.events.entries()) {
-			if (event.type === "participants_accepted") {
+			if (event.type === "participants_accepted" || event.type === "mission_terminal") {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
 					message: "Completion events must exactly match the returned delivery work",

--- a/protocol/src/mission-coordinator.test.ts
+++ b/protocol/src/mission-coordinator.test.ts
@@ -846,6 +846,75 @@ describe("Mission coordinator", () => {
 		expect(reduceMissionCoordinatorEvent(afterFirst, firstReply)).toBe(afterFirst);
 		expect(afterFirst).toMatchObject({ status: "active", turn_count: 1 });
 	});
+
+	it.each([
+		["expired", "deadline_exceeded", null],
+		["failed", "delivery_dead_lettered", deliveryId(2)],
+	] as const)(
+		"accepts a Relay terminal event that moves active work to %s",
+		(terminalStatus, reason, triggeringDeliveryId) => {
+			const active = replayMissionCoordinatorEvents(CONFIG, [acceptedEvent(1)]);
+			const terminal = missionTerminalEvent(2, terminalStatus, reason, triggeringDeliveryId);
+			const reduced = reduceMissionCoordinatorEvent(active, terminal);
+
+			expect(reduced).toMatchObject({
+				status: terminalStatus,
+				sequence_no: 2,
+				pending_revision: null,
+				current_participant_agent_id: null,
+				ready_agent_ids: [],
+				verification_records: [],
+			});
+			expect(reduceMissionCoordinatorEvent(reduced, terminal)).toBe(reduced);
+			expect(() =>
+				reduceMissionCoordinatorEvent(
+					reduced,
+					replyTurn(3, IDS.backend, 1, IDS.message1, null, "Late output."),
+				),
+			).toThrow(/terminal/);
+		},
+	);
+
+	it("expires a verifying Mission and clears in-flight coordinator progress", () => {
+		const verifying = replayMissionCoordinatorEvents(CONFIG, [
+			acceptedEvent(1),
+			readyTurn(2, IDS.backend, 1),
+			readyTurn(3, IDS.android, 1),
+			verificationEvent(4, IDS.backend, 1, "backend-contract"),
+		]);
+
+		const expired = reduceMissionCoordinatorEvent(
+			verifying,
+			missionTerminalEvent(5, "expired", "deadline_exceeded", null),
+		);
+
+		expect(expired).toMatchObject({
+			status: "expired",
+			ready_agent_ids: [],
+			verification_records: [],
+		});
+	});
+
+	it("rejects participant-state terminalization and mismatched terminal causes", () => {
+		const initial = createMissionCoordinatorState(CONFIG);
+		expect(() =>
+			reduceMissionCoordinatorEvent(
+				initial,
+				missionTerminalEvent(1, "expired", "deadline_exceeded", null),
+			),
+		).toThrow(/terminal_state/);
+		expect(
+			missionCoordinatorEventSchema.safeParse({
+				...missionTerminalEvent(1, "failed", "delivery_dead_lettered", deliveryId(1)),
+				triggering_delivery_id: null,
+			}).success,
+		).toBe(false);
+		expect(
+			missionCoordinatorAppendInputSchema.safeParse(
+				toAppendInput(missionTerminalEvent(1, "expired", "deadline_exceeded", deliveryId(1))),
+			).success,
+		).toBe(false);
+	});
 });
 
 function acceptedEvent(sequence: number) {
@@ -854,6 +923,21 @@ function acceptedEvent(sequence: number) {
 		type: "participants_accepted" as const,
 		participant_agent_ids: [IDS.backend, IDS.android],
 		contract: structuredClone(CONTRACT_V1),
+	};
+}
+
+function missionTerminalEvent(
+	sequence: number,
+	terminalStatus: "expired" | "failed",
+	reason: "deadline_exceeded" | "delivery_dead_lettered",
+	triggeringDeliveryId: string | null,
+) {
+	return {
+		...envelope(sequence),
+		type: "mission_terminal" as const,
+		terminal_status: terminalStatus,
+		reason,
+		triggering_delivery_id: triggeringDeliveryId,
 	};
 }
 

--- a/protocol/src/mission-coordinator.ts
+++ b/protocol/src/mission-coordinator.ts
@@ -111,12 +111,22 @@ const verificationRecordedEventSchema = z
 		evidence: verificationEvidenceSchema,
 	})
 	.strict();
+const missionTerminalEventSchema = z
+	.object({
+		...missionEventEnvelopeSchema.shape,
+		type: z.literal("mission_terminal"),
+		terminal_status: z.enum(["expired", "failed"]),
+		reason: z.enum(["deadline_exceeded", "delivery_dead_lettered"]),
+		triggering_delivery_id: uuidSchema.nullable(),
+	})
+	.strict();
 
 const rawMissionCoordinatorEventSchema = z.discriminatedUnion("type", [
 	participantsAcceptedEventSchema,
 	turnCompletedEventSchema,
 	contractAcknowledgedEventSchema,
 	verificationRecordedEventSchema,
+	missionTerminalEventSchema,
 ]);
 
 const rawMissionCoordinatorAppendInputSchema = z.discriminatedUnion("type", [
@@ -721,6 +731,14 @@ function validateMissionDeliveryItem(
 		}
 		return;
 	}
+	if (item.event.type === "mission_terminal") {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "Terminal Mission events do not derive Node deliveries",
+			path: ["event", "type"],
+		});
+		return;
+	}
 	if (item.actor_agent_id !== item.event.participant_agent_id) {
 		ctx.addIssue({
 			code: z.ZodIssueCode.custom,
@@ -747,6 +765,24 @@ function validateCoordinatorEventPayload(
 				code: z.ZodIssueCode.custom,
 				message: "Accepted Mission participants must be unique",
 				path: ["participant_agent_ids"],
+			});
+		}
+		return;
+	}
+	if (event.type === "mission_terminal") {
+		const expiresMission =
+			event.terminal_status === "expired" &&
+			event.reason === "deadline_exceeded" &&
+			event.triggering_delivery_id === null;
+		const failsMission =
+			event.terminal_status === "failed" &&
+			event.reason === "delivery_dead_lettered" &&
+			event.triggering_delivery_id !== null;
+		if (!expiresMission && !failsMission) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Mission terminal status must match its authoritative cause",
+				path: ["terminal_status"],
 			});
 		}
 		return;
@@ -866,8 +902,10 @@ export function reduceMissionCoordinatorEvent(
 		reduced = applyTurnCompleted(current, event);
 	} else if (event.type === "contract_acknowledged") {
 		reduced = applyContractAcknowledged(current, event);
-	} else {
+	} else if (event.type === "verification_recorded") {
 		reduced = applyVerificationRecorded(current, event);
+	} else {
+		reduced = applyMissionTerminal(current, event);
 	}
 
 	return {
@@ -901,6 +939,26 @@ type VerificationRecordedEvent = Extract<
 	MissionCoordinatorEvent,
 	{ readonly type: "verification_recorded" }
 >;
+type MissionTerminalEvent = Extract<MissionCoordinatorEvent, { readonly type: "mission_terminal" }>;
+
+function applyMissionTerminal(
+	state: MissionCoordinatorState,
+	event: MissionTerminalEvent,
+): MissionCoordinatorState {
+	if (state.status !== "active" && state.status !== "verifying") {
+		throw new InvalidMissionCoordinatorEventError("terminal_state");
+	}
+	return {
+		...state,
+		status: transitionMissionStatus(state.status, {
+			type: event.terminal_status === "expired" ? "expire" : "fail",
+		}),
+		pending_revision: null,
+		current_participant_agent_id: null,
+		ready_agent_ids: [],
+		verification_records: [],
+	};
+}
 
 function applyParticipantsAccepted(
 	state: MissionCoordinatorState,

--- a/relay/drizzle/0009_mission_terminal_reconciliation.sql
+++ b/relay/drizzle/0009_mission_terminal_reconciliation.sql
@@ -1,0 +1,40 @@
+-- Serialize concurrent startup before changing the Mission event actor contract.
+SELECT pg_advisory_xact_lock(
+  hashtextextended('agentrelay:migration:0009_mission_terminal_reconciliation', 0)
+);
+--> statement-breakpoint
+ALTER TABLE "mission_events"
+  ADD COLUMN IF NOT EXISTS "actor_kind" text NOT NULL DEFAULT 'agent';
+--> statement-breakpoint
+ALTER TABLE "mission_events"
+  ALTER COLUMN "actor_agent_id" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "mission_events"
+  DROP CONSTRAINT IF EXISTS "mission_events_actor_kind_chk",
+  DROP CONSTRAINT IF EXISTS "mission_events_actor_identity_chk",
+  DROP CONSTRAINT IF EXISTS "mission_events_actor_event_chk",
+  DROP CONSTRAINT IF EXISTS "mission_events_type_chk";
+--> statement-breakpoint
+ALTER TABLE "mission_events"
+  ADD CONSTRAINT "mission_events_actor_kind_chk" CHECK (
+    "actor_kind" IN ('agent','system')
+  ) NOT VALID,
+  ADD CONSTRAINT "mission_events_actor_identity_chk" CHECK (
+    ("actor_kind" = 'agent' AND "actor_agent_id" IS NOT NULL)
+    OR ("actor_kind" = 'system' AND "actor_agent_id" IS NULL)
+  ) NOT VALID,
+  ADD CONSTRAINT "mission_events_actor_event_chk" CHECK (
+    ("type" = 'mission_terminal' AND "actor_kind" = 'system')
+    OR ("type" != 'mission_terminal' AND "actor_kind" = 'agent')
+  ) NOT VALID,
+  ADD CONSTRAINT "mission_events_type_chk" CHECK (
+    "type" IN (
+      'participants_accepted','turn_completed','contract_acknowledged',
+      'verification_recorded','mission_terminal'
+    )
+  ) NOT VALID;
+
+-- Drizzle runs every pending migration in one transaction. Keeping these checks
+-- NOT VALID avoids scanning the append-only event ledger while that transaction
+-- retains ALTER TABLE's lock. PostgreSQL still enforces each check for all new or
+-- updated rows; a later maintenance migration may validate historical rows online.

--- a/relay/drizzle/meta/_journal.json
+++ b/relay/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1786021200000,
 			"tag": "0008_audit_actor_kind",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1786107600000,
+			"tag": "0009_mission_terminal_reconciliation",
+			"breakpoints": true
 		}
 	]
 }

--- a/relay/scripts/test-integration.sh
+++ b/relay/scripts/test-integration.sh
@@ -56,8 +56,10 @@ INTEGRATION_FILES=(
   src/db/migration-0006.test.ts
   src/db/migration-0007.test.ts
   src/db/migration-0008.test.ts
+  src/db/migration-0009.test.ts
   src/db/schema.test.ts
   src/services/delivery-ledger.test.ts
+  src/services/mission-reconciliation.test.ts
   src/services/delivery-revocation.test.ts
   src/services/mission-ledger.test.ts
   src/routes/admin.test.ts

--- a/relay/src/db/migration-0009.test.ts
+++ b/relay/src/db/migration-0009.test.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import postgres, { type Sql } from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { tryConnect } from "./test-utils.js";
+
+const TEST_URL = process.env.RELAY_TEST_DATABASE_URL ?? process.env.RELAY_DATABASE_URL;
+const conn = await tryConnect();
+const d = conn.available && TEST_URL ? describe : describe.skip;
+
+if (!conn.available || !TEST_URL) {
+	console.warn(`[migration-0009.test] skipping: ${conn.reason ?? "database URL unset"}`);
+}
+
+d("0009 Mission terminal reconciliation migration", () => {
+	let sql: Sql;
+	let migration: string;
+	const schemaName = `migration_0009_${randomUUID().replaceAll("-", "")}`;
+	const missionId = randomUUID();
+	const agentId = randomUUID();
+	const legacyEventId = randomUUID();
+
+	beforeAll(async () => {
+		sql = postgres(TEST_URL as string, { max: 1, onnotice: () => undefined });
+		await sql.unsafe(`CREATE SCHEMA "${schemaName}"`);
+		await sql.unsafe(`SET search_path TO "${schemaName}", public`);
+		await sql.unsafe(`
+			CREATE TABLE agents (id uuid PRIMARY KEY);
+			CREATE TABLE missions (id uuid PRIMARY KEY);
+			CREATE TABLE mission_participants (
+				mission_id uuid NOT NULL REFERENCES missions(id),
+				agent_id uuid NOT NULL REFERENCES agents(id),
+				PRIMARY KEY (mission_id, agent_id)
+			);
+			CREATE TABLE mission_events (
+				id uuid PRIMARY KEY,
+				mission_id uuid NOT NULL REFERENCES missions(id),
+				sequence_no integer NOT NULL,
+				type text NOT NULL,
+				actor_agent_id uuid NOT NULL REFERENCES agents(id),
+				idempotency_key text NOT NULL,
+				source_delivery_id uuid,
+				causal_parent_event_id uuid,
+				payload jsonb NOT NULL,
+				created_at timestamp with time zone DEFAULT now() NOT NULL,
+				CONSTRAINT mission_events_actor_participant_fk
+					FOREIGN KEY (mission_id, actor_agent_id)
+					REFERENCES mission_participants(mission_id, agent_id),
+				CONSTRAINT mission_events_type_chk CHECK (
+					type IN (
+						'participants_accepted','turn_completed',
+						'contract_acknowledged','verification_recorded'
+					)
+				)
+			);
+		`);
+		await sql`INSERT INTO agents (id) VALUES (${agentId})`;
+		await sql`INSERT INTO missions (id) VALUES (${missionId})`;
+		await sql`
+			INSERT INTO mission_participants (mission_id, agent_id)
+			VALUES (${missionId}, ${agentId})
+		`;
+		await sql`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_agent_id, idempotency_key, payload
+			) VALUES (
+				${legacyEventId}, ${missionId}, 1, 'participants_accepted', ${agentId},
+				'legacy:accepted', ${sql.json({ participant_agent_ids: [agentId] })}
+			)
+		`;
+		migration = await readFile(
+			new URL("../../drizzle/0009_mission_terminal_reconciliation.sql", import.meta.url),
+			"utf8",
+		);
+		await applyMigration(sql, migration);
+	});
+
+	afterAll(async () => {
+		if (sql) {
+			await sql.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+			await sql.end({ timeout: 2 });
+		}
+		if (conn.handle) await conn.handle.close();
+	});
+
+	it("backfills participant events and reapplies without rewriting them", async () => {
+		const [before] = await sql<Array<{ actor_kind: string; actor_agent_id: string; type: string }>>`
+			SELECT actor_kind, actor_agent_id, type
+			FROM mission_events
+			WHERE id = ${legacyEventId}
+		`;
+		expect(before).toEqual({
+			actor_kind: "agent",
+			actor_agent_id: agentId,
+			type: "participants_accepted",
+		});
+
+		await applyMigration(sql, migration);
+
+		const rows = await sql<Array<{ actor_kind: string; actor_agent_id: string }>>`
+			SELECT actor_kind, actor_agent_id
+			FROM mission_events
+			WHERE id = ${legacyEventId}
+		`;
+		expect(rows).toEqual([{ actor_kind: "agent", actor_agent_id: agentId }]);
+	});
+
+	it("defers the historical constraint scan while enforcing new writes", async () => {
+		const constraints = await sql<Array<{ conname: string; convalidated: boolean }>>`
+			SELECT conname, convalidated
+			FROM pg_constraint
+			WHERE conrelid = 'mission_events'::regclass
+				AND conname IN (
+					'mission_events_actor_kind_chk',
+					'mission_events_actor_identity_chk',
+					'mission_events_actor_event_chk',
+					'mission_events_type_chk'
+				)
+			ORDER BY conname
+		`;
+		expect(constraints).toEqual([
+			{ conname: "mission_events_actor_event_chk", convalidated: false },
+			{ conname: "mission_events_actor_identity_chk", convalidated: false },
+			{ conname: "mission_events_actor_kind_chk", convalidated: false },
+			{ conname: "mission_events_type_chk", convalidated: false },
+		]);
+	});
+
+	it("permits only a System actor for Mission terminal events", async () => {
+		const terminalEventId = randomUUID();
+		const [inserted] = await sql<
+			Array<{ actor_kind: string; actor_agent_id: string | null; type: string }>
+		>`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_kind, actor_agent_id,
+				idempotency_key, payload
+			) VALUES (
+				${terminalEventId}, ${missionId}, 2, 'mission_terminal', 'system', NULL,
+				'terminal:expired', ${sql.json({
+					terminal_status: "expired",
+					reason: "deadline_exceeded",
+					triggering_delivery_id: null,
+				})}
+			)
+			RETURNING actor_kind, actor_agent_id, type
+		`;
+		expect(inserted).toEqual({
+			actor_kind: "system",
+			actor_agent_id: null,
+			type: "mission_terminal",
+		});
+
+		await expect(sql`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_kind, actor_agent_id,
+				idempotency_key, payload
+			) VALUES (
+				${randomUUID()}, ${missionId}, 3, 'mission_terminal', 'agent', ${agentId},
+				'invalid:agent-terminal', '{}'::jsonb
+			)
+		`).rejects.toThrow(/mission_events_actor_event_chk/);
+		await expect(sql`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_kind, actor_agent_id,
+				idempotency_key, payload
+			) VALUES (
+				${randomUUID()}, ${missionId}, 3, 'turn_completed', 'system', NULL,
+				'invalid:system-turn', '{}'::jsonb
+			)
+		`).rejects.toThrow(/mission_events_actor_event_chk/);
+	});
+
+	it("enforces actor identity and the expanded event type set", async () => {
+		await expect(sql`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_kind, actor_agent_id,
+				idempotency_key, payload
+			) VALUES (
+				${randomUUID()}, ${missionId}, 3, 'turn_completed', 'agent', NULL,
+				'invalid:missing-agent', '{}'::jsonb
+			)
+		`).rejects.toThrow(/mission_events_actor_identity_chk/);
+		await expect(sql`
+			INSERT INTO mission_events (
+				id, mission_id, sequence_no, type, actor_kind, actor_agent_id,
+				idempotency_key, payload
+			) VALUES (
+				${randomUUID()}, ${missionId}, 3, 'unknown_event', 'agent', ${agentId},
+				'invalid:type', '{}'::jsonb
+			)
+		`).rejects.toThrow(/mission_events_(actor_event|type)_chk/);
+	});
+});
+
+async function applyMigration(sql: Sql, migration: string): Promise<void> {
+	await sql.begin(async (tx) => {
+		for (const statement of migration.split("--> statement-breakpoint")) {
+			if (statement.trim()) await tx.unsafe(statement);
+		}
+	});
+}

--- a/relay/src/db/schema.ts
+++ b/relay/src/db/schema.ts
@@ -420,9 +420,8 @@ export const missionEvents = pgTable(
 			.references(() => missions.id, { onDelete: "restrict" }),
 		sequenceNo: integer("sequence_no").notNull(),
 		type: text("type").notNull(),
-		actorAgentId: uuid("actor_agent_id")
-			.notNull()
-			.references(() => agents.id, { onDelete: "restrict" }),
+		actorKind: text("actor_kind").notNull().default("agent"),
+		actorAgentId: uuid("actor_agent_id").references(() => agents.id, { onDelete: "restrict" }),
 		idempotencyKey: text("idempotency_key").notNull(),
 		sourceDeliveryId: uuid("source_delivery_id"),
 		causalParentEventId: uuid("causal_parent_event_id"),
@@ -444,9 +443,30 @@ export const missionEvents = pgTable(
 			foreignColumns: [missionParticipants.missionId, missionParticipants.agentId],
 			name: "mission_events_actor_participant_fk",
 		}),
+		actorKindCheck: check(
+			"mission_events_actor_kind_chk",
+			sql`${t.actorKind} IN ('agent','system')`,
+		),
+		actorIdentityCheck: check(
+			"mission_events_actor_identity_chk",
+			sql`(
+				(${t.actorKind} = 'agent' AND ${t.actorAgentId} IS NOT NULL)
+				OR (${t.actorKind} = 'system' AND ${t.actorAgentId} IS NULL)
+			)`,
+		),
+		actorEventCheck: check(
+			"mission_events_actor_event_chk",
+			sql`(
+				(${t.type} = 'mission_terminal' AND ${t.actorKind} = 'system')
+				OR (${t.type} != 'mission_terminal' AND ${t.actorKind} = 'agent')
+			)`,
+		),
 		typeCheck: check(
 			"mission_events_type_chk",
-			sql`${t.type} IN ('participants_accepted','turn_completed','contract_acknowledged','verification_recorded')`,
+			sql`${t.type} IN (
+				'participants_accepted','turn_completed','contract_acknowledged',
+				'verification_recorded','mission_terminal'
+			)`,
 		),
 		sequenceCheck: check("mission_events_sequence_chk", sql`${t.sequenceNo} > 0`),
 	}),

--- a/relay/src/services/delivery-ledger.test-support.ts
+++ b/relay/src/services/delivery-ledger.test-support.ts
@@ -1,0 +1,313 @@
+import { randomUUID } from "node:crypto";
+import type { DeliveryClaimResult, MissionCoordinatorConfig } from "@agentrelay/protocol";
+import { eq, sql } from "drizzle-orm";
+import { nodeDeliveries } from "../db/schema.js";
+import type { TestDb } from "../db/test-utils.js";
+import { registerAgentWithInitialKey } from "./agent-registration.js";
+import {
+	claimDelivery,
+	completeDelivery,
+	listAvailableDeliveryEvents,
+	startDelivery,
+} from "./delivery-ledger.js";
+import { acceptMissionParticipant, createMissionLedger } from "./mission-ledger.js";
+import { type NodeCredentialContext, enrollNode, registerWorkspace } from "./node-enrollment.js";
+
+export const TEST_KEY_PEPPER = "p".repeat(32);
+
+export interface ParticipantFixture {
+	readonly agentId: string;
+	readonly nodeId: string;
+	readonly auth: NodeCredentialContext;
+}
+
+export interface DeliveryFixture {
+	readonly missionId: string;
+	readonly config: MissionCoordinatorConfig;
+	readonly contract: MissionCoordinatorConfig["mission_context"]["manifest"]["shared_contract"];
+	readonly backend: ParticipantFixture;
+	readonly android: ParticipantFixture;
+	readonly initialDeliveryId: string;
+}
+
+export async function createActivatedFixture(
+	handle: TestDb,
+	options: {
+		readonly backendCommands?: readonly string[];
+		readonly missionLifetimeMs?: number;
+	} = {},
+): Promise<DeliveryFixture> {
+	const backend = await registerParticipant(handle, {
+		role: "backend",
+		nodeName: "backend-mac",
+		workspaceAlias: "backend-api",
+		repositoryUrl: "https://github.com/acme/backend.git",
+	});
+	const android = await registerParticipant(handle, {
+		role: "android",
+		nodeName: "android-mac",
+		workspaceAlias: "android-app",
+		repositoryUrl: "https://github.com/acme/android.git",
+	});
+	const now = await databaseNow(handle);
+	const missionId = randomUUID();
+	const contract: DeliveryFixture["contract"] = {
+		artifact_id: randomUUID(),
+		type: "api_contract",
+		version: 1,
+		sha256: "a".repeat(64),
+		media_type: "application/json",
+		byte_size: 128,
+	};
+	const config: MissionCoordinatorConfig = {
+		mission_context: {
+			manifest: {
+				schema_version: 1,
+				mission_id: missionId,
+				objective: "Ship one compatible profile contract across backend and Android",
+				public_acceptance_criteria: ["Both repository checks pass"],
+				participants: [
+					{
+						agent_id: backend.agentId,
+						role: "backend",
+						workspace_alias: "backend-api",
+						repository_url: "https://github.com/acme/backend.git",
+						expected_base_commit: "1".repeat(40),
+						initial_assignment: "Implement the response contract",
+						requested_local_policy_profile: "bounded-code",
+					},
+					{
+						agent_id: android.agentId,
+						role: "android",
+						workspace_alias: "android-app",
+						repository_url: "https://github.com/acme/android.git",
+						expected_base_commit: "2".repeat(40),
+						initial_assignment: "Consume the response contract",
+						requested_local_policy_profile: "bounded-code",
+					},
+				],
+				shared_contract: contract,
+				max_turns: 20,
+				max_wall_time_seconds: 3_600,
+				token_budget: 100_000,
+				expires_at: new Date(
+					now.getTime() + (options.missionLifetimeMs ?? 3_600_000),
+				).toISOString(),
+				allowed_artifact_types: ["api_contract"],
+				created_at: new Date(now.getTime() - 1_000).toISOString(),
+			},
+			created_by: { principal_id: backend.agentId, kind: "agent" },
+		},
+		required_verification_commands: {
+			[backend.agentId]: [...(options.backendCommands ?? ["backend-test"])],
+			[android.agentId]: ["android-test"],
+		},
+	};
+
+	await createMissionLedger(handle.db, {
+		createdByAgentId: backend.agentId,
+		coordinatorConfig: config,
+	});
+	await acceptMissionParticipant(handle.db, {
+		missionId,
+		participantAgentId: backend.agentId,
+		nodeAuth: backend.auth,
+		acceptance: participantAcceptance(contract, "accept:backend", "d"),
+	});
+	await acceptMissionParticipant(handle.db, {
+		missionId,
+		participantAgentId: android.agentId,
+		nodeAuth: android.auth,
+		acceptance: participantAcceptance(contract, "accept:android", "e"),
+	});
+
+	const initial = await onlyAvailableDelivery(handle, backend.nodeId, "turn");
+	return {
+		missionId,
+		config,
+		contract,
+		backend,
+		android,
+		initialDeliveryId: initial.delivery_id,
+	};
+}
+
+async function registerParticipant(
+	handle: TestDb,
+	input: {
+		readonly role: "backend" | "android";
+		readonly nodeName: string;
+		readonly workspaceAlias: string;
+		readonly repositoryUrl: string;
+	},
+): Promise<ParticipantFixture> {
+	const suffix = randomUUID();
+	const registration = await registerAgentWithInitialKey(handle.db, {
+		handle: `${input.role}-${suffix}@agentrelay.test`,
+		email: `${input.role}-${suffix}@agentrelay.test`,
+		displayName: input.role === "backend" ? "Backend" : "Android",
+		role: input.role,
+		pepper: TEST_KEY_PEPPER,
+		keyEnvironment: "test",
+	});
+	const enrollment = await enrollNode(
+		handle.db,
+		registration.agent.id,
+		{ name: input.nodeName, capabilities: ["missions.execute"] },
+		"test",
+		TEST_KEY_PEPPER,
+	);
+	const auth: NodeCredentialContext = {
+		nodeId: enrollment.node.node_id,
+		agentId: registration.agent.id,
+		credentialId: enrollment.credential.id,
+		requestId: `test:${suffix}`,
+	};
+	await registerWorkspace(handle.db, auth, {
+		alias: input.workspaceAlias,
+		repository_url: input.repositoryUrl,
+		allowed_base_refs: ["refs/heads/main"],
+	});
+	return { agentId: registration.agent.id, nodeId: enrollment.node.node_id, auth };
+}
+
+export function participantAcceptance(
+	contract: DeliveryFixture["contract"],
+	idempotencyKey: string,
+	grantCharacter: string,
+) {
+	return {
+		idempotency_key: idempotencyKey,
+		contract: { ...contract },
+		local_policy_grant: {
+			profile_name: "bounded-code",
+			grant_sha256: grantCharacter.repeat(64),
+		},
+	};
+}
+
+export function verificationEvidence(
+	commandId: string,
+	outcome: "passed" | "failed",
+	recordedAt: string,
+) {
+	return {
+		verification_id: randomUUID(),
+		command_id: commandId,
+		outcome,
+		exit_code: outcome === "passed" ? 0 : 1,
+		duration_ms: 25,
+		summary: `${commandId} ${outcome}`,
+		output_sha256: "c".repeat(64),
+		artifacts: [],
+		recorded_at: recordedAt,
+	};
+}
+
+export function requireClaimed(result: DeliveryClaimResult) {
+	if (result.outcome !== "claimed") throw new Error("expected a claimed delivery");
+	return result;
+}
+
+export function requireLease(result: ReturnType<typeof requireClaimed>) {
+	const lease = result.item.delivery.lease;
+	if (!lease) throw new Error("expected an active delivery lease");
+	return lease;
+}
+
+export async function expireActiveLease(handle: TestDb, deliveryId: string): Promise<void> {
+	await handle.db
+		.update(nodeDeliveries)
+		.set({ leaseExpiresAt: sql`clock_timestamp() - interval '1 second'` })
+		.where(eq(nodeDeliveries.id, deliveryId));
+}
+
+export async function databaseNow(handle: TestDb): Promise<Date> {
+	const [row] = await handle.sql<Array<{ now: string | Date }>>`SELECT clock_timestamp() AS now`;
+	if (!row) throw new Error("expected the database clock");
+	return new Date(row.now);
+}
+
+export function deferred<T>(): {
+	readonly promise: Promise<T>;
+	readonly resolve: (value: T) => void;
+} {
+	let resolve = (_value: T): void => undefined;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+export async function waitForBlockedBy(
+	sqlClient: TestDb["sql"],
+	blockerPid: number,
+	message: string,
+	minimumWaiters = 1,
+	timeoutMs = 2_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const [row] = await sqlClient<Array<{ waiters: string }>>`
+			SELECT count(*)::text AS waiters
+			FROM pg_stat_activity
+			WHERE ${blockerPid} = ANY(pg_blocking_pids(pid))
+		`;
+		if (Number(row?.waiters ?? "0") >= minimumWaiters) return;
+	}
+	throw new Error(message);
+}
+
+export async function onlyAvailableDelivery(
+	handle: TestDb,
+	nodeId: string,
+	kind: "turn" | "verification",
+) {
+	const page = await listAvailableDeliveryEvents(handle.db, {
+		nodeId,
+		page: { after_cursor: null, limit: 50 },
+	});
+	const matching = page.items.filter((item) => item.delivery.kind === kind);
+	if (matching.length !== 1) {
+		throw new Error(`expected exactly one available ${kind} delivery, got ${matching.length}`);
+	}
+	return matching[0]!.delivery;
+}
+
+export async function claimAndStart(
+	handle: TestDb,
+	participant: ParticipantFixture,
+	deliveryId: string,
+	keySuffix: string,
+) {
+	const claim = requireClaimed(
+		await claimDelivery(handle.db, participant.auth, deliveryId, {
+			idempotency_key: `claim:${keySuffix}`,
+		}),
+	);
+	const lease = requireLease(claim);
+	const start = await startDelivery(handle.db, participant.auth, deliveryId, {
+		idempotency_key: `start:${keySuffix}`,
+		lease_id: lease.lease_id,
+		fencing_token: lease.fencing_token,
+	});
+	return { claim, lease, start };
+}
+
+export async function completeReadyTurn(
+	handle: TestDb,
+	participant: ParticipantFixture,
+	deliveryId: string,
+	keySuffix: string,
+) {
+	const execution = await claimAndStart(handle, participant, deliveryId, keySuffix);
+	return completeDelivery(handle.db, participant.auth, deliveryId, {
+		idempotency_key: `complete:${keySuffix}`,
+		lease_id: execution.lease.lease_id,
+		fencing_token: execution.lease.fencing_token,
+		result: {
+			type: "turn_completed",
+			disposition: { kind: "ready", evidence: [] },
+		},
+	});
+}

--- a/relay/src/services/delivery-ledger.test.ts
+++ b/relay/src/services/delivery-ledger.test.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import type { DeliveryClaimResult, MissionCoordinatorConfig } from "@agentrelay/protocol";
 import { and, asc, eq, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -12,7 +11,6 @@ import {
 	nodeDeliveries,
 } from "../db/schema.js";
 import { type TestDb, truncateAll, tryConnect } from "../db/test-utils.js";
-import { registerAgentWithInitialKey } from "./agent-registration.js";
 import {
 	claimDelivery,
 	completeDelivery,
@@ -22,17 +20,29 @@ import {
 	renewDelivery,
 	startDelivery,
 } from "./delivery-ledger.js";
+import {
+	TEST_KEY_PEPPER,
+	claimAndStart,
+	completeReadyTurn,
+	createActivatedFixture,
+	databaseNow,
+	deferred,
+	expireActiveLease,
+	onlyAvailableDelivery,
+	participantAcceptance,
+	requireClaimed,
+	requireLease,
+	verificationEvidence,
+	waitForBlockedBy,
+} from "./delivery-ledger.test-support.js";
 import { acceptMissionParticipant, createMissionLedger } from "./mission-ledger.js";
 import {
 	type NodeCredentialContext,
-	enrollNode,
-	registerWorkspace,
 	revokeNode,
 	revokeWorkspace,
 	rotateNodeCredential,
 } from "./node-enrollment.js";
 
-const KEY_PEPPER = "p".repeat(32);
 const TEST_DATABASE_URL = process.env.RELAY_TEST_DATABASE_URL ?? process.env.RELAY_DATABASE_URL;
 const conn = await tryConnect();
 const d = conn.available ? describe : describe.skip;
@@ -310,7 +320,7 @@ d("delivery claim and execution ledger", () => {
 				(value) => ({ status: "fulfilled" as const, value }),
 				(reason: unknown) => ({ status: "rejected" as const, reason }),
 			);
-			await waitForBlockedBy(handle, blockerPid, "renewal did not wait on the Mission lock");
+			await waitForBlockedBy(handle.sql, blockerPid, "renewal did not wait on the Mission lock");
 			expireAndRelease.resolve(undefined);
 			await blocker;
 			const outcome = await renewalOutcome;
@@ -426,7 +436,7 @@ d("delivery claim and execution ledger", () => {
 			fixture.backend.nodeId,
 			{ expected_credential_id: fixture.backend.auth.credentialId },
 			"test",
-			KEY_PEPPER,
+			TEST_KEY_PEPPER,
 			{ requestId: "test:rotate-active-lease" },
 		);
 		const rotatedAuth: NodeCredentialContext = {
@@ -515,6 +525,12 @@ d("delivery claim and execution ledger", () => {
 		await expect(
 			startDelivery(handle.db, fixture.backend.auth, fixture.initialDeliveryId, {
 				...startInput,
+			}),
+		).rejects.toMatchObject({ code: "not_authorized_transition" });
+		await expect(
+			startDelivery(handle.db, fixture.backend.auth, fixture.initialDeliveryId, {
+				...startInput,
+				fencing_token: "999",
 			}),
 		).rejects.toMatchObject({ code: "not_authorized_transition" });
 
@@ -612,7 +628,7 @@ d("delivery claim and execution ledger", () => {
 				(value) => ({ status: "fulfilled" as const, value }),
 				(reason: unknown) => ({ status: "rejected" as const, reason }),
 			);
-			await waitForBlockedBy(handle, blockerPid, "completion did not wait on the block fence");
+			await waitForBlockedBy(handle.sql, blockerPid, "completion did not wait on the block fence");
 			commitBlock.resolve(undefined);
 			await blocker;
 			const outcome = await completion;
@@ -770,20 +786,6 @@ d("delivery claim and execution ledger", () => {
 				),
 			);
 		expect(completionReceipts).toEqual([]);
-	});
-
-	it("hides stored work after its Mission expires", async () => {
-		const fixture = await createActivatedFixture(handle);
-		await handle.db
-			.update(missions)
-			.set({ expiresAt: sql`clock_timestamp() - interval '1 second'` })
-			.where(eq(missions.id, fixture.missionId));
-
-		const page = await listAvailableDeliveryEvents(handle.db, {
-			nodeId: fixture.backend.nodeId,
-			page: { after_cursor: null, limit: 50 },
-		});
-		expect(page.items).toEqual([]);
 	});
 
 	it("does not let an expired Mission starve later recoverable work", async () => {
@@ -998,6 +1000,45 @@ d("delivery claim and execution ledger", () => {
 			.where(eq(deliveryOperationReceipts.deliveryId, fixture.initialDeliveryId));
 		expect(receipts.filter((receipt) => receipt.operation === "claim")).toHaveLength(2);
 		expect(receipts.filter((receipt) => receipt.operation === "lease_expired")).toHaveLength(0);
+		const [mission] = await handle.db
+			.select()
+			.from(missions)
+			.where(eq(missions.id, fixture.missionId));
+		expect(mission).toMatchObject({ status: "failed" });
+		expect(mission?.state).toMatchObject({ status: "failed", sequence_no: 2 });
+		const [terminalEvent] = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(
+				and(
+					eq(missionEvents.missionId, fixture.missionId),
+					eq(missionEvents.type, "mission_terminal"),
+				),
+			);
+		expect(terminalEvent).toMatchObject({
+			actorKind: "system",
+			actorAgentId: null,
+			sourceDeliveryId: fixture.initialDeliveryId,
+			payload: {
+				terminal_status: "failed",
+				reason: "delivery_dead_lettered",
+				triggering_delivery_id: fixture.initialDeliveryId,
+			},
+		});
+		const terminalAudits = await handle.db
+			.select()
+			.from(auditLog)
+			.where(
+				and(eq(auditLog.action, "mission.terminal"), eq(auditLog.resourceId, terminalEvent!.id)),
+			);
+		expect(terminalAudits).toHaveLength(1);
+		expect(terminalAudits[0]?.metadata).toMatchObject({
+			mission_id: fixture.missionId,
+			status: "failed",
+			reason: "delivery_dead_lettered",
+			triggering_delivery_id: fixture.initialDeliveryId,
+			cancelled_delivery_ids: [],
+		});
 		const recoveryPoll = await listRecoverableDeliveryEvents(handle.db, {
 			nodeId: fixture.backend.nodeId,
 			page: { limit: 50 },
@@ -1187,295 +1228,3 @@ d("delivery claim and execution ledger", () => {
 		});
 	});
 });
-
-interface ParticipantFixture {
-	readonly agentId: string;
-	readonly nodeId: string;
-	readonly auth: NodeCredentialContext;
-}
-
-interface DeliveryFixture {
-	readonly missionId: string;
-	readonly config: MissionCoordinatorConfig;
-	readonly contract: MissionCoordinatorConfig["mission_context"]["manifest"]["shared_contract"];
-	readonly backend: ParticipantFixture;
-	readonly android: ParticipantFixture;
-	readonly initialDeliveryId: string;
-}
-
-async function createActivatedFixture(
-	handle: TestDb,
-	options: {
-		readonly backendCommands?: readonly string[];
-		readonly missionLifetimeMs?: number;
-	} = {},
-): Promise<DeliveryFixture> {
-	const backend = await registerParticipant(handle, {
-		role: "backend",
-		nodeName: "backend-mac",
-		workspaceAlias: "backend-api",
-		repositoryUrl: "https://github.com/acme/backend.git",
-	});
-	const android = await registerParticipant(handle, {
-		role: "android",
-		nodeName: "android-mac",
-		workspaceAlias: "android-app",
-		repositoryUrl: "https://github.com/acme/android.git",
-	});
-	const now = await databaseNow(handle);
-	const missionId = randomUUID();
-	const contract: DeliveryFixture["contract"] = {
-		artifact_id: randomUUID(),
-		type: "api_contract",
-		version: 1,
-		sha256: "a".repeat(64),
-		media_type: "application/json",
-		byte_size: 128,
-	};
-	const config: MissionCoordinatorConfig = {
-		mission_context: {
-			manifest: {
-				schema_version: 1,
-				mission_id: missionId,
-				objective: "Ship one compatible profile contract across backend and Android",
-				public_acceptance_criteria: ["Both repository checks pass"],
-				participants: [
-					{
-						agent_id: backend.agentId,
-						role: "backend",
-						workspace_alias: "backend-api",
-						repository_url: "https://github.com/acme/backend.git",
-						expected_base_commit: "1".repeat(40),
-						initial_assignment: "Implement the response contract",
-						requested_local_policy_profile: "bounded-code",
-					},
-					{
-						agent_id: android.agentId,
-						role: "android",
-						workspace_alias: "android-app",
-						repository_url: "https://github.com/acme/android.git",
-						expected_base_commit: "2".repeat(40),
-						initial_assignment: "Consume the response contract",
-						requested_local_policy_profile: "bounded-code",
-					},
-				],
-				shared_contract: contract,
-				max_turns: 20,
-				max_wall_time_seconds: 3_600,
-				token_budget: 100_000,
-				expires_at: new Date(
-					now.getTime() + (options.missionLifetimeMs ?? 3_600_000),
-				).toISOString(),
-				allowed_artifact_types: ["api_contract"],
-				created_at: new Date(now.getTime() - 1_000).toISOString(),
-			},
-			created_by: { principal_id: backend.agentId, kind: "agent" },
-		},
-		required_verification_commands: {
-			[backend.agentId]: [...(options.backendCommands ?? ["backend-test"])],
-			[android.agentId]: ["android-test"],
-		},
-	};
-
-	await createMissionLedger(handle.db, {
-		createdByAgentId: backend.agentId,
-		coordinatorConfig: config,
-	});
-	await acceptMissionParticipant(handle.db, {
-		missionId,
-		participantAgentId: backend.agentId,
-		nodeAuth: backend.auth,
-		acceptance: participantAcceptance(contract, "accept:backend", "d"),
-	});
-	await acceptMissionParticipant(handle.db, {
-		missionId,
-		participantAgentId: android.agentId,
-		nodeAuth: android.auth,
-		acceptance: participantAcceptance(contract, "accept:android", "e"),
-	});
-
-	const initial = await onlyAvailableDelivery(handle, backend.nodeId, "turn");
-	return {
-		missionId,
-		config,
-		contract,
-		backend,
-		android,
-		initialDeliveryId: initial.delivery_id,
-	};
-}
-
-async function registerParticipant(
-	handle: TestDb,
-	input: {
-		readonly role: "backend" | "android";
-		readonly nodeName: string;
-		readonly workspaceAlias: string;
-		readonly repositoryUrl: string;
-	},
-): Promise<ParticipantFixture> {
-	const suffix = randomUUID();
-	const registration = await registerAgentWithInitialKey(handle.db, {
-		handle: `${input.role}-${suffix}@agentrelay.test`,
-		email: `${input.role}-${suffix}@agentrelay.test`,
-		displayName: input.role === "backend" ? "Backend" : "Android",
-		role: input.role,
-		pepper: KEY_PEPPER,
-		keyEnvironment: "test",
-	});
-	const enrollment = await enrollNode(
-		handle.db,
-		registration.agent.id,
-		{ name: input.nodeName, capabilities: ["missions.execute"] },
-		"test",
-		KEY_PEPPER,
-	);
-	const auth: NodeCredentialContext = {
-		nodeId: enrollment.node.node_id,
-		agentId: registration.agent.id,
-		credentialId: enrollment.credential.id,
-		requestId: `test:${suffix}`,
-	};
-	await registerWorkspace(handle.db, auth, {
-		alias: input.workspaceAlias,
-		repository_url: input.repositoryUrl,
-		allowed_base_refs: ["refs/heads/main"],
-	});
-	return { agentId: registration.agent.id, nodeId: enrollment.node.node_id, auth };
-}
-
-function participantAcceptance(
-	contract: DeliveryFixture["contract"],
-	idempotencyKey: string,
-	grantCharacter: string,
-) {
-	return {
-		idempotency_key: idempotencyKey,
-		contract: { ...contract },
-		local_policy_grant: {
-			profile_name: "bounded-code",
-			grant_sha256: grantCharacter.repeat(64),
-		},
-	};
-}
-
-function verificationEvidence(commandId: string, outcome: "passed" | "failed", recordedAt: string) {
-	return {
-		verification_id: randomUUID(),
-		command_id: commandId,
-		outcome,
-		exit_code: outcome === "passed" ? 0 : 1,
-		duration_ms: 25,
-		summary: `${commandId} ${outcome}`,
-		output_sha256: "c".repeat(64),
-		artifacts: [],
-		recorded_at: recordedAt,
-	};
-}
-
-function requireClaimed(result: DeliveryClaimResult) {
-	if (result.outcome !== "claimed") throw new Error("expected a claimed delivery");
-	return result;
-}
-
-function requireLease(result: ReturnType<typeof requireClaimed>) {
-	const lease = result.item.delivery.lease;
-	if (!lease) throw new Error("expected an active delivery lease");
-	return lease;
-}
-
-async function expireActiveLease(handle: TestDb, deliveryId: string): Promise<void> {
-	await handle.db
-		.update(nodeDeliveries)
-		.set({ leaseExpiresAt: sql`clock_timestamp() - interval '1 second'` })
-		.where(eq(nodeDeliveries.id, deliveryId));
-}
-
-async function databaseNow(handle: TestDb): Promise<Date> {
-	const [row] = await handle.sql<Array<{ now: string | Date }>>`SELECT clock_timestamp() AS now`;
-	if (!row) throw new Error("expected the database clock");
-	return new Date(row.now);
-}
-
-function deferred<T>(): {
-	readonly promise: Promise<T>;
-	readonly resolve: (value: T) => void;
-} {
-	let resolve = (_value: T): void => undefined;
-	const promise = new Promise<T>((done) => {
-		resolve = done;
-	});
-	return { promise, resolve };
-}
-
-async function waitForBlockedBy(
-	handle: TestDb,
-	blockerPid: number,
-	message: string,
-	timeoutMs = 2_000,
-): Promise<void> {
-	const deadline = Date.now() + timeoutMs;
-	while (Date.now() < deadline) {
-		const [row] = await handle.sql<Array<{ waiters: string }>>`
-			SELECT count(*)::text AS waiters
-			FROM pg_stat_activity
-			WHERE ${blockerPid} = ANY(pg_blocking_pids(pid))
-		`;
-		if (Number(row?.waiters ?? "0") > 0) return;
-	}
-	throw new Error(message);
-}
-
-async function onlyAvailableDelivery(
-	handle: TestDb,
-	nodeId: string,
-	kind: "turn" | "verification",
-) {
-	const page = await listAvailableDeliveryEvents(handle.db, {
-		nodeId,
-		page: { after_cursor: null, limit: 50 },
-	});
-	const matching = page.items.filter((item) => item.delivery.kind === kind);
-	if (matching.length !== 1) {
-		throw new Error(`expected exactly one available ${kind} delivery, got ${matching.length}`);
-	}
-	return matching[0]!.delivery;
-}
-
-async function claimAndStart(
-	handle: TestDb,
-	participant: ParticipantFixture,
-	deliveryId: string,
-	keySuffix: string,
-) {
-	const claim = requireClaimed(
-		await claimDelivery(handle.db, participant.auth, deliveryId, {
-			idempotency_key: `claim:${keySuffix}`,
-		}),
-	);
-	const lease = requireLease(claim);
-	const start = await startDelivery(handle.db, participant.auth, deliveryId, {
-		idempotency_key: `start:${keySuffix}`,
-		lease_id: lease.lease_id,
-		fencing_token: lease.fencing_token,
-	});
-	return { claim, lease, start };
-}
-
-async function completeReadyTurn(
-	handle: TestDb,
-	participant: ParticipantFixture,
-	deliveryId: string,
-	keySuffix: string,
-) {
-	const execution = await claimAndStart(handle, participant, deliveryId, keySuffix);
-	return completeDelivery(handle.db, participant.auth, deliveryId, {
-		idempotency_key: `complete:${keySuffix}`,
-		lease_id: execution.lease.lease_id,
-		fencing_token: execution.lease.fencing_token,
-		result: {
-			type: "turn_completed",
-			disposition: { kind: "ready", evidence: [] },
-		},
-	});
-}

--- a/relay/src/services/delivery-ledger.ts
+++ b/relay/src/services/delivery-ledger.ts
@@ -52,9 +52,9 @@ import {
 	appendMissionEventInTransaction,
 	deliveryFromRow,
 	listStoredDeliveryEvents,
-	lockMissionMutation,
 	missionDeliveryItemFromRows,
 } from "./mission-ledger.js";
+import { reconcileMissionInTransaction, reconcileNodeMissions } from "./mission-reconciliation.js";
 import { assertMissionTrustBoundary } from "./mission-trust.js";
 import {
 	type NodeCredentialContext,
@@ -75,10 +75,24 @@ interface LockedDeliveryContext {
 	readonly workspaceStatus: string;
 }
 
+interface LockedDeliveryResult {
+	readonly context: LockedDeliveryContext;
+	readonly now: Date;
+	readonly reconciledStatus: string | null;
+}
+
+const postCommitRejection = Symbol("postCommitRejection");
+
+interface PostCommitRejection {
+	readonly [postCommitRejection]: true;
+	readonly error: unknown;
+}
+
 export async function listAvailableDeliveryEvents(
 	db: Database,
 	input: { readonly nodeId: string; readonly page: unknown },
 ) {
+	await reconcileNodeMissions(db, input.nodeId);
 	return listStoredDeliveryEvents(db, input);
 }
 
@@ -87,6 +101,7 @@ export async function listRecoverableDeliveryEvents(
 	input: { readonly nodeId: string; readonly page: unknown },
 ) {
 	const page = recoverableMissionDeliveryPageRequestSchema.parse(input.page);
+	await reconcileNodeMissions(db, input.nodeId);
 	const asOf = await readDatabaseClock(db);
 	const rows = await db
 		.select({ delivery: nodeDeliveries, event: missionEvents })
@@ -126,18 +141,20 @@ export async function claimDelivery(
 	const parsed = deliveryClaimInputSchema.parse(input);
 	const storedInput = operationInput(deliveryId, parsed);
 
-	return db.transaction(async (tx) => {
-		await lockNodeMutation(tx, auth.nodeId);
-		await assertActiveNodeCredential(tx, auth);
-		let context = await lockAuthorizedDeliveryContext(tx, auth, deliveryId);
+	return runLockedDeliveryOperation(db, auth, deliveryId, async (tx, locked) => {
+		let { context } = locked;
+		await assertMissionRoutingAuthority(tx, context.mission);
 		const replay = await replayClaim(tx, auth.nodeId, deliveryId, parsed, storedInput);
 		if (replay !== null) {
 			await assertDeliveryMissionTrust(tx, context.mission);
 			assertReplayableDelivery(context.delivery);
 			return replay;
 		}
+		if (locked.reconciledStatus !== null) {
+			throw terminalMutationError(locked.reconciledStatus);
+		}
 		await assertDeliveryMissionTrust(tx, context.mission);
-		const now = await readDatabaseClock(tx);
+		const { now } = locked;
 		assertRunnableContext(context, now);
 
 		if (context.delivery.status === "leased" || context.delivery.status === "executing") {
@@ -313,17 +330,18 @@ export async function completeDelivery(
 	const parsed = deliveryCompleteInputSchema.parse(input);
 	const storedInput = operationInput(deliveryId, parsed);
 
-	return db.transaction(async (tx) => {
-		await lockNodeMutation(tx, auth.nodeId);
-		await assertActiveNodeCredential(tx, auth);
-		const context = await lockAuthorizedDeliveryContext(tx, auth, deliveryId);
+	return runLockedDeliveryOperation(db, auth, deliveryId, async (tx, locked) => {
+		const { context, now } = locked;
+		await assertMissionRoutingAuthority(tx, context.mission);
 		const replay = await replayComplete(tx, auth.nodeId, deliveryId, parsed, storedInput);
 		if (replay !== null) {
 			assertReplayableDelivery(context.delivery);
 			return replay;
 		}
+		if (locked.reconciledStatus !== null) {
+			throw terminalMutationError(locked.reconciledStatus);
+		}
 		await assertDeliveryMissionTrust(tx, context.mission);
-		const now = await readDatabaseClock(tx);
 		assertRunnableContext(context, now);
 		if (context.delivery.status !== "executing" || context.delivery.settledByEventId !== null) {
 			throw new RelayError(
@@ -483,10 +501,9 @@ async function mutateLeaseDelivery<
 	mutate: (tx: DeliveryTransaction, context: LockedDeliveryContext, now: Date) => Promise<TResult>,
 ): Promise<TResult> {
 	const storedInput = operationInput(deliveryId, input);
-	return db.transaction(async (tx) => {
-		await lockNodeMutation(tx, auth.nodeId);
-		await assertActiveNodeCredential(tx, auth);
-		const context = await lockAuthorizedDeliveryContext(tx, auth, deliveryId);
+	return runLockedDeliveryOperation(db, auth, deliveryId, async (tx, locked) => {
+		const { context, now } = locked;
+		await assertMissionRoutingAuthority(tx, context.mission);
 		const replay = await replayOperation(
 			tx,
 			auth.nodeId,
@@ -503,13 +520,18 @@ async function mutateLeaseDelivery<
 			assertReplayableDelivery(context.delivery);
 			return replay;
 		}
+		if (locked.reconciledStatus !== null) {
+			throw terminalMutationError(locked.reconciledStatus);
+		}
 		await assertDeliveryMissionTrust(tx, context.mission);
-		const now = await readDatabaseClock(tx);
 		assertRunnableContext(context, now);
 		const result = await mutate(tx, context, now);
 		const receipt = deliveryOperationReceiptSchema.parse(result.receipt);
 		await persistNodeReceipt(tx, auth, context.delivery, receipt, storedInput, result);
 		await auditNodeOperation(tx, auth, context.delivery, receipt);
+		if (receipt.status_after === "dead_lettered") {
+			await reconcileMissionInTransaction(tx, context.delivery.missionId);
+		}
 		return result;
 	});
 }
@@ -615,16 +637,74 @@ async function prefetchMissionId(
 	return row.missionId;
 }
 
-async function lockAuthorizedDeliveryContext(
+async function reconcileAndLockDeliveryContext(
 	tx: DeliveryTransaction,
 	auth: NodeCredentialContext,
 	deliveryId: string,
-): Promise<LockedDeliveryContext> {
+): Promise<LockedDeliveryResult> {
 	const missionId = await prefetchMissionId(tx, auth.nodeId, deliveryId);
-	await lockMissionMutation(tx, missionId);
+	const reconciliation = await reconcileMissionInTransaction(tx, missionId);
 	const mission = await loadMission(tx, missionId);
-	await assertMissionRoutingAuthority(tx, mission);
-	return lockDeliveryContext(tx, auth, deliveryId, mission);
+	return {
+		context: await lockDeliveryContext(tx, auth, deliveryId, mission),
+		now: reconciliation.checkedAt,
+		reconciledStatus: reconciliation.reconciled ? reconciliation.status : null,
+	};
+}
+
+async function runLockedDeliveryOperation<TResult>(
+	db: Database,
+	auth: NodeCredentialContext,
+	deliveryId: string,
+	operation: (tx: DeliveryTransaction, locked: LockedDeliveryResult) => Promise<TResult>,
+): Promise<TResult> {
+	return runDeliveryTransaction(db, async (tx) => {
+		await lockNodeMutation(tx, auth.nodeId);
+		await assertActiveNodeCredential(tx, auth);
+		const locked = await reconcileAndLockDeliveryContext(tx, auth, deliveryId);
+		return preserveReconciliation(locked, () => operation(tx, locked));
+	});
+}
+
+async function runDeliveryTransaction<TResult>(
+	db: Database,
+	operation: (tx: DeliveryTransaction) => Promise<TResult | PostCommitRejection>,
+): Promise<TResult> {
+	const outcome = await db.transaction(operation);
+	if (isPostCommitRejection(outcome)) throw outcome.error;
+	return outcome;
+}
+
+function terminalMutationError(status: string): RelayError {
+	return new RelayError(
+		"invalid_transition",
+		`Mission reconciled to ${status} before the delivery mutation`,
+	);
+}
+
+async function preserveReconciliation<TResult>(
+	locked: LockedDeliveryResult,
+	operation: () => Promise<TResult>,
+): Promise<TResult | PostCommitRejection> {
+	try {
+		return await operation();
+	} catch (error) {
+		if (locked.reconciledStatus !== null) return postCommitReject(error);
+		throw error;
+	}
+}
+
+function postCommitReject(error: unknown): PostCommitRejection {
+	return { [postCommitRejection]: true, error };
+}
+
+function isPostCommitRejection(value: unknown): value is PostCommitRejection {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		postCommitRejection in value &&
+		(value as PostCommitRejection)[postCommitRejection] === true
+	);
 }
 
 async function assertDeliveryMissionTrust(
@@ -1032,6 +1112,7 @@ async function deadLetterExpiredFinalClaim(
 	});
 	await persistNodeReceipt(tx, auth, deadLettered, receipt, storedInput, result);
 	await auditNodeOperation(tx, auth, deadLettered, receipt);
+	await reconcileMissionInTransaction(tx, deadLettered.missionId);
 	return result;
 }
 

--- a/relay/src/services/mission-ledger.ts
+++ b/relay/src/services/mission-ledger.ts
@@ -1123,6 +1123,9 @@ export function missionDeliveryItemFromRows(
 	delivery: typeof nodeDeliveries.$inferSelect,
 	event: typeof missionEvents.$inferSelect,
 ): MissionDeliveryItem {
+	if (event.actorKind !== "agent" || event.actorAgentId === null) {
+		throw new RelayError("internal", "Node delivery source event is not participant-authored");
+	}
 	return {
 		delivery: deliveryFromRow(delivery),
 		event: eventFromRow(event),

--- a/relay/src/services/mission-reconciliation.test.ts
+++ b/relay/src/services/mission-reconciliation.test.ts
@@ -1,0 +1,720 @@
+import { and, eq, sql } from "drizzle-orm";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	auditLog,
+	deliveryOperationReceipts,
+	missionEvents,
+	missions,
+	nodeDeliveries,
+	workspaceBindings,
+} from "../db/schema.js";
+import { type TestDb, truncateAll, tryConnect } from "../db/test-utils.js";
+import {
+	claimDelivery,
+	completeDelivery,
+	listAvailableDeliveryEvents,
+	releaseDelivery,
+} from "./delivery-ledger.js";
+import {
+	claimAndStart,
+	completeReadyTurn,
+	createActivatedFixture,
+	databaseNow,
+	deferred,
+	onlyAvailableDelivery,
+	verificationEvidence,
+	waitForBlockedBy,
+} from "./delivery-ledger.test-support.js";
+import { reconcileMission } from "./mission-reconciliation.js";
+
+const TEST_DATABASE_URL = process.env.RELAY_TEST_DATABASE_URL ?? process.env.RELAY_DATABASE_URL;
+const conn = await tryConnect();
+const d = conn.available ? describe : describe.skip;
+
+if (!conn.available) {
+	console.warn(`[mission-reconciliation.test] skipping: ${conn.reason}`);
+}
+
+d("Mission terminal reconciliation", () => {
+	let handle: TestDb;
+
+	beforeAll(() => {
+		if (!conn.handle) throw new Error("expected database handle");
+		handle = conn.handle;
+	});
+
+	beforeEach(async () => {
+		await truncateAll(handle.sql);
+	});
+
+	afterAll(async () => {
+		if (handle) await handle.close();
+	});
+
+	it("lazily expires an active Mission and atomically cancels stored work", async () => {
+		const fixture = await createActivatedFixture(handle);
+		await handle.db
+			.update(missions)
+			.set({ expiresAt: sql`clock_timestamp() - interval '1 second'` })
+			.where(eq(missions.id, fixture.missionId));
+
+		const page = await listAvailableDeliveryEvents(handle.db, {
+			nodeId: fixture.backend.nodeId,
+			page: { after_cursor: null, limit: 50 },
+		});
+		expect(page.items).toEqual([]);
+
+		const [mission] = await handle.db
+			.select()
+			.from(missions)
+			.where(eq(missions.id, fixture.missionId));
+		expect(mission).toMatchObject({ status: "expired" });
+		expect(mission?.state).toMatchObject({ status: "expired", sequence_no: 2 });
+
+		const terminalEvents = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(
+				and(
+					eq(missionEvents.missionId, fixture.missionId),
+					eq(missionEvents.type, "mission_terminal"),
+				),
+			);
+		expect(terminalEvents).toHaveLength(1);
+		const terminalEvent = terminalEvents[0]!;
+		expect(terminalEvent).toMatchObject({
+			sequenceNo: 2,
+			actorKind: "system",
+			actorAgentId: null,
+			sourceDeliveryId: null,
+			payload: {
+				terminal_status: "expired",
+				reason: "deadline_exceeded",
+				triggering_delivery_id: null,
+			},
+		});
+
+		const [delivery] = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.id, fixture.initialDeliveryId));
+		expect(delivery).toMatchObject({
+			status: "cancelled",
+			activeLeaseId: null,
+			leaseExpiresAt: null,
+			settledByEventId: terminalEvent.id,
+			cancellationReason: "mission_expired",
+			cancelledAt: expect.any(Date),
+		});
+
+		const cancelReceipts = await handle.db
+			.select()
+			.from(deliveryOperationReceipts)
+			.where(
+				and(
+					eq(deliveryOperationReceipts.deliveryId, fixture.initialDeliveryId),
+					eq(deliveryOperationReceipts.operation, "cancel"),
+				),
+			);
+		expect(cancelReceipts).toHaveLength(1);
+		expect(cancelReceipts[0]).toMatchObject({
+			origin: "relay",
+			statusBefore: "stored",
+			statusAfter: "cancelled",
+			cancellationReason: "mission_expired",
+			input: {
+				reason: "mission_expired",
+				settled_by_event_id: terminalEvent.id,
+			},
+			output: {
+				delivery: {
+					status: "cancelled",
+					logical_settlement: { settled_by_event_id: terminalEvent.id },
+				},
+			},
+		});
+		const terminalAudits = await handle.db
+			.select()
+			.from(auditLog)
+			.where(
+				and(
+					eq(auditLog.actorKind, "system"),
+					eq(auditLog.action, "mission.terminal"),
+					eq(auditLog.resourceId, terminalEvent.id),
+				),
+			);
+		expect(terminalAudits).toHaveLength(1);
+		expect(terminalAudits[0]?.metadata).toMatchObject({
+			mission_id: fixture.missionId,
+			status: "expired",
+			reason: "deadline_exceeded",
+			triggering_delivery_id: null,
+			cancelled_delivery_ids: [fixture.initialDeliveryId],
+		});
+	});
+
+	it("repeated Mission reconciliation is an exact no-op", async () => {
+		const fixture = await createActivatedFixture(handle);
+		await handle.db
+			.update(missions)
+			.set({ expiresAt: sql`clock_timestamp() - interval '1 second'` })
+			.where(eq(missions.id, fixture.missionId));
+
+		const first = await reconcileMission(handle.db, fixture.missionId);
+		const second = await reconcileMission(handle.db, fixture.missionId);
+		expect(first).toMatchObject({
+			missionId: fixture.missionId,
+			reconciled: true,
+			status: "expired",
+			event: { type: "mission_terminal", terminal_status: "expired" },
+		});
+		expect(second).toMatchObject({
+			missionId: fixture.missionId,
+			reconciled: false,
+			status: "expired",
+			event: null,
+		});
+
+		const terminalEvents = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(
+				and(
+					eq(missionEvents.missionId, fixture.missionId),
+					eq(missionEvents.type, "mission_terminal"),
+				),
+			);
+		const cancelReceipts = await handle.db
+			.select()
+			.from(deliveryOperationReceipts)
+			.where(
+				and(
+					eq(deliveryOperationReceipts.deliveryId, fixture.initialDeliveryId),
+					eq(deliveryOperationReceipts.operation, "cancel"),
+				),
+			);
+		const terminalAudits = await handle.db
+			.select()
+			.from(auditLog)
+			.where(
+				and(
+					eq(auditLog.action, "mission.terminal"),
+					eq(auditLog.resourceId, first.event!.event_id),
+				),
+			);
+		expect(terminalEvents).toHaveLength(1);
+		expect(cancelReceipts).toHaveLength(1);
+		expect(terminalAudits).toHaveLength(1);
+	});
+
+	it("commits expiry reconciliation before rejecting late completion", async () => {
+		if (!TEST_DATABASE_URL) throw new Error("expected test database URL");
+		const fixture = await createActivatedFixture(handle);
+		const execution = await claimAndStart(
+			handle,
+			fixture.backend,
+			fixture.initialDeliveryId,
+			"expiry-race",
+		);
+		const blockerSql = postgres(TEST_DATABASE_URL, { max: 1, onnotice: () => undefined });
+		const lockAcquired = deferred<number>();
+		const expireAndRelease = deferred<void>();
+		let completion:
+			| Promise<
+					| { readonly status: "fulfilled"; readonly value: unknown }
+					| { readonly status: "rejected"; readonly reason: unknown }
+			  >
+			| undefined;
+		let reconciliation: ReturnType<typeof reconcileMission> | undefined;
+		const observerSql = postgres(TEST_DATABASE_URL, { max: 1, onnotice: () => undefined });
+		const blocker = blockerSql.begin(async (tx) => {
+			await tx`SELECT pg_advisory_xact_lock(hashtextextended(${fixture.missionId}, 0))`;
+			const [connection] = await tx`SELECT pg_backend_pid()::integer AS pid`;
+			lockAcquired.resolve(Number(connection?.pid));
+			await expireAndRelease.promise;
+			await tx`
+				UPDATE missions
+				SET expires_at = clock_timestamp() - interval '1 second'
+				WHERE id = ${fixture.missionId}
+			`;
+		});
+
+		try {
+			const blockerPid = await lockAcquired.promise;
+			completion = completeDelivery(handle.db, fixture.backend.auth, fixture.initialDeliveryId, {
+				idempotency_key: "complete:expiry-race",
+				lease_id: execution.lease.lease_id,
+				fencing_token: execution.lease.fencing_token,
+				result: {
+					type: "turn_completed",
+					disposition: { kind: "ready", evidence: [] },
+				},
+			}).then(
+				(value) => ({ status: "fulfilled" as const, value }),
+				(reason: unknown) => ({ status: "rejected" as const, reason }),
+			);
+			reconciliation = reconcileMission(handle.db, fixture.missionId);
+			await waitForBlockedBy(
+				observerSql,
+				blockerPid,
+				"completion and reconciliation did not both wait on the Mission lock",
+				2,
+			);
+			expireAndRelease.resolve(undefined);
+			await blocker;
+			const [outcome, reconciliationResult] = await Promise.all([completion, reconciliation]);
+			expect(outcome.status).toBe("rejected");
+			if (outcome.status !== "rejected") throw new Error("late completion unexpectedly succeeded");
+			expect(outcome.reason).toMatchObject({ code: "invalid_transition" });
+			expect(reconciliationResult).toMatchObject({
+				missionId: fixture.missionId,
+				status: "expired",
+			});
+		} finally {
+			expireAndRelease.resolve(undefined);
+			await blocker.catch(() => undefined);
+			await completion;
+			await reconciliation;
+			await blockerSql.end({ timeout: 2 });
+			await observerSql.end({ timeout: 2 });
+		}
+
+		const [mission] = await handle.db
+			.select()
+			.from(missions)
+			.where(eq(missions.id, fixture.missionId));
+		const [delivery] = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.id, fixture.initialDeliveryId));
+		expect(mission).toMatchObject({ status: "expired" });
+		expect(delivery).toMatchObject({
+			status: "cancelled",
+			activeLeaseId: null,
+			leaseExpiresAt: null,
+			cancellationReason: "mission_expired",
+		});
+		const [cancelReceipt] = await handle.db
+			.select()
+			.from(deliveryOperationReceipts)
+			.where(
+				and(
+					eq(deliveryOperationReceipts.deliveryId, fixture.initialDeliveryId),
+					eq(deliveryOperationReceipts.operation, "cancel"),
+				),
+			);
+		expect(cancelReceipt).toMatchObject({
+			origin: "relay",
+			statusBefore: "executing",
+			leaseId: execution.lease.lease_id,
+			fencingToken: execution.lease.fencing_token,
+			cancellationReason: "mission_expired",
+		});
+		const completionEvents = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(eq(missionEvents.sourceDeliveryId, fixture.initialDeliveryId));
+		const completionReceipts = await handle.db
+			.select()
+			.from(deliveryOperationReceipts)
+			.where(
+				and(
+					eq(deliveryOperationReceipts.deliveryId, fixture.initialDeliveryId),
+					eq(deliveryOperationReceipts.operation, "complete"),
+				),
+			);
+		expect(completionEvents).toEqual([]);
+		expect(completionReceipts).toEqual([]);
+	});
+
+	it("replays a committed completion when that replay first observes Mission expiry", async () => {
+		const fixture = await createActivatedFixture(handle);
+		const execution = await claimAndStart(
+			handle,
+			fixture.backend,
+			fixture.initialDeliveryId,
+			"completion-before-expiry",
+		);
+		const completeInput = {
+			idempotency_key: "complete:before-expiry",
+			lease_id: execution.lease.lease_id,
+			fencing_token: execution.lease.fencing_token,
+			result: {
+				type: "turn_completed" as const,
+				disposition: {
+					kind: "reply" as const,
+					message_type: "progress" as const,
+					message: "This exact receipt predates Mission expiry.",
+				},
+			},
+		};
+		const completed = await completeDelivery(
+			handle.db,
+			fixture.backend.auth,
+			fixture.initialDeliveryId,
+			completeInput,
+		);
+		await handle.db
+			.update(missions)
+			.set({ expiresAt: sql`clock_timestamp() - interval '1 second'` })
+			.where(eq(missions.id, fixture.missionId));
+
+		const replayed = await completeDelivery(
+			handle.db,
+			fixture.backend.auth,
+			fixture.initialDeliveryId,
+			structuredClone(completeInput),
+		);
+		expect(replayed).toEqual({ ...completed, replayed: true });
+		const [mission] = await handle.db
+			.select()
+			.from(missions)
+			.where(eq(missions.id, fixture.missionId));
+		expect(mission).toMatchObject({ status: "expired" });
+		const terminalEvents = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(
+				and(
+					eq(missionEvents.missionId, fixture.missionId),
+					eq(missionEvents.type, "mission_terminal"),
+				),
+			);
+		expect(terminalEvents).toHaveLength(1);
+		const [source] = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.id, fixture.initialDeliveryId));
+		expect(source).toMatchObject({ status: "acknowledged" });
+	});
+
+	it("commits expiry reconciliation before denying a replay with a revoked workspace route", async () => {
+		const fixture = await createActivatedFixture(handle);
+		const claimInput = { idempotency_key: "claim:revoked-route-expiry" };
+		await claimDelivery(handle.db, fixture.backend.auth, fixture.initialDeliveryId, claimInput);
+		await handle.db
+			.update(missions)
+			.set({ expiresAt: sql`clock_timestamp() - interval '1 second'` })
+			.where(eq(missions.id, fixture.missionId));
+		await handle.db
+			.update(workspaceBindings)
+			.set({ status: "revoked", revokedAt: sql`clock_timestamp()` })
+			.where(
+				and(
+					eq(workspaceBindings.nodeId, fixture.backend.nodeId),
+					eq(workspaceBindings.alias, "backend-api"),
+				),
+			);
+
+		await expect(
+			claimDelivery(handle.db, fixture.backend.auth, fixture.initialDeliveryId, claimInput),
+		).rejects.toMatchObject({ code: "not_authorized_transition" });
+
+		const [mission] = await handle.db
+			.select()
+			.from(missions)
+			.where(eq(missions.id, fixture.missionId));
+		const [delivery] = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.id, fixture.initialDeliveryId));
+		expect(mission).toMatchObject({ status: "expired" });
+		expect(delivery).toMatchObject({
+			status: "cancelled",
+			cancellationReason: "mission_expired",
+		});
+		const claimReceipts = await handle.db
+			.select()
+			.from(deliveryOperationReceipts)
+			.where(
+				and(
+					eq(deliveryOperationReceipts.deliveryId, fixture.initialDeliveryId),
+					eq(deliveryOperationReceipts.operation, "claim"),
+				),
+			);
+		expect(claimReceipts).toHaveLength(1);
+		const terminalEvents = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(
+				and(
+					eq(missionEvents.missionId, fixture.missionId),
+					eq(missionEvents.type, "mission_terminal"),
+				),
+			);
+		expect(terminalEvents).toHaveLength(1);
+	});
+
+	it("fails a verifying Mission when required work dead-letters and cancels its sibling", async () => {
+		const fixture = await createActivatedFixture(handle);
+		await completeReadyTurn(
+			handle,
+			fixture.backend,
+			fixture.initialDeliveryId,
+			"dead-letter-ready",
+		);
+		const androidTurn = await onlyAvailableDelivery(handle, fixture.android.nodeId, "turn");
+		await completeReadyTurn(
+			handle,
+			fixture.android,
+			androidTurn.delivery_id,
+			"dead-letter-android-ready",
+		);
+
+		const backendVerification = await onlyAvailableDelivery(
+			handle,
+			fixture.backend.nodeId,
+			"verification",
+		);
+		const androidVerification = await onlyAvailableDelivery(
+			handle,
+			fixture.android.nodeId,
+			"verification",
+		);
+		const backendExecution = await claimAndStart(
+			handle,
+			fixture.backend,
+			backendVerification.delivery_id,
+			"dead-letter-backend-verification",
+		);
+		const androidExecution = await claimAndStart(
+			handle,
+			fixture.android,
+			androidVerification.delivery_id,
+			"dead-letter-android-verification",
+		);
+
+		const released = await releaseDelivery(
+			handle.db,
+			fixture.backend.auth,
+			backendVerification.delivery_id,
+			{
+				idempotency_key: "release:dead-letter-backend-verification",
+				lease_id: backendExecution.lease.lease_id,
+				fencing_token: backendExecution.lease.fencing_token,
+				classification: "permanent",
+				summary: "Required verification cannot complete.",
+			},
+		);
+		expect(released.delivery).toMatchObject({
+			status: "dead_lettered",
+			logical_settlement: null,
+		});
+
+		const [mission] = await handle.db
+			.select()
+			.from(missions)
+			.where(eq(missions.id, fixture.missionId));
+		expect(mission).toMatchObject({ status: "failed" });
+		expect(mission?.state).toMatchObject({ status: "failed" });
+		const terminalEvents = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(
+				and(
+					eq(missionEvents.missionId, fixture.missionId),
+					eq(missionEvents.type, "mission_terminal"),
+				),
+			);
+		expect(terminalEvents).toHaveLength(1);
+		const terminalEvent = terminalEvents[0]!;
+		expect(terminalEvent).toMatchObject({
+			actorKind: "system",
+			actorAgentId: null,
+			sourceDeliveryId: backendVerification.delivery_id,
+			payload: {
+				terminal_status: "failed",
+				reason: "delivery_dead_lettered",
+				triggering_delivery_id: backendVerification.delivery_id,
+			},
+		});
+
+		const [cancelledSibling] = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.id, androidVerification.delivery_id));
+		expect(cancelledSibling).toMatchObject({
+			status: "cancelled",
+			activeLeaseId: null,
+			leaseExpiresAt: null,
+			settledByEventId: terminalEvent.id,
+			cancellationReason: "mission_failed",
+		});
+		const [cancelReceipt] = await handle.db
+			.select()
+			.from(deliveryOperationReceipts)
+			.where(
+				and(
+					eq(deliveryOperationReceipts.deliveryId, androidVerification.delivery_id),
+					eq(deliveryOperationReceipts.operation, "cancel"),
+				),
+			);
+		expect(cancelReceipt).toMatchObject({
+			origin: "relay",
+			statusBefore: "executing",
+			statusAfter: "cancelled",
+			leaseId: androidExecution.lease.lease_id,
+			fencingToken: androidExecution.lease.fencing_token,
+			cancellationReason: "mission_failed",
+			input: {
+				reason: "mission_failed",
+				settled_by_event_id: terminalEvent.id,
+			},
+		});
+		const terminalAudits = await handle.db
+			.select()
+			.from(auditLog)
+			.where(
+				and(
+					eq(auditLog.actorKind, "system"),
+					eq(auditLog.action, "mission.terminal"),
+					eq(auditLog.resourceId, terminalEvent.id),
+				),
+			);
+		const siblingCancelAudits = await handle.db
+			.select()
+			.from(auditLog)
+			.where(
+				and(
+					eq(auditLog.actorKind, "system"),
+					eq(auditLog.action, "delivery.cancel"),
+					eq(auditLog.resourceId, androidVerification.delivery_id),
+				),
+			);
+		expect(terminalAudits).toHaveLength(1);
+		expect(siblingCancelAudits).toHaveLength(1);
+		expect(terminalAudits[0]?.metadata).toMatchObject({
+			mission_id: fixture.missionId,
+			status: "failed",
+			reason: "delivery_dead_lettered",
+			triggering_delivery_id: backendVerification.delivery_id,
+			cancelled_delivery_ids: [androidVerification.delivery_id],
+		});
+	});
+
+	it("serializes final completion against permanent release into one terminal outcome", async () => {
+		const fixture = await createActivatedFixture(handle);
+		await completeReadyTurn(handle, fixture.backend, fixture.initialDeliveryId, "race-ready");
+		const androidTurn = await onlyAvailableDelivery(handle, fixture.android.nodeId, "turn");
+		await completeReadyTurn(handle, fixture.android, androidTurn.delivery_id, "race-android-ready");
+		const backendVerification = await onlyAvailableDelivery(
+			handle,
+			fixture.backend.nodeId,
+			"verification",
+		);
+		const backendExecution = await claimAndStart(
+			handle,
+			fixture.backend,
+			backendVerification.delivery_id,
+			"race-backend-verification",
+		);
+		const recordedAt = (await databaseNow(handle)).toISOString();
+		await completeDelivery(handle.db, fixture.backend.auth, backendVerification.delivery_id, {
+			idempotency_key: "complete:race-backend-verification",
+			lease_id: backendExecution.lease.lease_id,
+			fencing_token: backendExecution.lease.fencing_token,
+			result: {
+				type: "verification_recorded",
+				evidence: [verificationEvidence("backend-test", "passed", recordedAt)],
+			},
+		});
+
+		const androidVerification = await onlyAvailableDelivery(
+			handle,
+			fixture.android.nodeId,
+			"verification",
+		);
+		const androidExecution = await claimAndStart(
+			handle,
+			fixture.android,
+			androidVerification.delivery_id,
+			"race-android-verification",
+		);
+		const completeInput = {
+			idempotency_key: "complete:race-final-verification",
+			lease_id: androidExecution.lease.lease_id,
+			fencing_token: androidExecution.lease.fencing_token,
+			result: {
+				type: "verification_recorded" as const,
+				evidence: [verificationEvidence("android-test", "passed", recordedAt)],
+			},
+		};
+		const releaseInput = {
+			idempotency_key: "release:race-final-verification",
+			lease_id: androidExecution.lease.lease_id,
+			fencing_token: androidExecution.lease.fencing_token,
+			classification: "permanent" as const,
+			summary: "The final verifier cannot continue.",
+		};
+		const outcomes = await Promise.allSettled([
+			completeDelivery(
+				handle.db,
+				fixture.android.auth,
+				androidVerification.delivery_id,
+				completeInput,
+			),
+			releaseDelivery(
+				handle.db,
+				fixture.android.auth,
+				androidVerification.delivery_id,
+				releaseInput,
+			),
+		]);
+		expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+		expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+
+		const [mission] = await handle.db
+			.select()
+			.from(missions)
+			.where(eq(missions.id, fixture.missionId));
+		const [delivery] = await handle.db
+			.select()
+			.from(nodeDeliveries)
+			.where(eq(nodeDeliveries.id, androidVerification.delivery_id));
+		const terminalEvents = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(
+				and(
+					eq(missionEvents.missionId, fixture.missionId),
+					eq(missionEvents.type, "mission_terminal"),
+				),
+			);
+		const finalVerificationEvents = await handle.db
+			.select()
+			.from(missionEvents)
+			.where(eq(missionEvents.sourceDeliveryId, androidVerification.delivery_id));
+		const operationReceipts = await handle.db
+			.select()
+			.from(deliveryOperationReceipts)
+			.where(eq(deliveryOperationReceipts.deliveryId, androidVerification.delivery_id));
+
+		if (mission?.status === "completed") {
+			expect(delivery).toMatchObject({ status: "acknowledged" });
+			expect(terminalEvents).toEqual([]);
+			expect(
+				finalVerificationEvents.filter((event) => event.type === "verification_recorded"),
+			).toHaveLength(1);
+			expect(operationReceipts.filter((receipt) => receipt.operation === "complete")).toHaveLength(
+				1,
+			);
+			expect(operationReceipts.filter((receipt) => receipt.operation === "release")).toHaveLength(
+				0,
+			);
+		} else {
+			expect(mission).toMatchObject({ status: "failed" });
+			expect(delivery).toMatchObject({ status: "dead_lettered" });
+			expect(terminalEvents).toHaveLength(1);
+			expect(
+				finalVerificationEvents.filter((event) => event.type === "verification_recorded"),
+			).toHaveLength(0);
+			expect(operationReceipts.filter((receipt) => receipt.operation === "release")).toHaveLength(
+				1,
+			);
+			expect(operationReceipts.filter((receipt) => receipt.operation === "complete")).toHaveLength(
+				0,
+			);
+		}
+	});
+});

--- a/relay/src/services/mission-reconciliation.ts
+++ b/relay/src/services/mission-reconciliation.ts
@@ -1,0 +1,275 @@
+import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import {
+	type MissionCoordinatorEvent,
+	missionCoordinatorConfigSchema,
+	missionCoordinatorEventSchema,
+	missionCoordinatorStateSchema,
+	reduceMissionCoordinatorEvent,
+	replayMissionCoordinatorEvents,
+} from "@agentrelay/protocol";
+import { and, asc, eq, exists, inArray, isNull, lte, or, sql } from "drizzle-orm";
+import type { Database } from "../db/client.js";
+import {
+	deliveryOperationReceipts,
+	missionEvents,
+	missionParticipants,
+	missions,
+	nodeDeliveries,
+} from "../db/schema.js";
+import { RelayError } from "../errors.js";
+import { writeAudit } from "./audit.js";
+import { deliveryFromRow, eventFromRow, lockMissionMutation } from "./mission-ledger.js";
+
+type ReconciliationTransaction = Parameters<Parameters<Database["transaction"]>[0]>[0];
+type TerminalEvent = Extract<MissionCoordinatorEvent, { readonly type: "mission_terminal" }>;
+type TerminalCause =
+	| { readonly status: "expired"; readonly reason: "deadline_exceeded"; readonly deliveryId: null }
+	| {
+			readonly status: "failed";
+			readonly reason: "delivery_dead_lettered";
+			readonly deliveryId: string;
+	  };
+
+export interface MissionReconciliationResult {
+	readonly missionId: string;
+	readonly reconciled: boolean;
+	readonly status: string;
+	readonly event: TerminalEvent | null;
+	readonly checkedAt: Date;
+}
+
+export async function reconcileMission(
+	db: Database,
+	missionId: string,
+): Promise<MissionReconciliationResult> {
+	return db.transaction((tx) => reconcileMissionInTransaction(tx, missionId));
+}
+
+export async function reconcileNodeMissions(db: Database, nodeId: string): Promise<void> {
+	const unresolvedDeadLetter = db
+		.select({ id: nodeDeliveries.id })
+		.from(nodeDeliveries)
+		.where(
+			and(
+				eq(nodeDeliveries.missionId, missions.id),
+				eq(nodeDeliveries.status, "dead_lettered"),
+				isNull(nodeDeliveries.settledByEventId),
+			),
+		)
+		.limit(1);
+	const candidates = await db
+		.select({ missionId: missions.id })
+		.from(missions)
+		.innerJoin(missionParticipants, eq(missionParticipants.missionId, missions.id))
+		.where(
+			and(
+				eq(missionParticipants.nodeId, nodeId),
+				inArray(missions.status, ["active", "verifying"]),
+				or(lte(missions.expiresAt, sql`clock_timestamp()`), exists(unresolvedDeadLetter)),
+			),
+		);
+	for (const candidate of candidates) await reconcileMission(db, candidate.missionId);
+}
+
+export async function reconcileMissionInTransaction(
+	tx: ReconciliationTransaction,
+	missionId: string,
+): Promise<MissionReconciliationResult> {
+	await lockMissionMutation(tx, missionId);
+	const [mission] = await tx.select().from(missions).where(eq(missions.id, missionId)).limit(1);
+	if (!mission) throw new RelayError("internal", "Mission reconciliation target is missing");
+	const now = await readDatabaseClock(tx);
+	if (mission.status !== "active" && mission.status !== "verifying") {
+		return { missionId, reconciled: false, status: mission.status, event: null, checkedAt: now };
+	}
+
+	const cause = await terminalCause(tx, missionId, mission.expiresAt, now);
+	if (cause === null) {
+		return { missionId, reconciled: false, status: mission.status, event: null, checkedAt: now };
+	}
+
+	const config = missionCoordinatorConfigSchema.parse(mission.coordinatorConfig);
+	const storedEvents = await tx
+		.select()
+		.from(missionEvents)
+		.where(eq(missionEvents.missionId, missionId))
+		.orderBy(asc(missionEvents.sequenceNo));
+	const currentState = replayMissionCoordinatorEvents(config, storedEvents.map(eventFromRow));
+	const projectedState = missionCoordinatorStateSchema.parse(mission.state);
+	if (
+		currentState.sequence_no !== mission.lastEventSequence ||
+		!isDeepStrictEqual(currentState, projectedState)
+	) {
+		throw new RelayError("internal", "Stored Mission projection does not match its event ledger");
+	}
+
+	const eventId = randomUUID();
+	const terminalIdempotencyKey =
+		cause.status === "expired"
+			? "relay:mission-terminal:deadline"
+			: `relay:mission-terminal:delivery:${cause.deliveryId}`;
+	const parsedEvent = missionCoordinatorEventSchema.parse({
+		event_id: eventId,
+		idempotency_key: terminalIdempotencyKey,
+		mission_id: missionId,
+		sequence_no: currentState.sequence_no + 1,
+		created_at: now.toISOString(),
+		type: "mission_terminal",
+		terminal_status: cause.status,
+		reason: cause.reason,
+		triggering_delivery_id: cause.deliveryId,
+	});
+	if (parsedEvent.type !== "mission_terminal") {
+		throw new RelayError("internal", "Mission reconciliation produced a non-terminal event");
+	}
+	const event: TerminalEvent = parsedEvent;
+	const nextState = reduceMissionCoordinatorEvent(currentState, event);
+	const previousEvent = storedEvents.at(-1);
+	await tx.insert(missionEvents).values({
+		id: event.event_id,
+		missionId,
+		sequenceNo: event.sequence_no,
+		type: event.type,
+		actorKind: "system",
+		actorAgentId: null,
+		idempotencyKey: event.idempotency_key,
+		sourceDeliveryId: cause.deliveryId,
+		causalParentEventId: previousEvent?.id ?? null,
+		payload: {
+			terminal_status: event.terminal_status,
+			reason: event.reason,
+			triggering_delivery_id: event.triggering_delivery_id,
+		},
+		createdAt: now,
+	});
+
+	const cancellationReason = cause.status === "expired" ? "mission_expired" : "mission_failed";
+	const activeDeliveries = await tx
+		.select()
+		.from(nodeDeliveries)
+		.where(
+			and(
+				eq(nodeDeliveries.missionId, missionId),
+				inArray(nodeDeliveries.status, ["stored", "leased", "executing"]),
+				isNull(nodeDeliveries.settledByEventId),
+			),
+		)
+		.orderBy(asc(nodeDeliveries.cursor))
+		.for("update");
+	for (const delivery of activeDeliveries) {
+		const [cancelled] = await tx
+			.update(nodeDeliveries)
+			.set({
+				status: "cancelled",
+				activeLeaseId: null,
+				leaseExpiresAt: null,
+				settledByEventId: delivery.settledByEventId ?? event.event_id,
+				settledAt: delivery.settledAt ?? now,
+				cancelledAt: now,
+				cancellationReason,
+				updatedAt: now,
+			})
+			.where(and(eq(nodeDeliveries.id, delivery.id), eq(nodeDeliveries.status, delivery.status)))
+			.returning();
+		if (!cancelled) throw new RelayError("internal", "Failed to cancel terminal Mission work");
+		await tx.insert(deliveryOperationReceipts).values({
+			origin: "relay",
+			nodeId: delivery.nodeId,
+			missionId,
+			deliveryId: delivery.id,
+			operation: "cancel",
+			idempotencyKey: `relay:mission-terminal:${missionId}:${delivery.id}`,
+			credentialId: null,
+			attemptCount: delivery.attemptCount,
+			leaseId: delivery.activeLeaseId,
+			fencingToken: delivery.activeLeaseId === null ? null : delivery.lastFencingToken,
+			leaseExpiresAt: delivery.leaseExpiresAt,
+			statusBefore: delivery.status,
+			statusAfter: "cancelled",
+			cancellationReason,
+			input: { reason: cancellationReason, settled_by_event_id: event.event_id },
+			output: { delivery: deliveryFromRow(cancelled) },
+			recordedAt: now,
+		});
+		await writeAudit(tx, {
+			actorKind: "system",
+			actorId: null,
+			action: "delivery.cancel",
+			resourceType: "node_delivery",
+			resourceId: delivery.id,
+			metadata: {
+				origin: "relay",
+				node_id: delivery.nodeId,
+				mission_id: missionId,
+				reason: cancellationReason,
+				settled_by_event_id: event.event_id,
+			},
+		});
+	}
+
+	await tx
+		.update(missions)
+		.set({
+			state: nextState,
+			status: nextState.status,
+			lastEventSequence: nextState.sequence_no,
+			contractVersion: nextState.contract_version,
+			updatedAt: now,
+		})
+		.where(eq(missions.id, missionId));
+	await writeAudit(tx, {
+		actorKind: "system",
+		actorId: null,
+		action: "mission.terminal",
+		resourceType: "mission_event",
+		resourceId: event.event_id,
+		metadata: {
+			mission_id: missionId,
+			sequence_no: event.sequence_no,
+			status: event.terminal_status,
+			reason: event.reason,
+			triggering_delivery_id: event.triggering_delivery_id,
+			cancelled_delivery_ids: activeDeliveries.map((delivery) => delivery.id),
+		},
+	});
+	return { missionId, reconciled: true, status: nextState.status, event, checkedAt: now };
+}
+
+async function terminalCause(
+	tx: ReconciliationTransaction,
+	missionId: string,
+	expiresAt: Date,
+	now: Date,
+): Promise<TerminalCause | null> {
+	if (expiresAt.getTime() <= now.getTime()) {
+		return { status: "expired", reason: "deadline_exceeded", deliveryId: null };
+	}
+	const [deadLettered] = await tx
+		.select({ id: nodeDeliveries.id })
+		.from(nodeDeliveries)
+		.where(
+			and(
+				eq(nodeDeliveries.missionId, missionId),
+				eq(nodeDeliveries.status, "dead_lettered"),
+				isNull(nodeDeliveries.settledByEventId),
+			),
+		)
+		.orderBy(asc(nodeDeliveries.cursor))
+		.limit(1);
+	return deadLettered
+		? { status: "failed", reason: "delivery_dead_lettered", deliveryId: deadLettered.id }
+		: null;
+}
+
+async function readDatabaseClock(tx: ReconciliationTransaction): Promise<Date> {
+	const [clock] = await tx.execute(sql<{ now: string }>`SELECT clock_timestamp()::text AS now`);
+	if (!clock || typeof clock.now !== "string") {
+		throw new RelayError("internal", "Database clock is unavailable during Mission reconciliation");
+	}
+	const now = new Date(clock.now);
+	if (!Number.isFinite(now.getTime())) {
+		throw new RelayError("internal", "Database returned an invalid reconciliation timestamp");
+	}
+	return now;
+}


### PR DESCRIPTION
## Summary

- add a Relay-owned `mission_terminal` protocol event for deterministic `expired` and `failed` outcomes
- reconcile deadlines and unresolved dead letters under the Mission lock, atomically cancelling remaining runnable work with exact receipts and audits
- fence late delivery mutations while preserving authorized exact historical replay
- add upgrade-safe migration coverage, focused PostgreSQL race tests, and current architecture documentation

## Transition policy

- an eligible database deadline wins and maps `active` or `verifying` to `expired`
- otherwise the earliest unsettled dead-lettered delivery maps the Mission to `failed`
- these causes do not select `blocked` or `cancelled`
- reconciliation is lazy at delivery discovery and delivery-operation boundaries; no scheduler is introduced

## Validation

- protocol: 125 tests passed
- focused migration and reconciliation: 27 tests passed
- full Relay PostgreSQL integration: 173 tests passed
- combined stacked E2E: 9 tests passed, including Relay restart and stale-fence recovery
- workspace typecheck and build passed
- lint passed with the same 4 pre-existing unused-suppression warnings

## Stack and migration note

This PR intentionally targets `codex/issue-90-durable-replay` and depends on #122. Retarget it to `main` after #122 merges.

Migration 0009 adds the new checks as `NOT VALID` so PostgreSQL enforces new and updated rows without scanning the historical event ledger inside the migration transaction. A later maintenance migration may validate the historical rows online.

Closes #91