### PR TITLE
feat(node): make process ownership crash-releasable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,32 @@ jobs:
           pnpm --filter @agentrelay/protocol --filter relay --filter agentrelay-mcp
           --filter agentrelay-node test
 
+  node-lock-macos:
+    name: node-lock-macos (${{ matrix.node }})
+    needs: lint-typecheck
+    runs-on: macos-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Exercise native Node ownership
+        run: >-
+          pnpm --filter agentrelay-node exec vitest run
+          src/process-lock.test.ts src/process-lock.process.test.ts
+
   relay-image:
     needs: lint-typecheck
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ but no current descriptor or CLI activates Codex for a real model turn.
   replay, and foreground fake-adapter CLIs. Its `run-capsule` path launches one
   detached, Mission-scoped fake Capsule behind a private capability-authenticated
   Unix-socket protocol. The Capsule durably binds the exact start input before
-  exposing acceptance. Real Relay/Postgres E2E coverage kills the Node after host
-  acceptance, proves the Capsule remains reachable, then recovers the same turn and
-  commits exactly one Mission result after an operator-safe stale-lock cleanup.
+  exposing acceptance. A stable private `run.lock` inode is held with a nonblocking
+  kernel advisory lock, so a second live Node fails closed while normal exit,
+  `SIGKILL`, and host reboot release ownership without deleting the file. Real
+  Relay/Postgres E2E coverage kills the Node after host acceptance, proves the
+  Capsule remains reachable, then restarts directly, recovers the same turn, and
+  commits exactly one Mission result.
 - A provider-neutral persistent Capsule server behind the existing versioned,
   capability-authenticated Unix wire. The fake Capsule CLI and Node path retain their
   existing descriptor and wire contract through a compatibility wrapper. Unexpected

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **Status:** Canonical system overview as of 2026-08-03.
+> **Status:** Canonical system overview as of 2026-08-15.
 > Current implementation details live in [`hld.md`](hld.md) and
 > [`lld.md`](lld.md). The accepted next target lives in
 > [`RFC 001: AgentRelay Node and Missions`](rfcs/001-agentrelay-node-and-missions.md),
@@ -59,7 +59,11 @@ durable coordination foundations:
   operation intent before side effects, renews fenced leases, and drives the
   deterministic fake adapter for turn deliveries. Its optional persistent path
   launches a detached, Mission-scoped fake Capsule and recovers it through a private
-  capability-authenticated Unix socket after the Node process dies.
+  capability-authenticated Unix socket after the Node process dies. A stable private
+  `run.lock` held with a kernel advisory lock provides single-writer Node ownership;
+  its inode remains permanently in place while `run.owner.json` is diagnostic only.
+  Process death or host reboot releases ownership without PID inference or manual
+  file deletion.
 - A provider-neutral persistent Capsule server behind that same versioned wire. The
   existing fake descriptor and CLI use a compatibility wrapper, so no current command
   selects another runtime. An unexpected internal runtime failure is redacted and
@@ -364,9 +368,12 @@ The relay can run anywhere that supports the relay container image and Postgres.
 may self-host it or use a future hosted service. Every developer machine can run its
 own MCP process for interactive tools. The experimental AgentRelay Node is a separate
 foreground process today. It can launch detached fake Mission Capsules that outlive a
-normal Node exit or `SIGKILL`, but automatic Node supervision and real-runtime
-Capsule activation remain target behavior. The provider-neutral server and injected
-Codex runner do not change which runtime the current CLI launches.
+normal Node exit or `SIGKILL`. Its kernel-held singleton ownership is released on
+process death, so a replacement Node can restart directly and recover the same
+Capsule turn. No OS service manager currently installs, monitors, or automatically
+respawns that foreground process, and real-runtime Capsule activation remains target
+behavior. The provider-neutral server and injected Codex runner do not change which
+runtime the current CLI launches.
 
 A sleeping or powered-off machine remains offline. The relay queues work and the Node
 processes it after reconnecting.

--- a/docs/hld.md
+++ b/docs/hld.md
@@ -1,6 +1,6 @@
 # High-level design: current relay implementation
 
-> **Scope:** Current repository implementation as of 2026-08-03.
+> **Scope:** Current repository implementation as of 2026-08-15.
 > This document describes the existing handoff plane, public Mission delivery
 > control plane, experimental Node, and unactivated Codex Capsule libraries.
 > It does not describe a complete autonomous coding runtime. See
@@ -101,7 +101,10 @@ exact operation intents, renews the Relay lease, and reduces fake-host events. R
 database time controls retry eligibility; transient host failure advances a journaled
 execution attempt while lease-only recovery keeps the same host turn. Its device
 configuration and local journal are mode 0600; the checkout path never enters the
-Relay payload.
+Relay payload. Before opening the journal or Capsule registry, the Node holds a stable
+private `run.lock` with a nonblocking kernel advisory lock. PID and owner metadata are
+written separately to `run.owner.json` and are diagnostic only; they do not grant
+ownership. The `run.lock` inode remains permanently in place.
 
 The original `run` path remains in memory. The `run-capsule` path instead persists
 one fake host process per Mission, authenticates every request with a local capability,
@@ -276,9 +279,9 @@ and the relay-owned idempotency key is not exposed to the model.
 - A production-activated coding-agent runtime session. The Node/Capsule process proof
   still exercises only the deterministic fake; the injected Codex runner is covered
   only by fake-client wire tests and has not executed a model turn.
-- Automatic Node supervision or safe unattended reclamation of a `run.lock` left by
-  `SIGKILL`; restart currently requires an operator to verify the recorded process is
-  dead before removing that exact lock.
+- Automatic Node installation, OS service supervision, or process respawn. The
+  singleton kernel lock now permits direct restart after process death, but it does
+  not start the replacement Node.
 - A production guardian that owns provider quiescence proof and spawn, heartbeat and
   owner-death recovery, and OS-enforced Codex workspace/read-root and secret
   containment.
@@ -322,8 +325,13 @@ section of [`architecture.md`](architecture.md).
   starts it again. A separately running foreground Node can continue Mission polling.
 - A normal Node exit releases its singleton lock and leaves detached Capsules alive.
   During `SIGINT` or `SIGTERM`, an in-flight turn is first asked to cancel. A
-  `SIGKILL` cannot release the Node lock; after operator-safe lock cleanup, the
-  restarted Node can recover the Capsule's exact persisted turn and event history.
+  `SIGKILL` or host reboot releases the kernel lock without deleting the stable
+  `run.lock`, so a replacement Node can restart directly and recover the Capsule's
+  exact persisted turn and event history. A stopped or stalled live Node retains the
+  lock; ownership is never stolen on a heartbeat timeout. Every legacy schema-1 PID
+  lock fails closed before local state is opened because PID-only evidence cannot
+  exclude a live old Node in another PID namespace. Its one-time migration is an
+  explicit offline operator action.
 - The provider-neutral Capsule server authenticates before invoking a runtime. An
   unexpected runtime exception is returned only as a generic internal error; the
   server removes its owned socket and closes that runtime generation. Shutdown starts

--- a/docs/lld.md
+++ b/docs/lld.md
@@ -1,6 +1,6 @@
 # Low-level design: current relay contracts
 
-> **Scope:** Current repository implementation as of 2026-08-03.
+> **Scope:** Current repository implementation as of 2026-08-15.
 > This is a compact source-oriented reference, not a promise that planned fields or
 > routes exist. Unimplemented local Node runtime behavior remains in
 > [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md).
@@ -405,11 +405,33 @@ durable intent and the Mission/session scope. The Capsule permits one active tur
 Mission.
 
 This process path is experimental and Unix-only. A normal Node exit leaves detached
-Capsules running. A Node killed with `SIGKILL` cannot remove `run.lock`; the current
-restart proof verifies the recorded PID is dead and removes only that unchanged lock
-before restarting. There is no unattended supervisor or automatic stale-lock
-reclamation. Capsule restart is automatic only after repeated failed authenticated probes
-and ownership-safe removal of the same unchanged stale socket inode. The server binds
+Capsules running. Before opening the journal or Capsule registry, the Node opens a
+stable private mode-0600 `run.lock` and acquires a nonblocking kernel advisory lock
+through exact-pinned `fs-native-extensions@1.5.0`. The file and its inode remain
+stable; PID, timestamps, and owner metadata live in a separate mode-0600
+`run.owner.json` and are diagnostic rather than ownership authority. Normal exit,
+`SIGKILL`, and host reboot release the kernel lock, so the process test and
+Relay/Postgres E2E restart directly without deleting `run.lock`. A second live,
+stopped, or event-loop-stalled Node retains ownership, because there is no heartbeat
+or timeout-based stealing. A missing or malformed `run.owner.json` cannot change the
+kernel decision.
+
+A new schema-2 lock is fully written and synced in a private same-directory temporary
+file, published without overwrite, and followed by a directory sync. Every existing
+schema-1 PID lock fails closed: `ESRCH` inside one PID namespace cannot prove an old
+Node sharing the state is dead in every namespace. Migration therefore requires a
+one-time offline operator check and removal of only the legacy file. Malformed state,
+symlinks, wrong owner/mode/type, unsupported lock semantics, extra hard links, or path
+replacement also fail closed before local state access. Once schema 2 is established,
+its inode is never renamed or unlinked; release closes the held descriptor and leaves
+the file in place. That permanent schema-2 file also prevents a pre-kernel-lock Node
+binary from creating its schema-1 PID lock.
+The validated host boundary is a local macOS or glibc-Linux filesystem; Alpine/musl
+and network-filesystem lock semantics are not established by this checkpoint.
+
+There is no installed OS service supervisor or automatic process respawn. Capsule
+restart is automatic only after repeated failed authenticated probes and
+ownership-safe removal of the same unchanged stale socket inode. The server binds
 through a private alias so closing an old process cannot unlink a replacement socket.
 
 ### Unactivated Codex Capsule library

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -127,9 +127,14 @@ through the public control plane.
 - [x] Move the fake host into a detached, Mission-scoped Capsule with a strict private
   Unix-socket capability protocol and exact-input durable recovery.
 - [x] Kill the Node after Capsule acceptance, prove the same Capsule remains live,
-  safely reclaim the exact stale Node lock, and recover one turn/result on restart.
-- [ ] Add automatic Node supervision or a crash-releasable ownership design; the
-  current `SIGKILL` proof intentionally requires verified operator cleanup.
+  restart directly without deleting `run.lock`, and recover one turn/result.
+- [x] Add crash-releasable Node ownership with a stable private kernel lock. Treat
+  `run.owner.json` PID metadata as diagnostic, keep the `run.lock` inode permanently
+  in place, never steal ownership on a heartbeat timeout, and fail closed on every
+  legacy schema-1 PID lock until an explicit offline migration.
+- [ ] Package the Node as an installed background service with OS supervision and
+  automatic process respawn. Crash-releasable ownership makes restart safe; it does
+  not start the replacement process.
 
 Start with one eligible Node per logical agent and one active turn per Mission. The
 Capsule path is experimental and Unix-only; it is not yet an installed background

--- a/docs/research/002-foreground-node-runtime.md
+++ b/docs/research/002-foreground-node-runtime.md
@@ -80,8 +80,10 @@ Atomic JSON is sufficient for this checkpoint because the Node is a single write
 processes one delivery at a time. Each save durably creates any missing directory
 chain, writes and syncs a same-directory temporary file, renames it over the journal,
 and syncs the leaf directory. A singleton process lock prevents two local writers.
-Stale locks are refused rather than removed automatically; recovery requires the owner
-to confirm no Node process is alive before deleting the exact lock file.
+This initial checkpoint inferred liveness from PID metadata and deliberately required
+operator recovery. The later Node-ownership checkpoint replaced that lifecycle with a
+permanent stable kernel-held `run.lock`: `run.owner.json` is diagnostic, and process
+death releases ownership without deleting the lock file.
 
 SQLite would add a native dependency and migration surface without improving the
 first proof. The storage interface remains separate so a later scheduler can move to
@@ -147,8 +149,9 @@ checkpoint, not autonomous coding completion.
 
 The follow-on gate moved the fake host behind a separately persistent Capsule, killed
 and restarted the Node process after host acceptance, recovered the same turn and
-event history, and published one Relay completion. Its implementation and remaining
-operator boundary are recorded in
+event history, and published one Relay completion. The subsequent kernel-lock
+checkpoint removed the original operator cleanup while preserving that Capsule proof.
+The current boundary is recorded in
 [`003-persistent-mission-capsule.md`](003-persistent-mission-capsule.md). The next
 runtime gate is the first pinned coding-agent adapter.
 

--- a/docs/research/003-persistent-mission-capsule.md
+++ b/docs/research/003-persistent-mission-capsule.md
@@ -1,13 +1,14 @@
 # Persistent Mission Capsule
 
 - **Date:** 2026-08-03
+- **Updated:** 2026-08-15
 - **Status:** Implemented for a detached deterministic fake runtime on Unix; a real
   coding-agent adapter and two-machine Mission remain open.
 - **Decision:** Keep Relay authority and local policy in the foreground Node, while a
   Mission-scoped Capsule owns durable host-session and turn state across Node-process
   death.
-- **Scope:** One fake Capsule per Mission, one active turn per Capsule, and
-  operator-assisted Node restart after `SIGKILL`.
+- **Scope:** One fake Capsule per Mission, one active turn per Capsule, and direct
+  Node restart after `SIGKILL` through crash-releasable singleton ownership.
 
 ## Question
 
@@ -100,25 +101,34 @@ This prevents a restarted Node from attaching previously accepted output to chan
 objective text, assignments, peer messages, artifacts, contract version, or session
 scope. Live delivery and recovered replay pass through the same Node event reducer.
 
-## Process lifecycle and operator boundary
+## Process lifecycle and ownership boundary
 
-A normal Node exit releases `run.lock` but does not terminate detached Capsules. If
-`SIGINT` or `SIGTERM` arrives during a turn, the Node asks the adapter to cancel that
-turn before its bounded shutdown completes; the Capsule process itself remains
-available with the terminal event history.
+A normal Node exit releases kernel ownership while leaving `run.lock` in place, and
+does not terminate detached Capsules. If `SIGINT` or `SIGTERM` arrives during a turn,
+the Node asks the adapter to cancel that turn before its bounded shutdown completes;
+the Capsule process itself remains available with the terminal event history.
 
-`SIGKILL` cannot run Node cleanup. The Capsule continues independently, but the Node's
-mode-0600 `run.lock` remains. The current recovery procedure is deliberately
-operator-assisted:
+The Node now opens a stable mode-0600 `run.lock` and acquires a nonblocking kernel
+advisory lock through exact-pinned `fs-native-extensions@1.5.0` before opening its
+journal or Capsule registry. The inode is not unlinked, renamed, or atomically
+replaced during normal operation; it remains permanently in place. PID, timestamps,
+and owner metadata are written durably to the separate mode-0600 sibling
+`run.owner.json`; none of them grants or denies ownership, and missing or malformed
+diagnostics cannot change the kernel lock decision.
 
-1. Open the exact lock without following symlinks.
-2. Verify it is a private regular file and records the killed Node PID.
-3. Confirm that PID is no longer alive.
-4. Recheck that the file identity has not changed.
-5. Remove only that lock, sync its directory, and restart the Node.
+The kernel releases ownership on normal exit, `SIGKILL`, and host reboot, so a
+replacement Node can restart directly against the same stable file. A stopped,
+suspended, or event-loop-stalled live Node retains the lock. There is no heartbeat or
+timeout at which another process may steal ownership. The lock handle closes last on
+graceful shutdown and is not inherited by a detached Capsule.
 
-The Node does not guess that a lock is stale or reclaim it automatically. Automatic
-service supervision or a crash-releasable ownership mechanism is separate work.
+Path and primitive uncertainty fail closed before journal access. Every schema-1 PID
+lock requires a one-time explicit offline migration: `ESRCH` inside one PID namespace
+cannot exclude a live old Node in another namespace that shares the state. Malformed
+or partial state, symlinks, wrong type/owner/mode, extra hard links, path replacement,
+or unsupported lock semantics produce an actionable operator error rather than
+guessed reclamation. This is safe singleton ownership, not OS service supervision: no
+current installer or service manager starts a replacement Node after failure.
 
 Capsule socket ownership is also fail-closed. After repeated failed authenticated probes,
 the Node compares the private socket's device/inode identity, quarantines the path,
@@ -131,6 +141,9 @@ guessing ownership.
 
 Focused Node tests cover:
 
+- private stable-lock creation, diagnostic metadata, and fail-closed path validation;
+- two live contenders, a stopped live owner, `SIGKILL` followed by immediate
+  reacquisition, legacy ownership, and non-inheritance by detached Capsules;
 - durable session, turn, and event replay after reopening both adapter and Capsule;
 - coalesced concurrent creation of one Capsule/session;
 - exact duplicate start and rejection of changed start or recovery input;
@@ -149,8 +162,9 @@ The Relay/Postgres E2E test uses the built Node and Capsule binaries. It:
 3. Kills the Node with `SIGKILL`.
 4. Uses the persisted local capability to recover the same turn through the same
    Capsule and observes its terminal event while the Node is absent.
-5. Performs the validated stale-`run.lock` cleanup above.
-6. Starts a one-cycle Node recovery process.
+5. Starts a one-cycle Node recovery process directly, without deleting or replacing
+   `run.lock`.
+6. Confirms the replacement acquires kernel ownership before opening local state.
 7. Verifies the original accepted event and turn ID, one result message, one Mission
    turn, and exactly one `delivery.complete` audit row.
 
@@ -168,9 +182,8 @@ still recoverable rather than deleting state or inventing an input.
 This checkpoint does not provide:
 
 - a Codex, Claude, or other real agent-host adapter;
-- automatic Node or Capsule installation and supervision;
+- automatic Node or Capsule installation, OS supervision, or process respawn;
 - Windows support;
-- unattended Node stale-lock recovery;
 - isolated worktree creation or complete command, network, path, deadline, token,
   expiry, and revocation enforcement;
 - contract-acknowledgement or registered verification-command delivery handlers;

--- a/docs/rfcs/001-agentrelay-node-and-missions.md
+++ b/docs/rfcs/001-agentrelay-node-and-missions.md
@@ -1,8 +1,9 @@
 # RFC 001: AgentRelay Node and Missions
 
 - **Status:** Accepted; Relay control-plane steps 1-3, the foreground Node, the
-  persistent fake-Capsule recovery checkpoint, and an unactivated guarded Codex
-  client/journal are implemented; runtime integration and the two-machine proof remain
+  persistent fake-Capsule recovery checkpoint, crash-releasable singleton Node
+  ownership, and an unactivated guarded Codex client/journal are implemented; runtime
+  integration and the two-machine proof remain
 - **Date:** 2026-08-01
 - **Scope:** Two agents, two machines, two repositories, one real runtime adapter
 
@@ -441,8 +442,10 @@ The evaluation harness then runs one hidden end-to-end check that agents did not
    failure after host acceptance, lost Relay responses, stale fences, transient
    retry, cancellation, shutdown, local-policy denial, and paginated assignment
    starvation are covered. A detached fake Capsule now proves exact-turn recovery
-   after the Node is killed following host acceptance. Pre-claim/after-claim process
-   cuts, unattended Node restart, busy-session, and full adversarial coverage remain.
+   after the Node is killed following host acceptance. The stable kernel-held Node
+   lock permits direct restart without file deletion and refuses a stopped live
+   contender. Pre-claim/after-claim process cuts, busy-session, and full adversarial
+   coverage remain.
 6. **In progress:** the Codex `0.146.0` app-server protocol/client is pinned and the
    unactivated Capsule journal proves local at-most-once barriers, exact-input replay,
    redacted terminal normalization, and cancellation intent. Runtime/server/CLI

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> **Updated:** 2026-08-14. This roadmap replaces the old mailbox -> Auto Mode ->
+> **Updated:** 2026-08-15. This roadmap replaces the old mailbox -> Auto Mode ->
 > Ambient Agent release sequence. The architectural contract is
 > [`RFC 001: AgentRelay Node and Missions`](rfcs/001-agentrelay-node-and-missions.md).
 
@@ -95,13 +95,19 @@ adapter replay. It can launch a detached, Mission-scoped fake Capsule through a
 private capability-authenticated Unix socket. Unit fault injection and real
 Relay/Postgres E2E coverage prove one host turn per processed delivery across
 duplicate polling, runner reconstruction, and `SIGKILL` after host acceptance. The
-restart proof still requires operator-safe cleanup of the killed Node's stale process
-lock. The Capsule server is now provider-neutral while the existing descriptor, CLI,
-and wire remain fake-compatible. An injected Codex runner is tested through that real
-Unix wire. Runtime shutdown concurrently fences admitted work, and background runtime
-failures can retire their server generation, but no production path selects Codex.
-Contract acknowledgement, verification execution, guarded real-runtime activation,
-and the two-machine exit gate remain open.
+Node now holds a stable private `run.lock` with a kernel advisory lock: process death
+or reboot releases ownership, direct restart needs no file deletion, and a stopped or
+stalled live owner cannot be displaced by a timeout. The lock inode remains
+permanently in place, and PID metadata in `run.owner.json` is diagnostic rather than
+authority. Every legacy schema-1 PID lock requires a one-time explicit offline
+migration because PID-only evidence cannot rule out another namespace. The Capsule
+server is now provider-neutral while the existing descriptor, CLI, and wire remain
+fake-compatible. An injected Codex runner is tested through that real Unix wire.
+Runtime shutdown concurrently fences admitted work, and background runtime failures
+can retire their server generation, but no production path selects Codex. OS service
+installation and automatic process respawn, contract acknowledgement, verification
+execution, guarded real-runtime activation, and the two-machine exit gate remain
+open.
 
 - Add a `node/` pnpm workspace and daemon CLI.
 - Register device-scoped credentials and capabilities.

--- a/node/README.md
+++ b/node/README.md
@@ -40,8 +40,9 @@ fake adapter before a real coding-agent adapter is introduced.
 
 The real Relay/Postgres E2E coverage includes both in-process runner reconstruction
 and an OS-process boundary: it kills the Node after Capsule acceptance, probes the
-same live Capsule while the Node is absent, restarts the Node after safe stale-lock
-cleanup, and proves one turn reference, one result message, and one completion audit.
+same live Capsule while the Node is absent, restarts the Node directly after the
+kernel releases ownership, and proves one turn reference, one result message, and one
+completion audit.
 
 ## Current boundary
 
@@ -58,9 +59,10 @@ requires a separate, explicit preflight for every nested repository and its loca
 configuration.
 
 The Capsule checkpoint is experimental and Unix-only because its transport is a Unix
-domain socket. It is not a general local daemon manager: there is no installer,
-service supervisor, automatic Node stale-lock reclamation, or real Codex/Claude
-adapter yet.
+domain socket. It is not a general local daemon manager: there is no installer, OS
+service supervisor, automatic process respawn, or real Codex/Claude adapter yet. The
+foreground Node's singleton ownership is crash-releasable, but an external service
+manager must still start a replacement process.
 
 ## Configuration
 
@@ -143,11 +145,29 @@ Relay request still has its own bounded client timeout.
 
 The Node journal is stored beside the config under `state/journal.json`; Capsule state
 defaults to `state/capsules/<mission-id>/`. Do not run two Node processes against the
-same directory; `run.lock` enforces the single-writer assumption. A `SIGKILL` can
-leave that lock behind even though the detached Capsule continues. The Node refuses
-to remove it automatically. Confirm the recorded process is dead and the file has
-not changed before deleting that exact `run.lock` and restarting. This operator step
-is part of the current crash-recovery proof, not automatic supervision.
+same directory. A stable, mode-0600 `run.lock` is held with a nonblocking kernel
+advisory lock, through exact-pinned `fs-native-extensions@1.5.0`, before the journal or
+Capsule registry is opened. The lock file and inode remain permanently in place;
+ownership is the live kernel lock, not the PID and timestamps written to the
+separate sibling `run.owner.json` diagnostic file beside it. A second live Node
+therefore fails before local state access, while normal exit, `SIGKILL`, and host
+reboot release ownership automatically. A stopped or event-loop-stalled live Node
+keeps ownership: there is no heartbeat or timeout-based stealing. Missing or
+malformed diagnostics never grant or deny ownership.
+
+Keep Node state on a local filesystem with supported advisory-lock semantics. This
+checkpoint validates macOS and glibc Linux; Alpine/musl and network filesystems are
+not established ownership boundaries and are unsupported here.
+
+The Node closes the ownership handle last during graceful shutdown, and detached
+Capsules do not inherit it. Symlinks, insecure or replaced lock paths, unsupported
+lock behavior, and every legacy schema-1 PID lock fail closed with an operator-facing
+error. PID-only evidence cannot exclude a live old Node in another PID namespace. For
+the one-time upgrade, stop every Node that can access this state, verify the state is
+offline, remove only the legacy `run.lock`, and start the new Node. Once schema 2 is
+established, do not delete or replace `run.lock` as part of normal recovery. This
+provides safe direct restart after process death; it does not install or run an OS
+service supervisor.
 
 The current Node journal uses schema 2 to retain the active attempt's exact validated
 start input. Empty schema-1 journals migrate automatically. A schema-1 journal with

--- a/node/package.json
+++ b/node/package.json
@@ -29,6 +29,7 @@
 	"dependencies": {
 		"@agentrelay/protocol": "workspace:*",
 		"cac": "^6.7.14",
+		"fs-native-extensions": "1.5.0",
 		"pino": "^9.5.0",
 		"undici": "^7.29.0",
 		"zod": "^3.23.8"

--- a/node/src/kernel-file-lock.ts
+++ b/node/src/kernel-file-lock.ts
@@ -1,0 +1,34 @@
+import { createRequire } from "node:module";
+
+export interface KernelFileLock {
+	tryLock(fileDescriptor: number): boolean;
+	unlock(fileDescriptor: number): void;
+}
+
+interface NativeFileLockModule {
+	tryLock(fileDescriptor: number): boolean;
+	unlock(fileDescriptor: number): void;
+}
+
+let nativeFileLock: NativeFileLockModule | undefined;
+
+export const kernelFileLock: KernelFileLock = Object.freeze({
+	tryLock(fileDescriptor: number): boolean {
+		return loadNativeFileLock().tryLock(fileDescriptor);
+	},
+	unlock(fileDescriptor: number): void {
+		loadNativeFileLock().unlock(fileDescriptor);
+	},
+});
+
+function loadNativeFileLock(): NativeFileLockModule {
+	if (nativeFileLock !== undefined) return nativeFileLock;
+	const loaded = createRequire(import.meta.url)(
+		"fs-native-extensions",
+	) as Partial<NativeFileLockModule>;
+	if (typeof loaded.tryLock !== "function" || typeof loaded.unlock !== "function") {
+		throw new TypeError("fs-native-extensions does not expose the required lock operations");
+	}
+	nativeFileLock = loaded as NativeFileLockModule;
+	return nativeFileLock;
+}

--- a/node/src/process-lock-state.ts
+++ b/node/src/process-lock-state.ts
@@ -1,0 +1,344 @@
+import { randomUUID } from "node:crypto";
+import { constants, type Stats } from "node:fs";
+import { type FileHandle, link, lstat, open, readdir, unlink } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, normalize } from "node:path";
+import { z } from "zod";
+import { syncDirectory } from "./durable-file.js";
+import {
+	ensurePrivateStateDirectory,
+	readPrivateJsonIfPresent,
+	writePrivateJson,
+} from "./private-state-file.js";
+
+const MAX_LOCK_FILE_BYTES = 4_096;
+const ACQUISITION_ATTEMPTS = 8;
+
+const legacyLockMetadataSchema = z
+	.object({
+		schema_version: z.literal(1),
+		lock_id: z.string().uuid(),
+		pid: z.number().int().positive(),
+		started_at: z.string().datetime({ offset: true }),
+	})
+	.strict();
+
+const kernelLockFileSchema = z
+	.object({
+		schema_version: z.literal(2),
+		kind: z.literal("agentrelay_node_kernel_lock"),
+	})
+	.strict();
+
+export const ownerMetadataSchema = z
+	.object({
+		schema_version: z.literal(2),
+		lock_id: z.string().uuid(),
+		pid: z.number().int().positive(),
+		started_at: z.string().datetime({ offset: true }),
+	})
+	.strict();
+
+export type LegacyLockMetadata = z.infer<typeof legacyLockMetadataSchema>;
+export type OwnerMetadata = z.infer<typeof ownerMetadataSchema>;
+
+const KERNEL_LOCK_FILE = Object.freeze({
+	schema_version: 2 as const,
+	kind: "agentrelay_node_kernel_lock" as const,
+});
+
+interface OpenLockFile {
+	readonly handle: FileHandle;
+	readonly contents:
+		| { readonly kind: "legacy"; readonly metadata: LegacyLockMetadata }
+		| { readonly kind: "kernel" };
+}
+
+export class ProcessLockError extends Error {
+	constructor(
+		readonly reason: "already_running" | "invalid_lock" | "unavailable",
+		readonly path: string,
+		message: string,
+		readonly owner?: Readonly<LegacyLockMetadata | OwnerMetadata>,
+		options: ErrorOptions = {},
+	) {
+		super(message, options);
+		this.name = "ProcessLockError";
+	}
+}
+
+export async function openStableProcessLock(path: string): Promise<FileHandle> {
+	await prepareLockDirectory(path);
+	for (let attempt = 0; attempt < ACQUISITION_ATTEMPTS; attempt += 1) {
+		const existing = await openLockFile(path);
+		if (existing === null) {
+			await publishKernelLockFile(path);
+			continue;
+		}
+		if (existing.contents.kind === "kernel") return existing.handle;
+
+		await existing.handle.close().catch(() => undefined);
+		throw new ProcessLockError(
+			"invalid_lock",
+			path,
+			`Legacy schema-1 process ownership at ${path} cannot be reclaimed safely from PID metadata. Stop every Node that can access this state, verify the state is offline, then remove this legacy file once; the next start will create the permanent kernel lock`,
+			existing.contents.metadata,
+		);
+	}
+
+	throw new ProcessLockError(
+		"unavailable",
+		path,
+		`Could not acquire process lock at ${path} because its ownership file kept changing`,
+	);
+}
+
+export async function assertStableProcessLock(path: string, handle: FileHandle): Promise<void> {
+	await assertPathReferencesHandle(path, handle);
+	if ((await handle.stat()).nlink !== 1) {
+		throw invalidLock(path, `Process lock must have exactly one filesystem link: ${path}`);
+	}
+}
+
+async function assertPathReferencesHandle(path: string, handle: FileHandle): Promise<void> {
+	let pathStats: Awaited<ReturnType<typeof lstat>>;
+	try {
+		pathStats = await lstat(path);
+	} catch (error) {
+		throw invalidLock(
+			path,
+			`Process lock path changed while it was being inspected: ${path}`,
+			error,
+		);
+	}
+	const handleStats = await handle.stat();
+	if (
+		pathStats.isSymbolicLink() ||
+		!pathStats.isFile() ||
+		pathStats.dev !== handleStats.dev ||
+		pathStats.ino !== handleStats.ino
+	) {
+		throw invalidLock(path, `Process lock path changed while it was being inspected: ${path}`);
+	}
+}
+
+export async function readOwnerMetadata(path: string): Promise<OwnerMetadata | undefined> {
+	try {
+		const decoded = await readPrivateJsonIfPresent(ownerMetadataPath(path));
+		if (decoded === null) return undefined;
+		const parsed = ownerMetadataSchema.safeParse(decoded);
+		return parsed.success ? parsed.data : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function writeOwnerMetadata(path: string, metadata: OwnerMetadata): Promise<void> {
+	await writePrivateJson(ownerMetadataPath(path), metadata);
+}
+
+async function openLockFile(path: string): Promise<OpenLockFile | null> {
+	let handle: FileHandle;
+	try {
+		handle = await open(path, constants.O_RDWR | constants.O_NOFOLLOW);
+	} catch (error) {
+		if (isNotFound(error)) return null;
+		throw new ProcessLockError(
+			isUnsafeFileError(error) ? "invalid_lock" : "unavailable",
+			path,
+			`Cannot open private process lock at ${path}`,
+			undefined,
+			{ cause: error },
+		);
+	}
+
+	try {
+		const stats = await validatePrivateRegularFile(path, handle);
+		await assertPathReferencesHandle(path, handle);
+		const decoded = await readLockJson(path, handle, stats.size);
+
+		if (kernelLockFileSchema.safeParse(decoded).success) {
+			if (stats.nlink !== 1) await removePublishedTemporaryLinks(path, handle);
+			return { handle, contents: { kind: "kernel" } };
+		}
+		const legacy = legacyLockMetadataSchema.safeParse(decoded);
+		if (legacy.success) {
+			return { handle, contents: { kind: "legacy", metadata: legacy.data } };
+		}
+		throw invalidLock(path, `Process lock at ${path} is invalid`);
+	} catch (error) {
+		await handle.close().catch(() => undefined);
+		throw error;
+	}
+}
+
+async function publishKernelLockFile(path: string): Promise<void> {
+	const directory = dirname(path);
+	const temporaryPath = join(directory, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+	let temporaryExists = false;
+
+	try {
+		const handle = await open(
+			temporaryPath,
+			constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+			0o600,
+		);
+		temporaryExists = true;
+		try {
+			await handle.chmod(0o600);
+			await handle.writeFile(`${JSON.stringify(KERNEL_LOCK_FILE, null, 2)}\n`, "utf8");
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
+
+		try {
+			await link(temporaryPath, path);
+		} catch (error) {
+			if (isAlreadyExists(error)) return;
+			throw error;
+		}
+	} catch (error) {
+		throw new ProcessLockError(
+			"unavailable",
+			path,
+			`Cannot provision private process lock at ${path}`,
+			undefined,
+			{ cause: error },
+		);
+	} finally {
+		if (temporaryExists) {
+			await unlink(temporaryPath).catch((error: unknown) => {
+				if (!isNotFound(error)) throw error;
+			});
+			await syncDirectory(directory);
+		}
+	}
+}
+
+async function readLockJson(path: string, handle: FileHandle, size: number): Promise<unknown> {
+	if (size > MAX_LOCK_FILE_BYTES) {
+		throw invalidLock(path, `Process lock at ${path} exceeds the byte limit`);
+	}
+	const buffer = Buffer.alloc(size);
+	let bytesRead = 0;
+	while (bytesRead < size) {
+		const result = await handle.read(buffer, bytesRead, size - bytesRead, bytesRead);
+		if (result.bytesRead === 0) break;
+		bytesRead += result.bytesRead;
+	}
+	if (bytesRead !== size || (await handle.stat()).size !== size) {
+		throw invalidLock(path, `Process lock at ${path} changed while it was being read`);
+	}
+	try {
+		return JSON.parse(buffer.toString("utf8"));
+	} catch (error) {
+		throw invalidLock(path, `Process lock at ${path} is malformed`, error);
+	}
+}
+
+async function removePublishedTemporaryLinks(path: string, handle: FileHandle): Promise<void> {
+	const directory = dirname(path);
+	const expected = await handle.stat();
+	let removed = false;
+	for (const name of await readdir(directory)) {
+		if (!isLockTemporaryName(path, name)) continue;
+		const candidate = join(directory, name);
+		let candidateStats: Stats;
+		try {
+			candidateStats = await lstat(candidate);
+		} catch (error) {
+			if (isNotFound(error)) continue;
+			throw error;
+		}
+		if (
+			candidateStats.isSymbolicLink() ||
+			!candidateStats.isFile() ||
+			candidateStats.dev !== expected.dev ||
+			candidateStats.ino !== expected.ino ||
+			(candidateStats.mode & 0o777) !== 0o600 ||
+			(process.getuid !== undefined && candidateStats.uid !== process.getuid())
+		) {
+			continue;
+		}
+		await assertPathReferencesHandle(candidate, handle);
+		try {
+			await unlink(candidate);
+			removed = true;
+		} catch (error) {
+			if (!isNotFound(error)) throw error;
+		}
+	}
+	if (removed) await syncDirectory(directory);
+	await assertStableProcessLock(path, handle);
+}
+
+function isLockTemporaryName(path: string, name: string): boolean {
+	const escapedName = basename(path).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(
+		`^\\.${escapedName}\\.[1-9][0-9]*\\.[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\\.tmp$`,
+	).test(name);
+}
+
+async function prepareLockDirectory(path: string): Promise<void> {
+	if (!isAbsolute(path) || normalize(path) !== path || path.includes("\0")) {
+		throw invalidLock(path, `Process lock path must be absolute and normalized: ${path}`);
+	}
+	try {
+		await ensurePrivateStateDirectory(dirname(path));
+	} catch (error) {
+		throw invalidLock(
+			path,
+			`Process lock parent directory is not private and canonical: ${path}`,
+			error,
+		);
+	}
+}
+
+async function validatePrivateRegularFile(path: string, handle: FileHandle): Promise<Stats> {
+	const stats = await handle.stat();
+	if (!stats.isFile()) throw invalidLock(path, `Process lock must be a regular file: ${path}`);
+	if (stats.size > MAX_LOCK_FILE_BYTES) {
+		throw invalidLock(path, `Process lock at ${path} exceeds the byte limit`);
+	}
+	if ((stats.mode & 0o777) !== 0o600) {
+		throw invalidLock(path, `Process lock must have mode 0600: ${path}`);
+	}
+	if (process.getuid !== undefined && stats.uid !== process.getuid()) {
+		throw invalidLock(path, `Process lock must be owned by the current user: ${path}`);
+	}
+	return stats;
+}
+
+function ownerMetadataPath(path: string): string {
+	const filename = basename(path);
+	const stem = filename.endsWith(".lock") ? filename.slice(0, -".lock".length) : filename;
+	return join(dirname(path), `${stem}.owner.json`);
+}
+
+function invalidLock(path: string, message: string, cause?: unknown): ProcessLockError {
+	return new ProcessLockError(
+		"invalid_lock",
+		path,
+		message,
+		undefined,
+		cause === undefined ? undefined : { cause },
+	);
+}
+
+function isUnsafeFileError(error: unknown): boolean {
+	return ["EACCES", "EISDIR", "ELOOP", "EPERM"].includes(errorCode(error) ?? "");
+}
+
+function isAlreadyExists(error: unknown): boolean {
+	return errorCode(error) === "EEXIST";
+}
+
+function isNotFound(error: unknown): boolean {
+	return errorCode(error) === "ENOENT";
+}
+
+function errorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? String(error.code)
+		: undefined;
+}

--- a/node/src/process-lock.process.test.ts
+++ b/node/src/process-lock.process.test.ts
@@ -1,0 +1,198 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, realpath, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireProcessLock } from "./process-lock.js";
+
+const temporaryDirectories: string[] = [];
+const subprocesses: ChildProcess[] = [];
+const detachedProcessIds: number[] = [];
+
+const PROCESS_WORKER_SOURCE = String.raw`
+import { spawn } from "node:child_process";
+import { acquireProcessLock } from "./process-lock.ts";
+
+const lockPath = process.argv[1];
+const mode = process.argv[2];
+let heldLock;
+try {
+	heldLock = await acquireProcessLock(lockPath);
+} catch (error) {
+	await new Promise((resolve) => {
+		process.stdout.write(JSON.stringify({ acquired: false, reason: error?.reason }) + "\n", resolve);
+	});
+	process.exit(0);
+}
+
+if (mode === "detached-child") {
+	const child = spawn(process.execPath, ["--eval", "setInterval(() => {}, 1_000)"], {
+		detached: true,
+		stdio: "ignore",
+	});
+	child.unref();
+	process.stdout.write(JSON.stringify({ acquired: true, childPid: child.pid }) + "\n");
+} else {
+	process.stdout.write(JSON.stringify({ acquired: true, pid: process.pid }) + "\n");
+}
+setInterval(() => void heldLock, 1_000);
+`;
+
+afterEach(async () => {
+	for (const child of subprocesses.splice(0)) await killWorker(child);
+	for (const pid of detachedProcessIds.splice(0)) killProcess(pid, "SIGKILL");
+	const { rm } = await import("node:fs/promises");
+	await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+describe("process lock ownership across processes", () => {
+	it("allows exactly one of two simultaneous contenders", async () => {
+		const path = join(await temporaryDirectory(), "run.lock");
+		const first = startWorker(path, "hold");
+		const second = startWorker(path, "hold");
+		const results = await Promise.all([workerReady(first), workerReady(second)]);
+
+		expect(results.filter((result) => result.acquired === true)).toHaveLength(1);
+		expect(results.filter((result) => result.reason === "already_running")).toHaveLength(1);
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"denies another process while the owner is stopped",
+		async () => {
+			const path = join(await temporaryDirectory(), "run.lock");
+			const worker = startWorker(path, "hold");
+			await expect(workerReady(worker)).resolves.toMatchObject({ acquired: true });
+			if (worker.pid === undefined) throw new Error("Worker PID is unavailable");
+			process.kill(worker.pid, "SIGSTOP");
+
+			await expect(acquireProcessLock(path)).rejects.toMatchObject({
+				name: "ProcessLockError",
+				reason: "already_running",
+			});
+		},
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"reacquires the same inode immediately after the owner is killed",
+		async () => {
+			const path = join(await temporaryDirectory(), "run.lock");
+			const worker = startWorker(path, "hold");
+			await expect(workerReady(worker)).resolves.toMatchObject({ acquired: true });
+			const inode = (await stat(path)).ino;
+			if (worker.pid === undefined) throw new Error("Worker PID is unavailable");
+
+			process.kill(worker.pid, "SIGKILL");
+			await waitForExit(worker);
+			const lock = await acquireProcessLock(path);
+			expect((await stat(path)).ino).toBe(inode);
+			await lock.release();
+		},
+	);
+
+	it.skipIf(process.platform === "win32")(
+		"does not let a detached child inherit Node ownership",
+		async () => {
+			const path = join(await temporaryDirectory(), "run.lock");
+			const worker = startWorker(path, "detached-child");
+			const ready = await workerReady(worker);
+			if (typeof ready.childPid !== "number") throw new Error("Detached child PID is unavailable");
+			detachedProcessIds.push(ready.childPid);
+			if (worker.pid === undefined) throw new Error("Worker PID is unavailable");
+
+			process.kill(worker.pid, "SIGKILL");
+			await waitForExit(worker);
+			expect(isProcessAlive(ready.childPid)).toBe(true);
+
+			const lock = await acquireProcessLock(path);
+			await lock.release();
+		},
+	);
+});
+
+async function temporaryDirectory(): Promise<string> {
+	const path = await realpath(await mkdtemp(join(tmpdir(), "agentrelay-node-lock-process-")));
+	temporaryDirectories.push(path);
+	return path;
+}
+
+function startWorker(path: string, mode: "hold" | "detached-child"): ChildProcess {
+	const child = spawn(
+		process.execPath,
+		["--import", "tsx", "--input-type=module", "--eval", PROCESS_WORKER_SOURCE, path, mode],
+		{
+			cwd: dirname(fileURLToPath(import.meta.url)),
+			stdio: ["ignore", "pipe", "pipe"],
+		},
+	);
+	subprocesses.push(child);
+	return child;
+}
+
+async function workerReady(child: ChildProcess): Promise<Record<string, unknown>> {
+	if (child.stdout === null || child.stderr === null)
+		throw new Error("Worker pipes are unavailable");
+	return await new Promise((resolve, reject) => {
+		let stdout = "";
+		let stderr = "";
+		const timeout = setTimeout(
+			() => reject(new Error(`Worker readiness timed out: ${stderr}`)),
+			5_000,
+		);
+		child.stdout?.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString("utf8");
+			const newline = stdout.indexOf("\n");
+			if (newline === -1) return;
+			clearTimeout(timeout);
+			try {
+				resolve(JSON.parse(stdout.slice(0, newline)) as Record<string, unknown>);
+			} catch (error) {
+				reject(error);
+			}
+		});
+		child.stderr?.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString("utf8");
+		});
+		child.once("exit", (code, signal) => {
+			clearTimeout(timeout);
+			reject(new Error(`Worker exited before readiness (${code ?? signal}): ${stderr}`));
+		});
+	});
+}
+
+async function killWorker(child: ChildProcess): Promise<void> {
+	if (child.pid === undefined || child.exitCode !== null || child.signalCode !== null) return;
+	killProcess(child.pid, "SIGCONT");
+	killProcess(child.pid, "SIGKILL");
+	await waitForExit(child).catch(() => undefined);
+}
+
+function killProcess(pid: number, signal: NodeJS.Signals): void {
+	try {
+		process.kill(pid, signal);
+	} catch (error) {
+		if (errorCode(error) !== "ESRCH") throw error;
+	}
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		if (errorCode(error) === "ESRCH") return false;
+		throw error;
+	}
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	await once(child, "exit");
+}
+
+function errorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? String(error.code)
+		: undefined;
+}

--- a/node/src/process-lock.test.ts
+++ b/node/src/process-lock.test.ts
@@ -1,7 +1,19 @@
-import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { renameSync, writeFileSync } from "node:fs";
+import {
+	chmod,
+	link,
+	mkdir,
+	mkdtemp,
+	readFile,
+	realpath,
+	stat,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { kernelFileLock } from "./kernel-file-lock.js";
 import { acquireProcessLock } from "./process-lock.js";
 
 const temporaryDirectories: string[] = [];
@@ -12,93 +24,242 @@ afterEach(async () => {
 });
 
 describe("acquireProcessLock", () => {
-	it("creates a mode-0600 singleton lock and rejects a live owner", async () => {
+	it("keeps one private kernel-lock inode across release and reacquisition", async () => {
 		const root = await temporaryDirectory();
 		const path = join(root, "run.lock");
+		const ownerPath = join(root, "run.owner.json");
 		const first = await acquireProcessLock(
 			path,
 			fixedOptions("10000000-0000-4000-8000-000000000001"),
 		);
+		const firstStats = await stat(path);
 
-		expect((await stat(path)).mode & 0o777).toBe(0o600);
+		expect(firstStats.mode & 0o777).toBe(0o600);
+		expect((await stat(root)).mode & 0o777).toBe(0o700);
+		expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+			schema_version: 2,
+			kind: "agentrelay_node_kernel_lock",
+		});
+		expect(JSON.parse(await readFile(ownerPath, "utf8"))).toEqual({
+			schema_version: 2,
+			lock_id: "10000000-0000-4000-8000-000000000001",
+			pid: 42,
+			started_at: "2026-08-03T00:00:00.000Z",
+		});
+		expect((await stat(ownerPath)).mode & 0o777).toBe(0o600);
+
 		await expect(
-			acquireProcessLock(path, {
-				...fixedOptions("10000000-0000-4000-8000-000000000002"),
-				isProcessAlive: () => true,
-			}),
+			acquireProcessLock(path, fixedOptions("10000000-0000-4000-8000-000000000002")),
 		).rejects.toMatchObject({
 			name: "ProcessLockError",
 			reason: "already_running",
+			owner: { pid: 42 },
+			message: expect.stringContaining("last reported owner PID 42"),
 		});
 
 		await first.release();
-	});
-
-	it("reports a stale lock without deleting or replacing it", async () => {
-		const root = await temporaryDirectory();
-		const path = join(root, "run.lock");
-		const stale = {
-			schema_version: 1,
-			lock_id: "10000000-0000-4000-8000-000000000001",
-			pid: 999,
-			started_at: "2026-08-03T00:00:00.000Z",
-		};
-		await writeFile(path, JSON.stringify(stale), { mode: 0o600 });
-
-		await expect(
-			acquireProcessLock(path, {
-				...fixedOptions("10000000-0000-4000-8000-000000000002"),
-				isProcessAlive: () => false,
-			}),
-		).rejects.toMatchObject({
-			name: "ProcessLockError",
-			reason: "stale_lock",
-			owner: stale,
-			message: expect.stringContaining("remove it only after confirming"),
-		});
-		expect(JSON.parse(await readFile(path, "utf8"))).toEqual(stale);
-	});
-
-	it("fails closed on malformed lock metadata", async () => {
-		const root = await temporaryDirectory();
-		const path = join(root, "run.lock");
-		await writeFile(path, "not-json", { mode: 0o600 });
-
-		await expect(acquireProcessLock(path, fixedOptions())).rejects.toMatchObject({
-			name: "ProcessLockError",
-			reason: "invalid_lock",
-		});
-	});
-
-	it("release is idempotent and permits a later owner", async () => {
-		const root = await temporaryDirectory();
-		const path = join(root, "run.lock");
-		const first = await acquireProcessLock(path, fixedOptions());
 		await first.release();
-		await first.release();
-
 		const second = await acquireProcessLock(
 			path,
 			fixedOptions("10000000-0000-4000-8000-000000000002"),
 		);
+		expect((await stat(path)).ino).toBe(firstStats.ino);
 		await second.release();
 	});
 
-	it("does not remove a lock file replaced by a different owner", async () => {
+	it("uses malformed owner metadata only as unavailable diagnostics", async () => {
 		const root = await temporaryDirectory();
 		const path = join(root, "run.lock");
 		const first = await acquireProcessLock(path, fixedOptions());
-		const replacement = {
-			schema_version: 1,
-			lock_id: "10000000-0000-4000-8000-000000000099",
-			pid: 99,
-			started_at: "2026-08-03T00:00:00.000Z",
-		};
-		await writeFile(path, JSON.stringify(replacement), { mode: 0o600 });
+		await writeFile(join(root, "run.owner.json"), "not-json", { mode: 0o600 });
+
+		await expect(acquireProcessLock(path, fixedOptions())).rejects.toMatchObject({
+			name: "ProcessLockError",
+			reason: "already_running",
+			owner: undefined,
+			message: expect.stringContaining("owner diagnostics are unavailable"),
+		});
 
 		await first.release();
+	});
 
-		expect(JSON.parse(await readFile(path, "utf8"))).toEqual(replacement);
+	it("fails closed on schema-1 ownership even when its PID appears absent", async () => {
+		const root = await temporaryDirectory();
+		const path = join(root, "run.lock");
+		const legacy = legacyMetadata(999_999_999);
+		await writeFile(path, `${JSON.stringify(legacy)}\n`, { mode: 0o600 });
+
+		await expect(acquireProcessLock(path, fixedOptions())).rejects.toMatchObject({
+			name: "ProcessLockError",
+			reason: "invalid_lock",
+			owner: legacy,
+			message: expect.stringContaining("cannot be reclaimed safely from PID metadata"),
+		});
+		expect(JSON.parse(await readFile(path, "utf8"))).toEqual(legacy);
+	});
+
+	it("finishes an interrupted schema-2 hard-link publication", async () => {
+		const root = await temporaryDirectory();
+		const path = join(root, "run.lock");
+		const initial = await acquireProcessLock(path, fixedOptions());
+		await initial.release();
+		const temporaryAlias = join(root, ".run.lock.999.10000000-0000-4000-8000-000000000001.tmp");
+		await link(path, temporaryAlias);
+
+		const recovered = await acquireProcessLock(path, fixedOptions());
+		expect((await stat(path)).nlink).toBe(1);
+		await expect(stat(temporaryAlias)).rejects.toMatchObject({ code: "ENOENT" });
+		await recovered.release();
+	});
+
+	it("fails closed on an unknown extra link to the schema-2 inode", async () => {
+		const root = await temporaryDirectory();
+		const path = join(root, "run.lock");
+		const initial = await acquireProcessLock(path, fixedOptions());
+		await initial.release();
+		await link(path, join(root, "unknown-alias.lock"));
+
+		await expect(acquireProcessLock(path, fixedOptions())).rejects.toMatchObject({
+			name: "ProcessLockError",
+			reason: "invalid_lock",
+			message: expect.stringContaining("exactly one filesystem link"),
+		});
+	});
+
+	it("fails closed if the stable path is replaced after native lock acquisition", async () => {
+		const root = await temporaryDirectory();
+		const path = join(root, "run.lock");
+		const movedPath = join(root, "moved.lock");
+		const initial = await acquireProcessLock(path, fixedOptions());
+		await initial.release();
+
+		await expect(
+			acquireProcessLock(path, {
+				...fixedOptions(),
+				kernelLock: {
+					tryLock: (fileDescriptor) => {
+						const acquired = kernelFileLock.tryLock(fileDescriptor);
+						if (!acquired) return false;
+						renameSync(path, movedPath);
+						writeFileSync(
+							path,
+							`${JSON.stringify({ schema_version: 2, kind: "agentrelay_node_kernel_lock" })}\n`,
+							{ mode: 0o600 },
+						);
+						return true;
+					},
+					unlock: (fileDescriptor) => kernelFileLock.unlock(fileDescriptor),
+				},
+			}),
+		).rejects.toMatchObject({
+			name: "ProcessLockError",
+			reason: "invalid_lock",
+			message: expect.stringContaining("path changed"),
+		});
+
+		const recovered = await acquireProcessLock(path, fixedOptions());
+		await recovered.release();
+	});
+
+	it("fails closed on malformed, linked, or insecure lock state", async () => {
+		const malformedRoot = await temporaryDirectory();
+		const malformedPath = join(malformedRoot, "run.lock");
+		await writeFile(malformedPath, "not-json", { mode: 0o600 });
+		await expect(acquireProcessLock(malformedPath, fixedOptions())).rejects.toMatchObject({
+			reason: "invalid_lock",
+		});
+
+		const symlinkRoot = await temporaryDirectory();
+		const target = join(symlinkRoot, "target.lock");
+		const symlinkPath = join(symlinkRoot, "run.lock");
+		await writeFile(target, JSON.stringify(legacyMetadata(999)), { mode: 0o600 });
+		await symlink(target, symlinkPath);
+		await expect(acquireProcessLock(symlinkPath, fixedOptions())).rejects.toMatchObject({
+			reason: "invalid_lock",
+		});
+
+		const modeRoot = await temporaryDirectory();
+		const modePath = join(modeRoot, "run.lock");
+		await writeFile(modePath, JSON.stringify(legacyMetadata(999)), { mode: 0o644 });
+		await expect(acquireProcessLock(modePath, fixedOptions())).rejects.toMatchObject({
+			reason: "invalid_lock",
+		});
+
+		const publicRoot = await temporaryDirectory();
+		await chmod(publicRoot, 0o755);
+		await expect(
+			acquireProcessLock(join(publicRoot, "run.lock"), fixedOptions()),
+		).rejects.toMatchObject({ reason: "invalid_lock" });
+		await chmod(publicRoot, 0o700);
+
+		const directoryRoot = await temporaryDirectory();
+		const directoryPath = join(directoryRoot, "run.lock");
+		await mkdir(directoryPath, { mode: 0o700 });
+		await expect(acquireProcessLock(directoryPath, fixedOptions())).rejects.toMatchObject({
+			reason: "invalid_lock",
+		});
+	});
+
+	it("releases the descriptor when the native lock primitive fails", async () => {
+		const root = await temporaryDirectory();
+		const path = join(root, "run.lock");
+
+		await expect(
+			acquireProcessLock(path, {
+				...fixedOptions(),
+				kernelLock: {
+					tryLock: () => {
+						throw new Error("unsupported kernel primitive");
+					},
+					unlock: () => undefined,
+				},
+			}),
+		).rejects.toMatchObject({
+			name: "ProcessLockError",
+			reason: "unavailable",
+		});
+
+		const lock = await acquireProcessLock(path, fixedOptions());
+		await lock.release();
+	});
+
+	it("closes the descriptor even if explicit unlock fails", async () => {
+		const root = await temporaryDirectory();
+		const path = join(root, "run.lock");
+		const lock = await acquireProcessLock(path, {
+			...fixedOptions(),
+			kernelLock: {
+				tryLock: (fileDescriptor) => kernelFileLock.tryLock(fileDescriptor),
+				unlock: () => {
+					throw new Error("unlock failed");
+				},
+			},
+		});
+
+		const firstRelease = lock.release();
+		expect(lock.release()).toBe(firstRelease);
+		await expect(firstRelease).rejects.toThrow("unlock failed");
+
+		const next = await acquireProcessLock(path, fixedOptions());
+		await next.release();
+	});
+
+	it("releases the kernel lock if durable owner diagnostics cannot be written", async () => {
+		const root = await temporaryDirectory();
+		const path = join(root, "run.lock");
+		const ownerPath = join(root, "run.owner.json");
+		await mkdir(ownerPath, { mode: 0o700 });
+
+		await expect(acquireProcessLock(path, fixedOptions())).rejects.toMatchObject({
+			name: "ProcessLockError",
+			reason: "unavailable",
+			message: expect.stringContaining("owner diagnostics"),
+		});
+
+		const { rm } = await import("node:fs/promises");
+		await rm(ownerPath, { recursive: true });
+		const lock = await acquireProcessLock(path, fixedOptions());
+		await lock.release();
 	});
 });
 
@@ -107,12 +268,21 @@ function fixedOptions(id = "10000000-0000-4000-8000-000000000001") {
 		pid: 42,
 		id: () => id,
 		now: () => new Date("2026-08-03T00:00:00.000Z"),
-		isProcessAlive: (pid: number) => pid === 42,
+	};
+}
+
+function legacyMetadata(pid: number) {
+	return {
+		schema_version: 1,
+		lock_id: "10000000-0000-4000-8000-000000000001",
+		pid,
+		started_at: "2026-08-03T00:00:00.000Z",
 	};
 }
 
 async function temporaryDirectory(): Promise<string> {
 	const path = await mkdtemp(join(tmpdir(), "agentrelay-node-lock-"));
-	temporaryDirectories.push(path);
-	return path;
+	const canonicalPath = await realpath(path);
+	temporaryDirectories.push(canonicalPath);
+	return canonicalPath;
 }

--- a/node/src/process-lock.ts
+++ b/node/src/process-lock.ts
@@ -1,24 +1,21 @@
 import { randomUUID } from "node:crypto";
-import { constants } from "node:fs";
-import { mkdir, open, readFile, unlink } from "node:fs/promises";
-import { dirname } from "node:path";
-import { z } from "zod";
-import { syncDirectory } from "./durable-file.js";
+import type { FileHandle } from "node:fs/promises";
+import { type KernelFileLock, kernelFileLock } from "./kernel-file-lock.js";
+import {
+	type OwnerMetadata,
+	ProcessLockError,
+	assertStableProcessLock,
+	openStableProcessLock,
+	ownerMetadataSchema,
+	readOwnerMetadata,
+	writeOwnerMetadata,
+} from "./process-lock-state.js";
 
-const lockMetadataSchema = z
-	.object({
-		schema_version: z.literal(1),
-		lock_id: z.string().uuid(),
-		pid: z.number().int().positive(),
-		started_at: z.string().datetime({ offset: true }),
-	})
-	.strict();
-
-type LockMetadata = z.infer<typeof lockMetadataSchema>;
+export { ProcessLockError } from "./process-lock-state.js";
 
 export interface ProcessLock {
 	readonly path: string;
-	readonly metadata: Readonly<LockMetadata>;
+	readonly metadata: Readonly<OwnerMetadata>;
 	release(): Promise<void>;
 }
 
@@ -26,174 +23,93 @@ export interface AcquireProcessLockOptions {
 	readonly pid?: number;
 	readonly now?: () => Date;
 	readonly id?: () => string;
-	readonly isProcessAlive?: (pid: number) => boolean;
-}
-
-export class ProcessLockError extends Error {
-	constructor(
-		readonly reason: "already_running" | "stale_lock" | "invalid_lock" | "unavailable",
-		readonly path: string,
-		message: string,
-		readonly owner?: Readonly<LockMetadata>,
-		options: ErrorOptions = {},
-	) {
-		super(message, options);
-		this.name = "ProcessLockError";
-	}
+	readonly kernelLock?: KernelFileLock;
 }
 
 export async function acquireProcessLock(
 	path: string,
 	options: AcquireProcessLockOptions = {},
 ): Promise<ProcessLock> {
-	const metadata = lockMetadataSchema.parse({
-		schema_version: 1,
+	const metadata = ownerMetadataSchema.parse({
+		schema_version: 2,
 		lock_id: (options.id ?? randomUUID)(),
 		pid: options.pid ?? process.pid,
 		started_at: (options.now ?? (() => new Date()))().toISOString(),
 	});
-	const isProcessAlive = options.isProcessAlive ?? defaultIsProcessAlive;
+	const handle = await openStableProcessLock(path);
+	const lock = options.kernelLock ?? kernelFileLock;
 
-	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-	for (let attempt = 0; attempt < 3; attempt += 1) {
-		try {
-			return await createLock(path, metadata);
-		} catch (error) {
-			if (!isAlreadyExists(error)) {
-				throw new ProcessLockError(
-					"unavailable",
-					path,
-					`Cannot acquire process lock at ${path}`,
-					undefined,
-					{
-						cause: error,
-					},
-				);
-			}
-		}
-
-		const existing = await readExistingLock(path);
-		if (existing === null) continue;
-		if (isProcessAlive(existing.pid)) {
-			throw new ProcessLockError(
-				"already_running",
-				path,
-				`AgentRelay Node is already running with PID ${existing.pid}`,
-				existing,
-			);
-		}
+	let acquired: boolean;
+	try {
+		acquired = lock.tryLock(handle.fd);
+	} catch (error) {
+		await handle.close().catch(() => undefined);
 		throw new ProcessLockError(
-			"stale_lock",
+			"unavailable",
 			path,
-			`Stale AgentRelay Node lock found for non-running PID ${existing.pid} at ${path}; remove it only after confirming no Node process is running`,
-			existing,
+			`Kernel process locking is unavailable for ${path}`,
+			undefined,
+			{ cause: error },
 		);
 	}
 
-	throw new ProcessLockError("unavailable", path, `Could not acquire process lock at ${path}`);
-}
-
-async function createLock(path: string, metadata: LockMetadata): Promise<ProcessLock> {
-	const handle = await open(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
-	try {
-		await handle.chmod(0o600);
-		await handle.writeFile(`${JSON.stringify(metadata, null, 2)}\n`, "utf8");
-		await handle.sync();
-		await syncDirectory(dirname(path));
-	} catch (error) {
+	if (!acquired) {
+		const owner = await readOwnerMetadata(path);
 		await handle.close().catch(() => undefined);
-		await unlink(path).catch(() => undefined);
-		throw error;
+		throw new ProcessLockError(
+			"already_running",
+			path,
+			owner === undefined
+				? `AgentRelay Node ownership is already held at ${path}; owner diagnostics are unavailable`
+				: `AgentRelay Node ownership is already held at ${path}; last reported owner PID ${owner.pid}`,
+			owner,
+		);
 	}
 
-	let released = false;
+	try {
+		await assertStableProcessLock(path, handle);
+		await writeOwnerMetadata(path, metadata);
+		await assertStableProcessLock(path, handle);
+	} catch (error) {
+		await handle.close().catch(() => undefined);
+		if (error instanceof ProcessLockError) throw error;
+		throw new ProcessLockError(
+			"unavailable",
+			path,
+			`Cannot write process owner diagnostics for ${path}`,
+			undefined,
+			{ cause: error },
+		);
+	}
+
+	return processLock(path, metadata, handle, lock);
+}
+
+function processLock(
+	path: string,
+	metadata: OwnerMetadata,
+	handle: FileHandle,
+	lock: KernelFileLock,
+): ProcessLock {
+	let releasePromise: Promise<void> | undefined;
 	return {
 		path,
 		metadata: Object.freeze({ ...metadata }),
-		async release(): Promise<void> {
-			if (released) return;
-			released = true;
-			await handle.close();
-
-			const current = await readExistingLock(path).catch(() => null);
-			if (current?.lock_id !== metadata.lock_id) return;
-			await unlink(path).catch((error: unknown) => {
-				if (!isNotFound(error)) throw error;
-			});
-			await syncDirectory(dirname(path));
+		release(): Promise<void> {
+			releasePromise ??= releaseKernelLock(handle, lock);
+			return releasePromise;
 		},
 	};
 }
 
-async function readExistingLock(path: string): Promise<LockMetadata | null> {
-	let raw: string;
+async function releaseKernelLock(handle: FileHandle, lock: KernelFileLock): Promise<void> {
+	let unlockError: unknown;
 	try {
-		raw = await readFile(path, "utf8");
+		lock.unlock(handle.fd);
 	} catch (error) {
-		if (isNotFound(error)) return null;
-		throw new ProcessLockError(
-			"unavailable",
-			path,
-			`Cannot read process lock at ${path}`,
-			undefined,
-			{
-				cause: error,
-			},
-		);
+		unlockError = error;
+	} finally {
+		await handle.close();
 	}
-
-	let decoded: unknown;
-	try {
-		decoded = JSON.parse(raw);
-	} catch (error) {
-		throw new ProcessLockError(
-			"invalid_lock",
-			path,
-			`Process lock at ${path} is malformed`,
-			undefined,
-			{
-				cause: error,
-			},
-		);
-	}
-	const parsed = lockMetadataSchema.safeParse(decoded);
-	if (!parsed.success) {
-		throw new ProcessLockError(
-			"invalid_lock",
-			path,
-			`Process lock at ${path} is invalid`,
-			undefined,
-			{
-				cause: parsed.error,
-			},
-		);
-	}
-	return parsed.data;
-}
-
-function defaultIsProcessAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0);
-		return true;
-	} catch (error) {
-		return !isNoSuchProcess(error);
-	}
-}
-
-function isAlreadyExists(error: unknown): boolean {
-	return errorCode(error) === "EEXIST";
-}
-
-function isNotFound(error: unknown): boolean {
-	return errorCode(error) === "ENOENT";
-}
-
-function isNoSuchProcess(error: unknown): boolean {
-	return errorCode(error) === "ESRCH";
-}
-
-function errorCode(error: unknown): string | undefined {
-	return typeof error === "object" && error !== null && "code" in error
-		? String(error.code)
-		: undefined;
+	if (unlockError !== undefined) throw unlockError;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       cac:
         specifier: ^6.7.14
         version: 6.7.14
+      fs-native-extensions:
+        specifier: 1.5.0
+        version: 1.5.0
       pino:
         specifier: ^9.5.0
         version: 9.14.0
@@ -908,6 +911,25 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  bare-addon-resolve@1.10.1:
+    resolution: {integrity: sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
+  bare-module-resolve@1.12.4:
+    resolution: {integrity: sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
+  bare-semver@1.1.0:
+    resolution: {integrity: sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
@@ -1184,6 +1206,9 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-native-extensions@1.5.0:
+    resolution: {integrity: sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1389,6 +1414,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  require-addon@1.2.0:
+    resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
+    engines: {bare: '>=1.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1620,6 +1649,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  which-runtime@1.4.0:
+    resolution: {integrity: sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2101,6 +2133,17 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  bare-addon-resolve@1.10.1:
+    dependencies:
+      bare-module-resolve: 1.12.4
+      bare-semver: 1.1.0
+
+  bare-module-resolve@1.12.4:
+    dependencies:
+      bare-semver: 1.1.0
+
+  bare-semver@1.1.0: {}
+
   body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
@@ -2366,6 +2409,13 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-native-extensions@1.5.0:
+    dependencies:
+      require-addon: 1.2.0
+      which-runtime: 1.4.0
+    transitivePeerDependencies:
+      - bare-url
+
   fsevents@2.3.3:
     optional: true
 
@@ -2542,6 +2592,12 @@ snapshots:
       unpipe: 1.0.0
 
   real-require@0.2.0: {}
+
+  require-addon@1.2.0:
+    dependencies:
+      bare-addon-resolve: 1.10.1
+    transitivePeerDependencies:
+      - bare-url
 
   require-from-string@2.0.2: {}
 
@@ -2805,6 +2861,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  which-runtime@1.4.0: {}
 
   which@2.0.2:
     dependencies:

--- a/tests/e2e/src/node-delivery.e2e.test.ts
+++ b/tests/e2e/src/node-delivery.e2e.test.ts
@@ -1,17 +1,6 @@
 import { type ChildProcess, execFile as execFileCallback, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { constants } from "node:fs";
-import {
-	lstat,
-	mkdir,
-	mkdtemp,
-	open,
-	readFile,
-	realpath,
-	rm,
-	unlink,
-	writeFile,
-} from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, realpath, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -466,7 +455,7 @@ describe("foreground Node delivery", () => {
 	}, 60_000);
 
 	it.skipIf(process.platform === "win32")(
-		"replays exactly once after operator-assisted Node recovery while its detached capsule survives",
+		"replays exactly once after direct Node restart while its detached capsule survives",
 		async () => {
 			const backend = await relay.createAgent({
 				handle: "capsule-backend@e2e",
@@ -520,11 +509,12 @@ describe("foreground Node delivery", () => {
 			const capsuleRoot = join(backendHome, "state", "capsules");
 			const missionId = randomUUID();
 			const capsuleDirectory = join(capsuleRoot, missionId);
-			const staleLockPath = join(backendHome, "run.lock");
+			const lockPath = join(backendHome, "run.lock");
 			let runningNode: TrackedNodeProcess | null = startNodeProcess(
 				backendConfigPath,
 				completionDelayMs,
 			);
+			let competingNode: TrackedNodeProcess | null = null;
 			let capsuleDescriptor: CapsuleLaunchDescriptor | null = null;
 			let socketIdentity: FileIdentity | null = null;
 			let noLaunchAdapter: PersistentFakeCapsuleAdapter | null = null;
@@ -563,10 +553,17 @@ describe("foreground Node delivery", () => {
 				if (killedPid === undefined) throw new Error("Started Node process has no PID");
 				capsuleDescriptor = await readCapsuleLaunchDescriptor(capsuleDirectory);
 				socketIdentity = await privateSocketIdentity(capsuleDescriptor.socket_path);
-				const lockIdentity = await nodeLockIdentity(staleLockPath, killedPid);
+
+				competingNode = startNodeProcess(backendConfigPath, completionDelayMs, true);
+				await expectNodeExit(competingNode, 1, "Concurrent Node start");
+				expect(competingNode.stderr).toContain("AgentRelay Node ownership is already held");
+				expect(competingNode.stderr).toContain(String(killedPid));
+				competingNode = null;
+
 				const killed = await stopNodeProcess(runningNode, "SIGKILL");
 				expect(killed).toEqual({ code: null, signal: "SIGKILL" });
 				runningNode = null;
+				expect(await lstatIfPresent(lockPath)).not.toBeNull();
 				const stateAtCrash = nodeJournalStateSchema.parse(
 					JSON.parse(await readFile(journalPath, "utf8")),
 				);
@@ -617,16 +614,7 @@ describe("foreground Node delivery", () => {
 				);
 
 				runningNode = startNodeProcess(backendConfigPath, completionDelayMs, true);
-				await expectNodeExit(runningNode, 1, "Stale-lock restart");
-				expect(runningNode.stderr).toContain(
-					`Stale AgentRelay Node lock found for non-running PID ${killedPid}`,
-				);
-				expect(runningNode.stderr).toContain(staleLockPath);
-				runningNode = null;
-
-				await reclaimKilledNodeLock(staleLockPath, killedPid, lockIdentity);
-				runningNode = startNodeProcess(backendConfigPath, completionDelayMs, true);
-				await expectNodeExit(runningNode, 0, "Operator-assisted restart");
+				await expectNodeExit(runningNode, 0, "Direct restart after SIGKILL");
 				runningNode = null;
 				const survivingSession = await noLaunchAdapter.ensureSession(capsuleDescriptor.session);
 				expect(survivingSession.sessionId).toBe(acceptedEvent.turn.sessionId);
@@ -658,9 +646,13 @@ describe("foreground Node delivery", () => {
 				expect(completionAudits).toHaveLength(1);
 			} finally {
 				try {
-					if (runningNode !== null) await stopNodeProcess(runningNode, "SIGKILL");
+					if (competingNode !== null) await stopNodeProcess(competingNode, "SIGKILL");
 				} finally {
-					await stopCapsule(noLaunchAdapter, capsuleDirectory, capsuleDescriptor, socketIdentity);
+					try {
+						if (runningNode !== null) await stopNodeProcess(runningNode, "SIGKILL");
+					} finally {
+						await stopCapsule(noLaunchAdapter, capsuleDirectory, capsuleDescriptor, socketIdentity);
+					}
 				}
 			}
 		},
@@ -971,7 +963,7 @@ function startNodeProcess(
 		stderr: "",
 		exited: new Promise((resolve, reject) => {
 			child.once("error", reject);
-			child.once("exit", (code, signal) => resolve({ code, signal }));
+			child.once("close", (code, signal) => resolve({ code, signal }));
 		}),
 	};
 	child.stdout?.setEncoding("utf8");
@@ -1110,42 +1102,6 @@ function errorCode(error: unknown): string | undefined {
 	return typeof error === "object" && error !== null && "code" in error
 		? String(error.code)
 		: undefined;
-}
-
-async function nodeLockIdentity(path: string, expectedPid: number): Promise<FileIdentity> {
-	const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
-	try {
-		const stats = await handle.stat();
-		if (!stats.isFile() || (stats.mode & 0o777) !== 0o600) {
-			throw new Error("Node lock is not a private regular file");
-		}
-		const decoded = JSON.parse(await handle.readFile("utf8")) as { pid?: unknown };
-		if (decoded.pid !== expectedPid) {
-			throw new Error(`Node lock does not belong to expected PID ${expectedPid}`);
-		}
-		return { dev: stats.dev, ino: stats.ino };
-	} finally {
-		await handle.close();
-	}
-}
-
-async function reclaimKilledNodeLock(
-	path: string,
-	killedPid: number,
-	expectedIdentity: FileIdentity,
-): Promise<void> {
-	try {
-		process.kill(killedPid, 0);
-		throw new Error(`Refusing to reclaim a lock while PID ${killedPid} is alive`);
-	} catch (error) {
-		if (errorCode(error) !== "ESRCH") throw error;
-	}
-	const current = await nodeLockIdentity(path, killedPid);
-	if (current.dev !== expectedIdentity.dev || current.ino !== expectedIdentity.ino) {
-		throw new Error("Refusing to reclaim a Node lock that changed after validation");
-	}
-	await unlink(path);
-	await syncDirectory(dirname(path));
 }
 
 async function stopCapsule(


### PR DESCRIPTION
## Summary

- replace PID-file ownership with an OS-held advisory lock on one stable, private v2 lock inode
- keep owner metadata diagnostic-only and release ownership automatically on exit, SIGKILL, or reboot
- fail closed for every legacy v1 PID lock with an explicit one-time offline migration
- prove contention, SIGSTOP, SIGKILL recovery, inode stability, and detached-child non-inheritance across real processes
- add named macOS Node 20 and 22 CI lanes and update the operator/runtime documentation

## Validation

- pnpm lint
- pnpm -r typecheck
- pnpm -r build
- pnpm --filter agentrelay-node test
- focused ownership tests on macOS Node 20 and 22
- focused ownership tests in clean glibc Linux Node 20 and 22 containers
- full AgentRelay E2E suite against isolated Postgres: 9 passed

## Boundary

This makes ownership crash-releasable. It does not install an OS service or automatically respawn the Node.

Closes #92