### PR TITLE
feat(node): add fail-closed Codex provider guardian

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,8 @@ jobs:
           pnpm --filter @agentrelay/protocol --filter relay --filter agentrelay-mcp
           --filter agentrelay-node test
 
-  node-lock-macos:
-    name: node-lock-macos (${{ matrix.node }})
+  node-process-macos:
+    name: node-process-macos (${{ matrix.node }})
     needs: lint-typecheck
     runs-on: macos-latest
     timeout-minutes: 10
@@ -123,10 +123,13 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Exercise native Node ownership
+      - run: pnpm --filter @agentrelay/protocol build
+
+      - name: Exercise native Node and guardian ownership
         run: >-
           pnpm --filter agentrelay-node exec vitest run
           src/process-lock.test.ts src/process-lock.process.test.ts
+          src/codex-provider-guardian.process.test.ts
 
   containment-linux:
     name: containment-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,12 +158,12 @@ jobs:
 
       - run: pnpm --filter @agentrelay/protocol build
 
-      - name: Prove the Linux Mission containment boundary
+      - name: Prove Linux containment and guardian owner death
         env:
           AGENTRELAY_RUN_CONTAINMENT_TESTS: '1'
         run: >-
           pnpm --filter agentrelay-node exec vitest run
-          src/runtime-containment.process.test.ts
+          src/runtime-containment.process.test.ts src/codex-provider-guardian.process.test.ts
 
   relay-image:
     needs: lint-typecheck

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@
 > has not been activated for a real model turn. A Linux-only Codex `0.146.0`
 > containment library now exists, but no Capsule descriptor or CLI selects it, its
 > recovery handle is not yet stored by the Mission lifecycle, and macOS parity,
-> production runtime supervision, and the two-machine proof remain incomplete.
+> verified local authority wiring, installed service supervision, and the two-machine
+> proof remain incomplete.
 
 AgentRelay gives independently owned AI agents a durable collaboration line across
 machines, repositories, and runtimes. They can exchange questions, contracts, and
@@ -56,7 +57,7 @@ repositories is the first proof, not the final product boundary.
 | --- | --- | --- |
 | **Shipped** | Authenticated MCP mailbox | `agentrelay-mcp` 0.2.1: identities, invites, typed handoffs, messages, blocks, trust, and audit |
 | **Shipped** | Durable Mission control plane | Relay + Postgres: Mission state, delivery leases, fencing, retries, recovery, and revocation |
-| **Experimental** | Node, persistent Capsule, and containment | Local policy, crash recovery, and an unactivated Linux containment library; current commands still select deterministic fake runtimes |
+| **Experimental** | Node, persistent Capsule, guardian, and containment | Local recovery and provider supervision libraries; current commands still select deterministic fake runtimes |
 | **Next gate** | Guarded real Codex activation | Guarded Real Mission 0 through the public pipeline, then the two-machine backend ↔ Android proof |
 
 The repository does not yet ship the full autonomous runtime described above. The
@@ -126,6 +127,16 @@ but no current descriptor or CLI activates Codex for a real model turn.
   mandatory runtime canary, and exact retained recovery manifest. Its dedicated Linux
   process gate passes; current commands still do not select it. See
   [research 006](docs/research/006-mission-workspace-containment.md).
+- An unactivated provider guardian that atomically owns one Codex generation behind a
+  stable kernel lock. Before the durable start barrier or provider spawn, its detached
+  guardian prearms an out-of-group teardown witness that retains the same lock. The
+  witness independently enforces heartbeat and deadline loss, removes the complete
+  guardian/provider process group, and is the only same-boot teardown writer of
+  durable quiescence after proving group absence. Ambiguous same-boot ownership fails
+  closed; changed kernel boot identity permits safe reboot recovery. Linux CI also
+  starts pinned Codex
+  through this guardian and the containment boundary. See
+  [research 007](docs/research/007-codex-provider-guardian.md).
 - CLI setup, invite/join, install, doctor/fix, key rotation, audit, relay-synchronized
   block/unblock, and local trust management.
 - An in-process Slack dispatcher with encrypted-at-rest webhook configuration.
@@ -139,8 +150,8 @@ but no current descriptor or CLI activates Codex for a real model turn.
   before provider start and reopens only that retained instance after a crash.
 - Complete local verification, contract-artifact carriage, and policy/evidence
   enforcement outside the model.
-- A production provider-process guardian, heartbeat/liveness ownership, complete
-  command/network mediation, and a supported containment boundary beyond Linux;
+- Mission-authority wiring for the guardian, complete command/network mediation, an
+  installed OS service boundary, and a supported containment boundary beyond Linux;
   then a Claude runtime adapter.
 - A real two-machine, two-repository proof using the public control plane.
 
@@ -158,6 +169,8 @@ The provider-neutral server and injected-runner checkpoint is recorded in
 [`Injected Codex Capsule runner`](docs/research/005-codex-capsule-runner.md).
 The Linux-first workspace boundary and its remaining activation gates are recorded in
 [`Mission workspace containment`](docs/research/006-mission-workspace-containment.md).
+The provider-generation ownership and teardown checkpoint is recorded in
+[`Codex provider guardian`](docs/research/007-codex-provider-guardian.md).
 The implementation sequence and stop/go gates are in
 [`docs/roadmap.md`](docs/roadmap.md).
 
@@ -399,7 +412,8 @@ this README does not claim full A2A conformance.
     │   ├── 003-persistent-mission-capsule.md
     │   ├── 004-codex-capsule-journal.md
     │   ├── 005-codex-capsule-runner.md
-    │   └── 006-mission-workspace-containment.md
+    │   ├── 006-mission-workspace-containment.md
+    │   └── 007-codex-provider-guardian.md
     └── rfcs/
         └── 001-agentrelay-node-and-missions.md
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> **Status:** Canonical system overview as of 2026-08-16.
+> **Status:** Canonical system overview as of 2026-08-17.
 > Current implementation details live in [`hld.md`](hld.md) and
 > [`lld.md`](lld.md). The accepted next target lives in
 > [`RFC 001: AgentRelay Node and Missions`](rfcs/001-agentrelay-node-and-missions.md),
@@ -15,6 +15,8 @@
 > and [`Injected Codex Capsule runner`](research/005-codex-capsule-runner.md). The
 > Linux-first runtime boundary is recorded in
 > [`Mission workspace containment`](research/006-mission-workspace-containment.md).
+> The provider-generation ownership boundary is recorded in
+> [`Codex provider guardian`](research/007-codex-provider-guardian.md).
 
 ## Product thesis
 
@@ -72,13 +74,15 @@ durable coordination foundations:
   retires the running server generation. Runtime shutdown starts while admitted
   handlers drain, and detached background work can request retirement.
 - An unactivated Codex library checkpoint with a pinned guarded app-server client, a
-  schema-v2 durable journal, and an injected runner. It publishes a stable logical
-  turn before provider binding and reconciles an uncertain start only in a fresh
-  provider generation after an injected quiescence assertion. Tests traverse the real
-  Unix wire with fake app-server clients. For an inherited uncertain interrupt, the
-  fresh generation reads the exact intent once, preserves a terminal provider outcome
-  when present, or records a transient failure without a second interrupt. Tests do
-  not execute a model turn.
+  schema-v2 durable journal, an injected runner, and a provider guardian. The guardian
+  owns one kernel-locked generation and prearms an out-of-group teardown witness before
+  writing the start barrier or spawning the provider. The witness retains the lock,
+  independently observes heartbeat and deadline loss, proves the guardian/provider
+  group absent, and alone records same-boot teardown quiescence. The runner uses that
+  fresh-generation proof to reconcile uncertain starts and inherited interrupts
+  without replay. Tests traverse the real Unix wire with fake app-server clients; the
+  Linux process gate also starts pinned Codex through the guardian and containment
+  boundary. No test executes a model turn.
 - An unactivated Linux containment library for Codex `0.146.0`. It binds an
   owner-controlled standalone checkout to an explicit Bubblewrap filesystem policy,
   mandatory runtime canary, and exact retained recovery manifest. Its dedicated Linux
@@ -95,12 +99,12 @@ system does not contain:
 
 - A production-activated coding-agent path. The persistent CLI still hosts only the
   deterministic fake runtime; the Codex runner has no descriptor/CLI selection,
-  production guardian, service supervisor, heartbeat, or real-turn proof.
+  verified Mission-authority input, service supervisor, or real-turn proof.
 - Automatic worktree isolation, complete command/network mediation, or local
   verification and contract-acknowledgement handlers.
-- Production wiring that composes the Linux containment library with a Codex
-  descriptor, durably stores its exact recovery handle before provider start, and
-  gives a guardian ownership of provider generation and owner-death behavior.
+- Production wiring that composes the guardian and Linux containment library with a
+  Codex descriptor, durably stores its exact recovery handle before provider start,
+  and continuously supplies verified Mission authority.
 - A supported containment boundary outside Linux. macOS explicitly fails closed in
   this checkpoint.
 - A real two-machine execution proof through the public control plane.
@@ -181,9 +185,11 @@ part of the correctness boundary.
 The Codex adapter library now implements this interface behind the provider-neutral
 Capsule server. Its child environment is allowlisted, and its home is derived locally
 beneath the Capsule and revalidated as canonical, current-user-owned, and exactly mode
-0700. Before a client is created, an injected recovery authority must assert that the
-previous provider generation is quiescent. That assertion is a seam for a future
-guardian, not current production ownership or process-death proof.
+0700. `CodexProviderGuardian.openGeneration()` atomically owns the kernel lock,
+durable generation barrier, provider spawn, Capsule-owner heartbeat, deadline,
+revocation, and process-group teardown. A runner receives that owned generation only
+after the guardian has armed a detached teardown witness, written the barrier, and
+started the provider.
 
 The separate Node-owned containment library can wrap both the pinned Codex version
 probe and app-server spawn on Linux. Its returned recovery handle is local authority,
@@ -257,8 +263,8 @@ normalized authoritatively, while an absent or still-running turn becomes a boun
 transient `failed` result because the prior provider was already proven quiescent.
 
 This is a library and fault-harness checkpoint. The fake Capsule descriptor and CLI
-remain unchanged, the quiescence proof is injected rather than guardian-owned, and no
-real Codex model turn has crossed the Mission delivery path.
+remain unchanged, and the guardian boundary's detached reaper is the authoritative
+quiescence finalizer. No real Codex model turn has crossed the Mission delivery path.
 
 ## Delivery semantics
 
@@ -307,8 +313,8 @@ advisory, and an SSE write or open connection never counts as processed.
 The unactivated Codex journal extends the same local rule to the pre-provider-binding
 window: schema v2 exposes a stable logical turn immediately, persists the exact
 provider intent before `turn/start`, and only reconciles in a fresh provider
-generation after the quiescence assertion. Schema-v1 development files are not
-migrated by this checkpoint.
+generation after the witness has finalized matching prior-generation quiescence.
+Schema-v1 development files are not migrated by this checkpoint.
 
 ## Security model
 
@@ -338,6 +344,11 @@ Remote agent content is untrusted data. The receiving owner controls local autho
   running server generation. Concurrent runtime close fences admitted work, and a
   detached driver failure requests retirement. These apply only to the unactivated
   Codex library path.
+- Kernel-locked provider-generation ownership with a private redacted lifecycle
+  record, owner heartbeat, absolute deadline, local revocation signal, provider exit
+  and request-timeout observation, reboot-gated recovery, and an out-of-group witness
+  that records quiescence only after process-group teardown. This is an unactivated
+  guardian library, not verified Mission authority.
 - A Linux-only, fail-closed Codex containment library. This is library capability,
   not an active Mission security claim.
 - Static recommended host permission configuration.
@@ -358,8 +369,9 @@ Remote agent content is untrusted data. The receiving owner controls local autho
   a network write and a local file write together.
 - An allowed AgentRelay send tool can become an exfiltration path unless outbound
   content and artifact policy are bounded.
-- The Codex recovery authority is only an injected quiescence assertion. There is no
-  production guardian that atomically owns proof plus spawn or heartbeat/watchdog.
+- The guardian's deadline and revocation inputs are not yet derived from continuously
+  verified Mission lease, fence, expiry, and revocation state. Local commands,
+  network effects, and other side effects are not completely mediated.
 - The Linux containment boundary is not selected by the Capsule/Node CLI, and the
   Mission lifecycle does not durably store its exact recovery handle. Its dedicated
   Linux process proof passes as library-level evidence, but that does not activate a
@@ -396,10 +408,13 @@ foreground process today. It can launch detached fake Mission Capsules that outl
 normal Node exit or `SIGKILL`. Its kernel-held singleton ownership is released on
 process death, so a replacement Node can restart directly and recover the same
 Capsule turn. No OS service manager currently installs, monitors, or automatically
-respawns that foreground process, and real-runtime Capsule activation remains target
-behavior. The provider-neutral server and injected Codex runner do not change which
-runtime the current CLI launches. The same is true of the Linux containment library:
-it is not composed into that launch path, and no service lifecycle stores its
+respawns that foreground process. The detached provider guardian and its independent
+teardown witness handle Capsule-plus-guardian loss as long as the witness survives.
+Loss of the witness or every local lifecycle owner fails closed; an installed
+service/cgroup boundary is still needed for restart, upgrade, rollback, and descendants
+that escape the supervised process group (#120). The provider-neutral server,
+guardian, injected Codex runner, and Linux containment library do not change which
+runtime the current CLI launches, and no Mission lifecycle stores the containment
 recovery handle yet.
 
 A sleeping or powered-off machine remains offline. The relay queues work and the Node
@@ -424,6 +439,8 @@ processes it after reconnecting.
   provider-neutral server, schema-v2 turn lifecycle, and wire-level fake-client proof.
 - [`Mission workspace containment`](research/006-mission-workspace-containment.md):
   Linux-only workspace policy, retained recovery identity, and activation gates.
+- [`Codex provider guardian`](research/007-codex-provider-guardian.md): kernel-locked
+  provider ownership, liveness, authority inputs, and teardown-witness proof.
 - [`roadmap.md`](roadmap.md): implementation order and stop/go gates.
 - [`auto-mode.md`](auto-mode.md) and [`ambient-agent.md`](ambient-agent.md):
   superseded explorations retained as decision records.
@@ -436,9 +453,9 @@ they disagree, document the gap; do not present the target as already shipped.
 - **Agent:** a logical network identity owned by a person or organization.
 - **Node:** a separately authenticated relay device identity plus an experimental
   foreground daemon that launches detached fake Mission Capsules. Its library also
-  contains an unactivated provider-neutral Capsule/Codex path and Linux containment
-  boundary; in the target, it is a supervised persistent per-device execution
-  boundary.
+  contains an unactivated provider-neutral Capsule/Codex path, provider guardian, and
+  Linux containment boundary; in the target, it is a supervised persistent per-device
+  execution boundary.
 - **Workspace binding:** a relay-visible logical alias and repository/base-ref
   constraint that the current Node maps locally to an approved checkout.
 - **Runtime adapter:** host-specific control of a coding-agent session.

--- a/docs/hld.md
+++ b/docs/hld.md
@@ -1,8 +1,8 @@
 # High-level design: current relay implementation
 
-> **Scope:** Current repository implementation as of 2026-08-16.
+> **Scope:** Current repository implementation as of 2026-08-17.
 > This document describes the existing handoff plane, public Mission delivery
-> control plane, experimental Node, and unactivated Codex Capsule libraries.
+> control plane, experimental Node, and unactivated Codex runtime libraries.
 > It does not describe a complete autonomous coding runtime. See
 > [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md) for the target system.
 
@@ -17,11 +17,13 @@ Humans or active agent sessions still initiate mailbox checks. Separately, the
 foreground `agentrelay-node` command can use a pre-issued Node credential, accept a
 Mission assignment, durably lease one turn, and drive either an in-process fake
 adapter or a detached persistent fake Mission Capsule. A provider-neutral Capsule
-server and injected Codex runner now exist behind that wire as a tested library
-checkpoint, but the descriptor and CLI still choose the fake. No current command
-activates a real model turn or turns Mission work into repository changes. A separate
-Linux-only containment library can construct the pinned Codex `0.146.0` Bubblewrap
-boundary, but no Mission lifecycle or runtime descriptor selects it.
+server, injected Codex runner, and provider guardian now exist behind that wire as a
+tested library checkpoint, but the descriptor and CLI still choose the fake. The
+guardian owns provider-generation spawn and live supervision; its prearmed detached
+witness owns post-absence quiescence finalization. No current command activates a real
+model turn or turns Mission work into repository changes. A separate Linux-only
+containment library can construct the pinned Codex `0.146.0` Bubblewrap boundary, but
+no Mission lifecycle or runtime descriptor composes it with the guardian.
 
 ## Components
 
@@ -42,7 +44,11 @@ agentrelay-node -> atomic local journal
         |-- in-process deterministic fake adapter
         `-- private Unix socket -> provider-neutral Capsule server
                                       |-- selected today: deterministic fake
-                                      `-- tested only: injected Codex runner + fake client
+                                      `-- tested only: injected Codex runner
+                                               -> detached guardian process group
+                                                  |-- pinned provider + descendants
+                                                  `-- spawns detached teardown witness
+                                                      outside the process group
 
 Unactivated Linux composition:
 owner-prepared checkout -> containment library -> pinned Codex sandbox/app-server
@@ -120,21 +126,28 @@ The wire server is now provider-neutral and accepts a locally injected runtime w
 preserving the fake descriptor, CLI entry point, and versioned request/response
 contract. The library also contains a `CodexCapsuleRunner` with probe, session,
 start/recover, event, and cancellation behavior. Its schema-v2 journal exposes a
-stable logical turn before a provider ID is known. A fresh provider generation may
-reconcile an uncertain start only after an injected authority has asserted the prior
-generation is quiescent. Unexpected internal runtime failures are redacted and retire
-the running server generation. Runtime shutdown starts concurrently with handler
-drain so `close()` can release and fence admitted work; detached background work can
-request the same retirement through the runtime lifecycle.
+stable logical turn before a provider ID is known. `CodexProviderGuardian` gives the
+runner one fresh generation only after it owns the stable kernel lock, durable start
+barrier, provider process group, owner heartbeat, deadline, and revocation watchdog.
+Before the barrier, the guardian prearms a detached witness outside its process group;
+the witness holds the same lock and is the only same-boot teardown process that records
+quiescence after proving the entire guardian/provider group absent.
+Unexpected internal runtime failures are redacted and retire the running server
+generation. Runtime shutdown starts concurrently with handler drain so `close()` can
+release and fence admitted work; detached background work can request the same
+retirement through the runtime lifecycle.
 
-This Codex path is tested through the real Unix wire with fake app-server clients. It
-has no descriptor/CLI selection, production process guardian, heartbeat, real
-model-turn proof, or Claude equivalent. The Codex child environment is allowlisted,
-and its private home is derived locally beneath the Capsule and revalidated as
-canonical, current-user-owned, and exactly mode 0700. For an inherited uncertain-
-interrupt barrier, a fresh generation reads the exact intent once, persists a
-terminal provider outcome when present, or records a transient failure without
-resending the interrupt.
+This Codex path is tested through the real Unix wire with fake app-server clients. Its
+guardian tests use real OS process trees, and the Linux process gate starts pinned
+Codex through the guardian and containment boundary without executing a model turn.
+It has no descriptor/CLI selection, verified Mission-authority input, real model-turn
+proof, or Claude equivalent. The Codex child environment is allowlisted, and its
+private home is derived locally beneath the Capsule and revalidated as canonical,
+current-user-owned, and exactly mode 0700. For an inherited uncertain-interrupt
+barrier, a fresh generation reads the exact intent once, persists a terminal provider
+outcome when present, or records a transient failure without resending the interrupt.
+Detailed guardian mechanics live in
+[research 007](research/007-codex-provider-guardian.md).
 
 The separate Linux containment library binds an owner-controlled standalone checkout
 to an explicit Bubblewrap policy, mandatory runtime canary, and private
@@ -279,6 +292,11 @@ and the relay-owned idempotency key is not exposed to the model.
   schema-v2 journal, stable pre-binding turn, exact fresh-generation reconciliation,
   bounded zero-match terminalization, pre-binding cancellation, and conservative
   inherited-interrupt terminalization are durable.
+- At that same unactivated boundary, a stable kernel lock excludes overlapping
+  generations. The guardian supervises owner/provider liveness, deadline, and local
+  revocation. Its prearmed out-of-group witness terminates and proves the process group
+  absent, then authoritatively records durable quiescence; the Capsule waits for that
+  proof before releasing replacement authority.
 - At a second unactivated library boundary, the exclusive Linux Codex containment
   manifest durably binds the workspace, pinned runtime, private paths, policy grant,
   and `retain_for_review` decision. The API returns an exact recovery handle, but the
@@ -299,8 +317,8 @@ and the relay-owned idempotency key is not exposed to the model.
 - Automatic Node installation, OS service supervision, or process respawn. The
   singleton kernel lock now permits direct restart after process death, but it does
   not start the replacement Node.
-- A production guardian that owns provider quiescence proof and spawn, heartbeat and
-  owner-death recovery.
+- Continuously verified Mission lease/fence/expiry/revocation inputs for the guardian
+  and complete local capability enforcement around every side effect.
 - Descriptor/CLI and Mission-lifecycle wiring for the Linux containment boundary,
   including durable storage of its exact recovery handle before provider start. The
   dedicated Linux process proof passes, but macOS has no supported equivalent.
@@ -363,11 +381,18 @@ section of [`architecture.md`](architecture.md).
   runtime close while handlers drain so the runtime can release and fence admitted
   operations. Detached runtime work can call `lifecycle.retire()` to trigger the same
   teardown.
-- The unactivated Codex runner creates its client only after an injected authority
-  asserts the previous provider generation is quiescent. It then resolves an
-  uncertain `turn/start` by an exact client-ID and text match or a bounded durable
-  zero-match terminal result, never by resending. There is no production authority
-  implementation, and schema-v1 development state is not migrated to schema v2. If
+- The unactivated Codex guardian prearms an out-of-group teardown witness before it
+  writes `spawn_maybe_started` or spawns the provider. Capsule loss, guardian loss,
+  provider exit, request timeout, deadline, revocation, and explicit shutdown converge
+  through one latched cause. The witness sends bounded TERM/KILL to the complete
+  guardian/provider group, proves it absent, then records quiescence and closes its
+  inherited lock. The Capsule independently proves absence, waits for that matching
+  record, and only then releases its lock. Capsule-plus-guardian death therefore
+  converges while the witness survives. Witness loss or loss of every lifecycle owner
+  fails closed; installed service/cgroup recovery and escaped descendants remain #120.
+- The runner resolves an uncertain `turn/start` in the guardian-owned fresh generation
+  by an exact client-ID and text match or a bounded durable zero-match terminal result,
+  never by resending. Schema-v1 development state is not migrated to schema v2. If
   that fresh generation inherits `interrupt_maybe_sent`, it performs one exact-intent
   read, persists an exact terminal outcome when present, or records a transient
   failure without issuing a second interrupt.
@@ -422,10 +447,12 @@ The mailbox remains a compatibility and inspection surface. The relay exposes a
 separate, authenticated Mission and delivery control plane without stretching the
 handoff row into a scheduler. The foreground Node now consumes one turn through that
 API with either an in-process fake or a detached persistent fake Capsule. A pinned
-Codex client and injected runner now pass the provider-neutral Capsule wire with fake
-app-server clients, and a Linux-only containment library now defines the workspace
-boundary. Its dedicated Linux process proof passes; both runtime libraries remain
-unactivated. The next gates are contract/artifact carriage, guardian and local
-capability enforcement, descriptor/CLI composition with durable recovery-handle
-storage, structured execution evidence, and Guarded Real Mission 0 through the public
-pipeline. The two-machine proof follows; see the roadmap for the dependency order.
+Codex client, injected runner, and provider guardian now pass the provider-neutral
+Capsule boundary with fake app-server clients, and a Linux-only containment library
+now defines the workspace boundary. Its dedicated Linux process proof starts pinned
+Codex through both unactivated boundaries. The next gates are contract/artifact
+carriage, verified local capability enforcement, descriptor/CLI composition with
+durable recovery-handle storage, structured execution evidence, and Guarded Real
+Mission 0 through the public pipeline. Installed service/cgroup containment,
+witness/all-owner loss, escaped descendants, and restart/upgrade/rollback remain #120.
+The two-machine proof follows; see the roadmap for the dependency order.

--- a/docs/lld.md
+++ b/docs/lld.md
@@ -1,6 +1,6 @@
 # Low-level design: current relay contracts
 
-> **Scope:** Current repository implementation as of 2026-08-16.
+> **Scope:** Current repository implementation as of 2026-08-17.
 > This is a compact source-oriented reference, not a promise that planned fields or
 > routes exist. Unimplemented local Node runtime behavior remains in
 > [`RFC 001`](rfcs/001-agentrelay-node-and-missions.md).
@@ -13,7 +13,7 @@
 ├── protocol/            Mission schemas, coordinator, fixtures, and adapter contract
 ├── relay/               Hono, Drizzle, Postgres relay
 ├── mcp-server/          agentrelay-mcp package and agentrelay CLI
-├── node/                Node, Capsule wire, fake runtime, and unactivated Codex path
+├── node/                Node, Capsule wire, fake runtime, and unactivated Codex boundaries
 ├── tests/e2e/           relay, MCP, Node, and detached-Capsule process harnesses
 ├── docs/                product, implementation, operations, and RFC docs
 ├── docker-compose.yml   Postgres dev service and self-host relay profile
@@ -24,12 +24,14 @@ The private `agentrelay-node` workspace now provides a foreground daemon and dur
 consumer for fake-adapter turn deliveries. It validates local workspace/policy state,
 journals discovery and operation intent, and can recover exact host events from an
 independently persistent fake Mission Capsule after the Node process is killed. There
-is now a provider-neutral Capsule server and injected Codex runner library, but no
-descriptor or CLI activates it and no test executes a real model turn. There is also
-no contract-acknowledgement or verification-delivery handler, so this still does not
+is now a provider-neutral Capsule server, injected Codex runner, and provider guardian
+library, but no descriptor or CLI activates them and no test executes a real model
+turn. The guardian owns generation spawn and live supervision; its prearmed detached
+reaper owns teardown proof and post-absence quiescence. There is also no
+contract-acknowledgement or verification-delivery handler, so this still does not
 prove execution on two machines. A Linux-only Codex containment library now exists,
-and its dedicated process test passes. It remains unactivated because no descriptor,
-CLI, or Mission lifecycle selects it.
+and its dedicated process test starts pinned Codex through both unactivated boundaries.
+No descriptor, CLI, or Mission lifecycle selects them.
 
 ## Protocol workspace
 
@@ -436,14 +438,16 @@ restart is automatic only after repeated failed authenticated probes and
 ownership-safe removal of the same unchanged stale socket inode. The server binds
 through a private alias so closing an old process cannot unlink a replacement socket.
 
-### Unactivated Codex Capsule library
+### Unactivated Codex Capsule, provider guardian, and teardown-reaper libraries
 
 `CodexCapsuleRunner` implements the same runtime-neutral server contract with an
-injected `CodexCapsuleClient` and `CodexRecoveryAuthority`. It implements probe,
-session start/resume, turn start/recovery, one provider-notification consumer,
-cancellation, and durable event streaming. Tests open it through the real private
-Unix wire using fake app-server clients. `agentrelay-node` and `agentrelay-capsule` do
-not construct it.
+owned `CodexProviderGeneration` supplied by
+`SupervisedCodexProviderGuardian.openGeneration()`. It implements probe, session
+start/resume, turn start/recovery, one provider-notification consumer, cancellation,
+and durable event streaming. Tests open it through the real private Unix wire using
+fake app-server clients. `agentrelay-node` and `agentrelay-capsule` do not construct
+this composition; `agentrelay-codex-guardian` is only its internal child-process entry
+point, including its private `--reaper` mode.
 
 `CodexCapsuleStore` schema v2 records a stable AgentRelay turn reference and its first
 `accepted` event during `prepareTurn`, before `turn/start` or a provider turn ID. The
@@ -452,14 +456,15 @@ exact validated `StartTurnInput`, derived prompt/schema, hashes, and determinist
 start coalesces on that logical turn; a changed duplicate conflicts. Schema-v1
 development state has no migration and is rejected.
 
-`CodexCapsuleRunner.open` requires the injected recovery authority to assert
-`provider_generation_start` quiescence before it calls the client factory. Therefore
-an unresolved start is inspected only from a fresh provider generation. Reconciliation
-reads the bound thread and accepts exactly one turn whose client ID and text match the
-persisted intent. A bounded zero match is durably terminalized as `failed`, or
-`cancelled` when cancellation was already requested; it never resends. Cancellation
-before provider binding survives reconciliation and produces one interrupt after the
-provider turn is found. If a later fresh generation inherits
+`CodexCapsuleRunner.open` obtains one generation from the guardian boundary. Therefore
+an unresolved start is inspected only after the guardian has excluded or reconciled
+its predecessor, armed the detached reaper, and started the new generation.
+Reconciliation reads the bound thread and
+accepts exactly one turn whose client ID and text match the persisted intent. A
+bounded zero match is durably terminalized as `failed`, or `cancelled` when
+cancellation was already requested; it never resends. Cancellation before provider
+binding survives reconciliation and produces one interrupt after the provider turn
+is found. If a later fresh generation inherits
 `interrupt_maybe_sent`, it does not repeat the interrupt. It reads the exact intent
 once: an exact terminal turn is normalized and persisted authoritatively, while an
 absent or still-`inProgress` turn becomes a redacted transient failure because the
@@ -475,10 +480,34 @@ otherwise allowlisted child environment. That client boundary alone does not pro
 filesystem isolation; the separate containment library below must wrap its process
 boundary on Linux.
 
-The recovery authority is only an interface supplied by tests. There is no production
-guardian that atomically owns quiescence proof and provider spawn, no durable provider
-generation owner or heartbeat, no descriptor/CLI wiring, and no real model-turn
-evidence.
+The guardian uses the stable `provider.lock` inode as kernel authority and writes
+bounded private lifecycle evidence to `provider-generation.json`. Its phases are
+`spawn_maybe_started`, `running`, `stop_requested`, and `quiescent`; the record also
+contains the Capsule and generation IDs, kernel boot-session ID, absolute deadline,
+last owner heartbeat, authoritative teardown cause, and one of `stopped`, `crashed`, or
+`unresponsive`. It contains no PID, path, prompt, provider turn ID, stderr, or secret.
+
+The Capsule retains the lock while a detached guardian inherits a validated duplicate
+and a private control channel. Before writing the start barrier or spawning the raw
+provider, the guardian starts a second detached process outside its process group. This
+teardown witness validates and retains the same lock descriptor; the raw provider never
+receives it. Both guardian and witness arm the absolute deadline and observe Capsule
+heartbeats before `ready`, while the guardian owns the provider process group.
+
+Provider exit, request timeout, local authority abort, deadline, heartbeat loss, or
+explicit shutdown latches one stop cause. The witness sends `SIGTERM` to the complete
+guardian/provider group, waits the bounded grace, escalates to group `SIGKILL`, and
+polls until the group is absent. Only then may it authoritatively write matching
+`quiescent` state and close its inherited lock. The Capsule independently proves group
+absence, waits for that durable matching state, and only then releases its own lock and
+settles termination. A same-boot non-quiescent predecessor fails closed, while a
+changed kernel boot-session ID safely reconciles state left by a host reboot.
+
+This still has no production descriptor/CLI wiring, verified Mission-authority input,
+installed service supervisor, or real model-turn evidence. Capsule-plus-guardian death
+converges if the witness survives. Loss of the witness or every local lifecycle owner,
+service restart/upgrade/rollback, cgroup containment, and descendants that escape the
+supervised process group remain #120.
 
 ### Unactivated Linux containment library
 
@@ -633,6 +662,7 @@ pnpm install --frozen-lockfile --package-import-method=copy
 pnpm --filter @agentrelay/protocol build
 AGENTRELAY_RUN_CONTAINMENT_TESTS=1 \
   pnpm --filter agentrelay-node exec vitest run \
+  src/codex-provider-guardian.process.test.ts \
   src/runtime-containment.process.test.ts
 ```
 
@@ -662,10 +692,12 @@ Do not extend `accepted_by_session` or the four-state handoff table into a distr
 runtime scheduler. Nodes, credentials, workspace bindings, Missions, events, and
 deliveries have a separate model and public control plane. The local Node now proves
 both the journaled in-process fake-turn boundary and detached fake-Capsule recovery
-after Node-process death. The provider-neutral server and injected Codex runner add an
-unactivated wire-level checkpoint; the Linux containment library adds an unactivated
-workspace boundary with exact retained recovery identity and a passing Linux process
-proof. The next gates are contract/verification and artifact carriage, guardian and
-local capability enforcement, descriptor/CLI composition with durable handle
-storage, structured execution evidence, Guarded Real Mission 0, and finally the
-two-machine proof. The mailbox API remains a compatibility and inspection surface.
+after Node-process death. The provider-neutral server, injected Codex runner, and
+provider guardian/reaper add an unactivated wire/process checkpoint; the Linux containment
+library adds an unactivated workspace boundary with exact retained recovery identity
+and a passing Linux process proof. The next gates are contract/verification and
+artifact carriage, verified local capability enforcement, descriptor/CLI composition
+with durable handle storage, structured execution evidence, Guarded Real Mission 0,
+and finally the two-machine proof. Installed service/cgroup containment,
+witness/all-owner loss, escaped descendants, and restart/upgrade/rollback remain #120. The
+mailbox API remains a compatibility and inspection surface.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -135,9 +135,10 @@ through the public control plane.
   `run.owner.json` PID metadata as diagnostic, keep the `run.lock` inode permanently
   in place, never steal ownership on a heartbeat timeout, and fail closed on every
   legacy schema-1 PID lock until an explicit offline migration.
-- [ ] Package the Node as an installed background service with OS supervision and
-  automatic process respawn. Crash-releasable ownership makes restart safe; it does
-  not start the replacement process.
+- [ ] Package the Node as an installed background service with OS/cgroup supervision
+  (#120), automatic process respawn, bounded restart/upgrade/rollback, and cleanup for
+  witness/all-owner loss or descendants that escape the supervised process group.
+  Crash-releasable ownership makes restart safe; it does not start the replacement.
 
 Start with one eligible Node per logical agent and one active turn per Mission. The
 Capsule path is experimental and Unix-only; it is not yet an installed background
@@ -162,7 +163,7 @@ service.
   one event consumer, cancellation, and recovery. Exercise it through the real
   Capsule Unix wire using fake app-server clients; this is not production activation.
 - [x] Reconcile an ambiguous `turn/start` by exact `clientUserMessageId` and text only
-  in a fresh provider generation after a mandatory injected quiescence proof. Carry
+  in a fresh guardian-owned provider generation. Carry
   cancellation across pre-binding recovery, durably terminalize a bounded zero match,
   and never resend an uncertain start.
 - [x] Resolve an inherited `interrupt_maybe_sent` barrier only in the fresh provider
@@ -180,9 +181,14 @@ service.
   fail-closed rather than claiming parity.
 - [ ] Complete contract/verification delivery handling and bounded provenance-marked
   Mission artifact carriage.
-- [ ] Add a production guardian for provider generations, heartbeat, teardown, and
-  quiescence proof; then enforce local capability grants outside the model.
-- [ ] Wire an explicit Codex descriptor/runtime factory into the Capsule and Node CLI.
+- [x] Add a provider guardian that atomically owns one kernel-locked generation,
+  heartbeat and provider liveness, absolute deadline, local revocation, a prearmed
+  out-of-group teardown witness, and durable quiescence only after process-group
+  absence (#96).
+- [ ] Continuously derive guardian authority and enforce local capability grants
+  outside the model (#97).
+- [ ] Wire an explicit Codex descriptor/runtime factory into the Capsule and Node CLI
+  (#98).
   Before provider start, durably store `{manifestPath, instanceId, bindingSha256}` and
   recover only that exact containment instance.
 - [ ] Require the RFC's structured turn dispositions and bounded local execution

--- a/docs/research/004-codex-capsule-journal.md
+++ b/docs/research/004-codex-capsule-journal.md
@@ -2,7 +2,9 @@
 
 - **Date:** 2026-08-03
 - **Status:** Client and journal implemented; the unactivated runner continuation is
-  recorded in [`005-codex-capsule-runner.md`](005-codex-capsule-runner.md).
+  recorded in [`005-codex-capsule-runner.md`](005-codex-capsule-runner.md), and its
+  guardian is recorded in
+  [`007-codex-provider-guardian.md`](007-codex-provider-guardian.md).
 - **Runtime:** Codex app-server `0.146.0`, read-only policy only.
 - **Scope:** Provider protocol validation, process ownership, durable local correlation,
   structured-output normalization, and crash-window design. No real Mission activation.
@@ -109,12 +111,14 @@ local cancellation intent exists.
 
 The stable local turn remains discoverable and cancellable before provider binding.
 Pre-binding cancellation survives reconciliation and produces one interrupt after an
-exact provider match. The quiescence authority is only an injected seam: there is no
-production guardian that owns proof and process spawn as one lifecycle. If a fresh
-generation inherits `interrupt_maybe_sent`, the runner does not send it again. It
-reads the exact intent once, persists an exact terminal provider outcome when present,
-or records a redacted transient failure and releases the active-turn slot. A rejection
-of the first interrupt RPC retires that provider generation before this recovery.
+exact provider match. At this journal checkpoint, quiescence authority was only an
+injected seam. Research 007 records the later guardian boundary: the guardian owns
+spawn and live supervision while its detached reaper owns final quiescence proof. If a
+fresh generation inherits `interrupt_maybe_sent`, the
+runner does not send it again. It reads the exact intent once, persists an exact
+terminal provider outcome when present, or records a redacted transient failure and
+releases the active-turn slot. A rejection of the first interrupt RPC retires that
+provider generation before this recovery.
 
 ## Evidence
 
@@ -146,12 +150,10 @@ installed `0.146.0` app-server handshake; it does not execute a Mission turn.
 
 ## Activation blockers
 
-Do not wire this checkpoint to a real delivery until all of these are true:
+The provider-generation guardian, detached teardown reaper, and their revocation,
+deadline, liveness, and teardown race proofs are now implemented in research 007. Do
+not wire this checkpoint to a real delivery until the remaining gates are true:
 
-- a production guardian owns provider-generation identity, quiescence proof, and
-  spawn, with heartbeat and owner-death evidence;
-- revocation, deadline, and process-death races have fault tests and closed recovery
-  rules against a real provider;
 - the Linux containment library is composed into the selected descriptor/CLI path,
   and the Mission lifecycle durably stores its exact recovery handle before provider
   start;
@@ -164,7 +166,7 @@ Do not wire this checkpoint to a real delivery until all of these are true:
 - Guarded Real Mission 0 passes before the two-machine Mission proof begins.
 
 The Linux containment process gate now passes. The remaining dependency order,
-through contract/artifact carriage, guardian/descriptor composition, and Guarded Real
-Mission 0, lives in the [roadmap](../roadmap.md). Research 005 records what the
-current injected runner proves; research 006 records containment and its lifecycle
-gates.
+through contract/artifact carriage, capability/descriptor composition, and Guarded
+Real Mission 0, lives in the [roadmap](../roadmap.md). Research 005 records the
+injected runner, research 006 records containment, and research 007 records the
+guardian and its remaining activation gates.

--- a/docs/research/004-codex-capsule-journal.md
+++ b/docs/research/004-codex-capsule-journal.md
@@ -96,12 +96,13 @@ durable state or returned events. Per-turn usage uses `tokenUsage.last`, not the
 thread-wide total. An interrupted provider turn becomes `cancelled` only when a durable
 local cancellation intent exists.
 
-## Implemented crash rule
+## Crash rule at this checkpoint
 
-`clientUserMessageId` is correlation, not idempotency. The injected runner now:
+`clientUserMessageId` is correlation, not idempotency. At this journal checkpoint,
+the injected runner:
 
-1. requires a fresh provider generation and an injected assertion that the previous
-   generation is quiescent before creating the client;
+1. required a fresh provider generation and an injected assertion that the previous
+   generation was quiescent before creating the client;
 2. persists `start_maybe_sent` before invoking `turn/start`;
 3. after an uncertain result, reads the bound thread with full turns;
 4. finds exactly one user message with the persisted client ID and exact text;
@@ -109,13 +110,13 @@ local cancellation intent exists.
    a bounded zero match as `failed` or already-requested `cancelled`; and
 6. never sends a second start merely because no match is visible.
 
-The stable local turn remains discoverable and cancellable before provider binding.
-Pre-binding cancellation survives reconciliation and produces one interrupt after an
-exact provider match. At this journal checkpoint, quiescence authority was only an
-injected seam. Research 007 records the later guardian boundary: the guardian owns
-spawn and live supervision while its detached reaper owns final quiescence proof. If a
-fresh generation inherits `interrupt_maybe_sent`, the
-runner does not send it again. It reads the exact intent once, persists an exact
+The stable local turn was already discoverable and cancellable before provider
+binding. Pre-binding cancellation survived reconciliation and produced one interrupt
+after an exact provider match. Quiescence authority was only an injected seam at this
+journal checkpoint. Research 007 records the later implemented boundary:
+`CodexProviderGuardian.openGeneration()` owns spawn and live supervision while its
+detached reaper owns final quiescence proof. The current runner still does not resend
+an inherited `interrupt_maybe_sent`; it reads the exact intent once, persists an exact
 terminal provider outcome when present, or records a redacted transient failure and
 releases the active-turn slot. A rejection of the first interrupt RPC retires that
 provider generation before this recovery.

--- a/docs/research/005-codex-capsule-runner.md
+++ b/docs/research/005-codex-capsule-runner.md
@@ -81,12 +81,14 @@ This change makes lookup, replay, and cancellation possible during the pre-provi
 binding window. Schema v2 does not migrate the earlier schema-v1 development format.
 Neither format is activated by a production descriptor today.
 
-## Fresh-generation recovery invariant
+## Fresh-generation recovery invariant at this checkpoint
 
-`CodexCapsuleRunner.open` requires an injected `CodexRecoveryAuthority` to assert that
-the previous provider generation is quiescent before the client factory runs. An
-unresolved thread or turn is therefore inspected only from a fresh provider
-generation.
+At this checkpoint, `CodexCapsuleRunner.open` required an injected
+`CodexRecoveryAuthority` to assert that the previous provider generation was
+quiescent before the client factory ran. An unresolved thread or turn was therefore
+inspected only from a fresh provider generation. Research 007 records the later
+implemented contract, where `CodexProviderGuardian.openGeneration()` owns that proof
+and returns the client inside a supervised generation.
 
 For a `turn/start` whose response may have been lost, the runner:
 
@@ -115,8 +117,8 @@ If the first interrupt RPC rejects after its durable barrier, the turn driver re
 the failed generation does not continue serving or retry the interrupt.
 
 At this runner checkpoint, recovery authority was an interface supplied by the test
-harness; there was no production guardian, durable provider-generation owner, or
-owner-death proof. Research 007 records the later guardian implementation.
+harness; there was no provider guardian, durable provider-generation owner, or
+owner-death proof. Research 007 records the later unactivated guardian implementation.
 
 ## Child environment and private home
 

--- a/docs/research/005-codex-capsule-runner.md
+++ b/docs/research/005-codex-capsule-runner.md
@@ -1,7 +1,9 @@
 # Provider-neutral Capsule server and injected Codex runner
 
 - **Date:** 2026-08-03
-- **Status:** Implemented and tested as an unactivated Node library checkpoint.
+- **Status:** Implemented and tested as an unactivated Node library checkpoint; the
+  later provider guardian is recorded in
+  [`007-codex-provider-guardian.md`](007-codex-provider-guardian.md).
 - **Runtime under test:** Codex app-server `0.146.0`, read-only policy.
 - **Scope:** Capsule runtime injection, schema-v2 logical turns, exact start recovery,
   child-process input isolation, and real Unix-wire tests with fake provider clients.
@@ -112,9 +114,9 @@ If the first interrupt RPC rejects after its durable barrier, the turn driver re
 `lifecycle.retire()`. The replacement generation then follows the one-read rule above;
 the failed generation does not continue serving or retry the interrupt.
 
-The recovery authority is an interface supplied by the test harness. There is no
-production guardian that atomically owns quiescence proof and process spawn, no
-durable provider-generation owner, and no owner-death proof.
+At this runner checkpoint, recovery authority was an interface supplied by the test
+harness; there was no production guardian, durable provider-generation owner, or
+owner-death proof. Research 007 records the later guardian implementation.
 
 ## Child environment and private home
 
@@ -163,20 +165,20 @@ still handshake-only and opt-in; it does not run a Mission or a model turn.
 
 ## Nonclaims and next gate
 
-This checkpoint does not provide:
+This historical checkpoint did not provide:
 
 - production descriptor, runtime-factory, Node, or Capsule CLI wiring;
 - a real Codex model turn or two-machine Mission;
-- a production provider guardian, atomic quiescence-proof-plus-spawn ownership,
-  heartbeat, or owner-death recovery;
+- provider-generation ownership; research 007 records the later guardian plus detached
+  reaper, heartbeat, deadline/revocation, owner-death, and teardown proof;
 - OS-enforced workspace/read-root or secret containment in this runner checkpoint;
 - deadline and revocation race evidence for a real provider process;
 - structured contract proposal, acknowledgement, readiness, or registered
   verification-command handling; or
 - the complete Node policy, evidence, and supervision boundary required by RFC 001.
 
-The Linux containment process proof now passes. Contract and artifact carriage,
-guardian and capability enforcement, descriptor composition with durable handle
-storage, structured execution evidence, and Guarded Real Mission 0 remain in the
-[roadmap's dependency order](../roadmap.md). Only after that public pipeline gate
-should the two-machine proof begin.
+The Linux containment and provider-guardian process proofs now pass. Contract and
+artifact carriage, verified capability enforcement, descriptor composition with
+durable handle storage, structured execution evidence, and Guarded Real Mission 0
+remain in the [roadmap's dependency order](../roadmap.md). Only after that public
+pipeline gate should the two-machine proof begin.

--- a/docs/research/006-mission-workspace-containment.md
+++ b/docs/research/006-mission-workspace-containment.md
@@ -126,12 +126,14 @@ boundaries:
 
 The guarded Codex client now requires an external process boundary for both its
 version probe and app-server spawn, but the fake Capsule descriptor and Node CLI do
-not construct this containment boundary. No Mission lifecycle durably stores the
-returned recovery handle, no real model turn uses it, no production guardian owns the
-provider lifecycle, and no macOS equivalent exists. The dedicated Linux process job
-now proves the implemented filesystem/network canaries, dirty recovery, and pinned
-Codex version/app-server handshake. That is evidence for the unactivated library
-boundary, not an activated Mission runtime.
+not construct this containment boundary. A provider guardian plus detached teardown
+reaper now own the unactivated provider lifecycle, as recorded in
+[`research 007`](007-codex-provider-guardian.md), but no Mission lifecycle supplies
+verified authority or durably stores the returned recovery handle, no real model turn
+uses either boundary, and no macOS containment equivalent exists. The dedicated Linux
+process job now proves the implemented filesystem/network canaries, dirty recovery,
+and pinned Codex version/app-server handshake through the guardian. That is evidence
+for the unactivated libraries, not an activated Mission runtime.
 
 ## Why this is the lowest-regret first step
 
@@ -300,7 +302,7 @@ This decision changes no public HTTP, JSON-RPC, MCP, or Mission schema by itself
 8. [x] Pass the dedicated Linux process job, including the policy canaries, dirty
    recovery, and pinned app-server handshake, as library-boundary evidence.
 9. [ ] Wire the boundary into a locally selected descriptor and Mission lifecycle,
-   durably store its exact recovery handle, and execute one guardian-owned real turn.
+   durably store its exact recovery handle, and execute one guarded real turn.
 
 The smallest falsifying experiment is the dedicated Linux process test. It launches a
 trivial descendant and a pinned app-server handshake through the boundary. Any

--- a/docs/research/007-codex-provider-guardian.md
+++ b/docs/research/007-codex-provider-guardian.md
@@ -138,6 +138,10 @@ provider authority and descendants, but it does not record quiescence while the 
 Capsule has not reaped its guardian zombie. State remains `stop_requested` and the lock
 remains held until complete process-group absence becomes provable.
 
+For the POSIX group probe, only `ESRCH` proves absence. Darwin can return `EPERM` for
+a zombie-only group; the witness treats that as present but unsignalable, retains its
+lock, and keeps polling instead of either inventing quiescence or failing permanently.
+
 The final row is intentionally not inferred from PIDs. Installed service/cgroup
 containment, restart/upgrade/rollback behavior, and descendants that escape the
 supervised process group remain issue #120.
@@ -156,6 +160,8 @@ The database-free test suite covers:
 - authoritative same-generation reaper finalization without rewriting another
   generation;
 - local revocation and absolute deadline against a provider that ignores `SIGTERM`;
+- Darwin `EPERM` handling that keeps zombie-only process groups fail-closed until a
+  later probe proves absence;
 - descendant cleanup, durable authoritative-cause state, reboot-gated recovery,
   startup-error redaction, and provider environment filtering;
 - fresh-generation uncertain-start and inherited-interrupt recovery through the real

--- a/docs/research/007-codex-provider-guardian.md
+++ b/docs/research/007-codex-provider-guardian.md
@@ -1,0 +1,180 @@
+# Codex provider guardian and teardown-witness ownership
+
+- **Date:** 2026-08-17
+- **Status:** Implemented and tested as an unactivated Node library boundary.
+- **Runtime under test:** Codex app-server `0.146.0`, read-only policy.
+- **Scope:** Provider-generation ownership, liveness, deadline and revocation teardown,
+  detached witness survival, durable quiescence evidence, and process-group cleanup.
+
+## Outcome
+
+`SupervisedCodexProviderGuardian` replaces the runner's injected quiescence assertion
+with one fail-closed generation boundary for provider spawn and termination. The runner
+receives a generation, not a free-standing client, and cannot construct a second
+client while that generation is active.
+
+This is still an unactivated composition. The current Capsule descriptor and Node CLI
+select deterministic fake runtimes. No Mission lifecycle supplies verified authority,
+stores the Linux containment recovery handle, or executes a real model turn through
+this guardian.
+
+## Process boundary
+
+```text
+Node -> detached Mission Capsule (holds provider lock)
+                   |
+                   `-> detached Codex guardian process group
+                         |-- guardian -> provider process tree
+                         `-- spawns detached teardown witness outside the group
+                                      `-- holds the same lock + private state access
+```
+
+The Capsule acquires a stable, private kernel lock and duplicates that descriptor into
+the trusted guardian. Before any durable start barrier or provider spawn, the guardian
+prearms an independent teardown witness outside its process group and passes it the
+same descriptor. The raw provider never receives the lock. This three-part ownership
+keeps a cleanup owner alive across the required failures:
+
+- Capsule death leaves the guardian and witness holding the lock; owner-channel loss
+  starts teardown.
+- Guardian death leaves the Capsule and witness holding the lock; both independently
+  drive or verify process-group removal.
+- Capsule and guardian death together leaves the witness outside their process group,
+  still holding the lock and able to finish teardown.
+- Provider death is observed by the guardian, which asks the witness to clean any
+  remaining descendants.
+
+The lock file and inode remain in place. Ownership is the live kernel lock, not its
+diagnostic PID metadata.
+
+## Generation invariant
+
+One generation follows this order:
+
+1. The Capsule acquires `provider.lock` and prepares the contained version and
+   app-server commands.
+2. The detached guardian inherits and validates the exact lock descriptor, owner PID,
+   IPC channel, Capsule identity, and private state directory.
+3. The guardian starts the detached witness outside its own process group. The witness
+   validates the lock, opens the private generation store, arms the absolute deadline
+   and heartbeat watchdog, and acknowledges readiness.
+4. Only after that acknowledgement does the guardian durably write
+   `spawn_maybe_started` with a random generation ID, kernel boot-session ID, and
+   absolute deadline.
+5. The guardian arms its matching watchdogs, verifies Codex `0.146.0`, spawns the
+   provider, and records `running` before publishing `ready`.
+6. The witness latches its first stop cause and sends `SIGTERM` to the complete
+   guardian/provider process group, waits the bounded grace, escalates to group
+   `SIGKILL`, and polls until the group is absent.
+7. Within the same boot, only the surviving witness may authoritatively record
+   matching `quiescent` state; it does so after absence proof, then closes its
+   inherited lock. The Capsule independently proves group absence, waits for that
+   durable state, releases its own lock, and settles generation termination.
+
+Prearming the witness before writing the start barrier closes both the old pre-spawn
+crash window and the joint Capsule/guardian-death window. Owner death during command
+preparation or witness startup leaves no barrier and cannot admit the provider. Owner
+death after the barrier is handled by the guardian or witness under the same bounded
+generation identity.
+
+A same-boot non-quiescent predecessor always fails closed. After a host reboot, the
+kernel has terminated every old process and released every descriptor; a changed
+kernel boot-session ID is therefore sufficient to reconcile the old generation before
+creating a new one. PID age, heartbeat age, and missing files are never treated as
+quiescence proof.
+
+## Liveness and authority
+
+The guardian/reaper boundary distinguishes these local outcomes:
+
+| Evidence | Stop cause | Observation |
+| --- | --- | --- |
+| Explicit Capsule shutdown | `capsule_shutdown` | `stopped` |
+| Local authority signal aborts | `authority_revoked` | `stopped` |
+| Absolute generation deadline expires | `deadline_exceeded` | `unresponsive` |
+| Capsule heartbeats stop | `heartbeat_timeout` | `unresponsive` |
+| A provider request exceeds its response bound | `provider_unresponsive` | `unresponsive` |
+| Provider or guardian fails unexpectedly | `provider_failure` | `crashed` |
+
+The absolute deadline is part of initialization, so `ready` also acknowledges that
+both the guardian and surviving witness watchdogs are armed. Capsule heartbeats are
+forwarded to the witness; the witness therefore retains deadline and heartbeat
+authority if the guardian or Capsule disappears. A local `AbortSignal` can revoke a
+generation without a runner calling `terminate` directly. Issue #97 must still prove
+that Mission lease, fence, expiry, and revocation state are the verified sources for
+these local inputs.
+
+## Recovery behavior
+
+The guardian supplies the fresh-generation boundary used by the schema-v2 Codex
+runner:
+
+- an ambiguous `turn/start` is reconciled by exact client ID and text without resend;
+- an inherited `interrupt_maybe_sent` intent is read once and never reissued; and
+- unexpected provider termination retires the owning Capsule generation.
+
+The private `provider-generation.json` file contains only bounded lifecycle fields. It
+does not contain a PID, process path, prompt, provider turn ID, stderr, or credential.
+Provider and supervisor failures become fixed local error categories, while the
+Capsule wire exposes only its existing generic runtime failure.
+
+## Failure matrix
+
+| Failure | Result |
+| --- | --- |
+| Capsule dies before guardian spawn | No start barrier exists; the kernel releases the lock and replacement can start. |
+| Witness cannot arm | No start barrier or provider exists; startup fails and the Capsule releases ownership after proving guardian-group absence. |
+| Capsule dies during version probe or provider life | Guardian or witness observes owner loss; the witness cleans the group and records quiescence. |
+| Guardian dies while Capsule lives | Witness cleans and finalizes the group; Capsule independently proves absence before releasing ownership. |
+| Capsule and guardian die together | The out-of-group witness retains the lock, cleans the group, records quiescence, and closes ownership. |
+| Provider dies | Guardian requests teardown; the witness records a provider crash after cleaning descendants. |
+| Provider ignores revocation or deadline | Witness grace expires and process-group `SIGKILL` removes provider authority and descendants. |
+| Witness fails after the start barrier | Guardian and Capsule remove the group, but no process invents quiescence; ownership remains fail-closed until reboot or OS-owned recovery. |
+| Host reboots | Changed boot-session identity reconciles the now-dead prior generation. |
+| Witness or every local lifecycle owner is lost | Replacement fails closed unless host reboot or an OS-owned containment boundary proves cleanup. |
+
+If Capsule heartbeats stall because the Capsule itself is stopped, the witness removes
+provider authority and descendants, but it does not record quiescence while the stopped
+Capsule has not reaped its guardian zombie. State remains `stop_requested` and the lock
+remains held until complete process-group absence becomes provable.
+
+The final row is intentionally not inferred from PIDs. Installed service/cgroup
+containment, restart/upgrade/rollback behavior, and descendants that escape the
+supervised process group remain issue #120.
+
+## Evidence
+
+The database-free test suite covers:
+
+- simultaneous guardian contenders and same-instance duplicate opens;
+- preparation-time revocation and witness-arm failure without a start barrier or
+  provider spawn;
+- owner death before guardian spawn, during the version probe, and after provider
+  readiness, including continuous-output pipe failure;
+- owner heartbeat stall, guardian death, joint Capsule/guardian death on Linux,
+  provider crash, and request timeout;
+- authoritative same-generation reaper finalization without rewriting another
+  generation;
+- local revocation and absolute deadline against a provider that ignores `SIGTERM`;
+- descendant cleanup, durable authoritative-cause state, reboot-gated recovery,
+  startup-error redaction, and provider environment filtering;
+- fresh-generation uncertain-start and inherited-interrupt recovery through the real
+  private Capsule wire; and
+- pinned Codex startup through both the guardian and the real Linux containment
+  boundary in the dedicated process job.
+
+The process tests run on supported Node versions on Linux and macOS. The Linux-only
+guardian-death, joint-owner-death, and Bubblewrap proofs run in the containment job.
+
+## Remaining activation gates
+
+- **#97:** continuously validate Relay lease/fence/expiry/revocation authority and
+  translate it into the local deadline and revocation signal.
+- **#98:** select the Codex descriptor in the Capsule/Node CLI, persist the exact
+  containment recovery handle before provider start, and run Guarded Real Mission 0.
+- **#120:** install the Node as an OS-supervised service, add cgroup/process containment,
+  and close witness/all-owner loss, escaped-descendant, restart, upgrade, and rollback
+  behavior.
+
+Until those gates pass, describe this as a guardian library and process proof, not an
+autonomous Mission runtime.

--- a/docs/research/007-codex-provider-guardian.md
+++ b/docs/research/007-codex-provider-guardian.md
@@ -130,6 +130,7 @@ Capsule wire exposes only its existing generic runtime failure.
 | Provider dies | Guardian requests teardown; the witness records a provider crash after cleaning descendants. |
 | Provider ignores revocation or deadline | Witness grace expires and process-group `SIGKILL` removes provider authority and descendants. |
 | Witness fails after the start barrier | Guardian and Capsule remove the group, but no process invents quiescence; ownership remains fail-closed until reboot or OS-owned recovery. |
+| Generation state disappears or changes identity after the start barrier | Witness removes the process group but retains its kernel lock because matching-generation quiescence cannot be recorded. |
 | Host reboots | Changed boot-session identity reconciles the now-dead prior generation. |
 | Witness or every local lifecycle owner is lost | Replacement fails closed unless host reboot or an OS-owned containment boundary proves cleanup. |
 
@@ -157,6 +158,8 @@ The database-free test suite covers:
   readiness, including continuous-output pipe failure;
 - owner heartbeat stall, guardian death, joint Capsule/guardian death on Linux,
   provider crash, and request timeout;
+- missing or replaced durable generation state after provider startup, with the
+  witness retaining ownership instead of admitting a replacement;
 - authoritative same-generation reaper finalization without rewriting another
   generation;
 - local revocation and absolute deadline against a provider that ignores `SIGTERM`;

--- a/docs/rfcs/001-agentrelay-node-and-missions.md
+++ b/docs/rfcs/001-agentrelay-node-and-missions.md
@@ -2,8 +2,9 @@
 
 - **Status:** Accepted; Relay control-plane steps 1-3, the foreground Node, the
   persistent fake-Capsule recovery checkpoint, crash-releasable singleton Node
-  ownership, and an unactivated guarded Codex client/journal are implemented; runtime
-  integration and the two-machine proof remain
+  ownership, and unactivated Codex client, journal, runner, guardian, and Linux
+  containment checkpoints are implemented; authority wiring, descriptor/CLI
+  activation, and the two-machine proof remain
 - **Date:** 2026-08-01
 - **Scope:** Two agents, two machines, two repositories, one real runtime adapter
 
@@ -446,10 +447,12 @@ The evaluation harness then runs one hidden end-to-end check that agents did not
    lock permits direct restart without file deletion and refuses a stopped live
    contender. Pre-claim/after-claim process cuts, busy-session, and full adversarial
    coverage remain.
-6. **In progress:** the Codex `0.146.0` app-server protocol/client is pinned and the
-   unactivated Capsule journal proves local at-most-once barriers, exact-input replay,
-   redacted terminal normalization, and cancellation intent. Runtime/server/CLI
-   integration and ambiguous-start recovery remain.
+6. **In progress:** the Codex `0.146.0` app-server protocol/client is pinned. The
+   unactivated provider-neutral Capsule server, schema-v2 journal, injected runner,
+   provider guardian, and Linux containment boundary prove local at-most-once
+   barriers, ambiguous-start recovery without resend, exact-input replay, redacted
+   terminal normalization, cancellation intent, and provider teardown. Verified
+   Mission authority, descriptor/CLI activation, and a real model turn remain.
 7. Run the two-machine backend-and-client pilot and compare it with one strong
    baseline using the same starting commits and budget.
 8. Decide whether to continue before adding SSE, Claude, A2A interoperability, or

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> **Updated:** 2026-08-16. This roadmap replaces the old mailbox -> Auto Mode ->
+> **Updated:** 2026-08-17. This roadmap replaces the old mailbox -> Auto Mode ->
 > Ambient Agent release sequence. The architectural contract is
 > [`RFC 001: AgentRelay Node and Missions`](rfcs/001-agentrelay-node-and-missions.md).
 
@@ -15,12 +15,16 @@ Mission and delivery control plane, and an experimental foreground Node. The Nod
 journals Relay authority and starts or resumes either an in-process fake-host turn or
 an independently persistent fake Mission Capsule. The detached Capsule and Node-
 process restart proof are implemented. The first pinned Codex client, durable journal,
-provider-neutral Capsule server, and injected runner now exist as an unactivated
-library checkpoint. A Linux-only Codex `0.146.0` containment library now adds
+provider-neutral Capsule server, injected runner, and provider guardian now exist as
+an unactivated library checkpoint. The guardian owns provider-generation spawn,
+liveness, and local authority inputs; its prearmed persistent out-of-group witness owns
+process-group removal and post-absence quiescence proof. A Linux-only Codex `0.146.0`
+containment library adds
 owner-controlled standalone-workspace admission, an explicit Bubblewrap policy,
 mandatory runtime canary, and exact retained-manifest recovery. It is not selected by
-the Capsule/Node CLI, but its dedicated Linux process proof now passes. The next
-runtime milestone is guarded production activation, not another protocol abstraction.
+the Capsule/Node CLI, but its dedicated Linux process proof now starts pinned Codex
+through both boundaries. The next runtime milestone is verified capability enforcement
+and guarded activation, not another protocol abstraction.
 
 We progress through evidence gates, not calendar promises or version hype.
 
@@ -107,10 +111,12 @@ migration because PID-only evidence cannot rule out another namespace. The Capsu
 server is now provider-neutral while the existing descriptor, CLI, and wire remain
 fake-compatible. An injected Codex runner is tested through that real Unix wire.
 Runtime shutdown concurrently fences admitted work, and background runtime failures
-can retire their server generation, but no production path selects Codex. OS service
-installation and automatic process respawn, contract acknowledgement, verification
-execution, durable containment-handle lifecycle wiring, guarded real-runtime
-activation, and the two-machine exit gate remain open.
+can retire their server generation, but no production path selects Codex. OS
+service/cgroup containment, automatic process respawn, witness/all-owner loss,
+escaped-descendant cleanup, and restart/upgrade/rollback behavior remain #120.
+Contract acknowledgement, verification execution, durable containment-handle
+lifecycle wiring, guarded real-runtime activation, and the two-machine exit gate also
+remain open.
 
 - Add a `node/` pnpm workspace and daemon CLI.
 - Register device-scoped credentials and capabilities.
@@ -129,28 +135,35 @@ one Node is killed and restarted mid-run.
 
 ## Stage 4: Codex vertical slice
 
-**Status:** unactivated runner checkpoint implemented. The pinned read-only client and
-schema-v2 journal now sit behind a provider-neutral Capsule server. The injected
-runner publishes a stable logical turn before provider binding, consumes one provider
-event stream, and reconciles an uncertain start only in a fresh provider generation
-after a mandatory injected quiescence proof. Tests exercise the real Capsule Unix
-wire with fake app-server clients. For an inherited uncertain interrupt, the fresh
-generation reads the exact intent once, persists a terminal provider outcome when
-available, or records a transient failure, without issuing another interrupt. Tests
-do not execute a model turn. The current descriptor and CLI still select the fake
-runtime, and no production guardian supplies the quiescence proof. A separate
-Linux-only containment library now validates a standalone workspace, constructs the
-pinned Bubblewrap boundary, runs a mandatory child canary, and binds recovery to an
-exact `retain_for_review` manifest. No Mission lifecycle stores its returned recovery
-handle. Its dedicated Linux process job passes, while every unsupported platform
-continues to fail closed.
+**Status:** unactivated guardian checkpoint implemented. The pinned read-only client,
+schema-v2 journal, injected runner, and provider guardian now sit behind a
+provider-neutral Capsule server. The runner publishes a stable logical turn before
+provider binding, consumes one provider event stream, and reconciles an uncertain
+start only in a guardian-owned fresh generation. The guardian owns the kernel-locked
+start barrier, Capsule and provider liveness, absolute deadline, and local revocation.
+Before the barrier it prearms an out-of-group witness that retains the same lock,
+removes the guardian/provider group, and records durable quiescence only after proving
+absence. Tests exercise the real Capsule Unix wire with fake app-server clients and
+real OS process trees, including joint Capsule/guardian loss on Linux. For an inherited
+uncertain interrupt, the fresh generation reads the exact intent once, persists a
+terminal provider outcome when available, or records a transient failure without
+issuing another interrupt. A separate Linux-only containment library validates a standalone
+workspace, constructs the pinned Bubblewrap boundary, runs a mandatory child canary,
+and binds recovery to an exact `retain_for_review` manifest. Its process job starts
+pinned Codex through both unactivated boundaries. No Mission lifecycle supplies
+verified authority or stores the recovery handle, the current descriptor and CLI
+still select the fake, and no test executes a model turn.
 
 - Implement contract/verification deliveries and bounded provenance-marked artifact
   carriage.
-- Add guardian-owned provider generations and a local capability reference monitor;
-  deny push, merge, publish, deploy, arbitrary network access, and secrets.
-- Activate the pinned Codex adapter through an explicit descriptor, compose the Linux
-  boundary, and durably store its exact recovery handle before provider start.
+- [x] Add guardian-owned provider generations, liveness, deadline/revocation inputs,
+  a prearmed teardown witness, durable post-absence quiescence, and process-group
+  teardown (#96).
+- [ ] Add a local capability reference monitor; deny push, merge, publish, deploy,
+  arbitrary network access, and secrets (#97).
+- [ ] Activate the pinned Codex adapter through an explicit descriptor, compose the
+  Linux boundary, and durably store its exact recovery handle before provider start
+  (#98).
 - Require one structured turn disposition with bounded local execution evidence.
 - Pass Guarded Real Mission 0 through the public pipeline before attempting the
   backend-and-Android two-machine scenario.

--- a/node/README.md
+++ b/node/README.md
@@ -38,10 +38,14 @@ unactivated.
   correlation, separately bounded 128 MiB request and 4 MiB response frames,
   mode-0700 directories, mode-0600 files and sockets, and an allowlisted child
   environment that excludes Relay, Node, and coding-runtime credentials.
-- An unactivated guarded Codex client and injected Capsule runner, plus a Linux-only
-  Codex `0.146.0` containment library. The dedicated Linux process job proves its
-  workspace/read/deny/network boundary and pinned app-server handshake; no current
-  descriptor, CLI, or Mission lifecycle selects it.
+- An unactivated guarded Codex client, injected Capsule runner, and provider guardian,
+  plus a Linux-only Codex `0.146.0` containment library. The guardian owns one
+  kernel-locked provider generation, absolute deadline, local revocation signal,
+  and liveness classification. It prearms a detached out-of-group witness before the
+  start barrier; that witness retains the lock, removes the guardian/provider process
+  group, and alone records same-boot teardown quiescence after proving the group absent.
+  The dedicated Linux process job starts pinned Codex through both boundaries; no
+  current descriptor, CLI, or Mission lifecycle selects them.
 
 The real Relay/Postgres E2E coverage includes both in-process runner reconstruction
 and an OS-process boundary: it kills the Node after Capsule acceptance, probes the
@@ -66,9 +70,13 @@ configuration.
 The Capsule checkpoint is experimental and Unix-only because its transport is a Unix
 domain socket. It is not a general local daemon manager: there is no installer, OS
 service supervisor, automatic process respawn, or production Codex/Claude activation.
-The guarded Codex client, injected runner, and Linux containment boundary exist only
-as unactivated libraries; see
+The guarded Codex client, injected runner, guardian, and Linux containment boundary
+exist only as unactivated libraries; see
+[`Codex provider guardian`](../docs/research/007-codex-provider-guardian.md) and
 [`Mission workspace containment`](../docs/research/006-mission-workspace-containment.md).
+`agentrelay-codex-guardian` is the guardian's internal child-process entry point, not
+a supported operator command or an activation path. Its internal `--reaper` mode is
+the persistent teardown witness, not another public command.
 The foreground Node's singleton ownership is crash-releasable, but an external
 service manager must still start a replacement process.
 
@@ -117,8 +125,10 @@ explicit loopback host during local development.
 At this checkpoint, `max_reported_tokens` feeds the host-event reducer. The other
 policy fields are validated and included in the acceptance grant hash, but turn
 deadlines, network sandboxing, and registered verification-command execution are not
-enforced by the active fake-runtime commands. The separate unactivated Linux
-containment library denies network access for processes launched through its boundary.
+enforced by the active fake-runtime commands. The unactivated guardian enforces a
+caller-supplied absolute deadline, and the separate Linux containment library denies
+network access for processes launched through its boundary. The Mission lifecycle does
+not yet supply either boundary with verified authority.
 
 Enrollment currently uses the agent-authenticated Relay route
 `POST /agents/me/nodes`; its one-time returned Node credential is copied into this

--- a/node/package.json
+++ b/node/package.json
@@ -12,7 +12,8 @@
 	"types": "dist/index.d.ts",
 	"bin": {
 		"agentrelay-node": "dist/bin/agentrelay-node.js",
-		"agentrelay-capsule": "dist/bin/agentrelay-capsule.js"
+		"agentrelay-capsule": "dist/bin/agentrelay-capsule.js",
+		"agentrelay-codex-guardian": "dist/bin/agentrelay-codex-guardian.js"
 	},
 	"files": ["dist"],
 	"scripts": {

--- a/node/src/bin/agentrelay-codex-guardian.ts
+++ b/node/src/bin/agentrelay-codex-guardian.ts
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
+import { CodexProviderReaper } from "../codex-provider-reaper.js";
 import { CodexProviderSupervisor } from "../codex-provider-supervisor.js";
 
 try {
-	new CodexProviderSupervisor().run();
+	if (process.argv[2] === "--reaper") {
+		new CodexProviderReaper().run();
+	} else if (process.argv.length === 2) {
+		new CodexProviderSupervisor().run();
+	} else {
+		throw new Error("Unsupported Codex guardian child mode");
+	}
 } catch {
 	process.stderr.write("Codex provider supervisor failed\n");
 	process.exitCode = 1;

--- a/node/src/bin/agentrelay-codex-guardian.ts
+++ b/node/src/bin/agentrelay-codex-guardian.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { CodexProviderSupervisor } from "../codex-provider-supervisor.js";
+
+try {
+	new CodexProviderSupervisor().run();
+} catch {
+	process.stderr.write("Codex provider supervisor failed\n");
+	process.exitCode = 1;
+}

--- a/node/src/boot-session.ts
+++ b/node/src/boot-session.ts
@@ -1,0 +1,25 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { z } from "zod";
+
+const execFileAsync = promisify(execFile);
+const bootSessionSchema = z.string().uuid();
+
+/** Returns a kernel-issued identity that changes only when this host boots. */
+export async function currentBootSessionId(): Promise<string> {
+	let value: string;
+	if (process.platform === "linux") {
+		value = await readFile("/proc/sys/kernel/random/boot_id", "utf8");
+	} else if (process.platform === "darwin") {
+		const result = await execFileAsync("/usr/sbin/sysctl", ["-n", "kern.bootsessionuuid"], {
+			encoding: "utf8",
+			timeout: 2_000,
+			maxBuffer: 1_024,
+		});
+		value = result.stdout;
+	} else {
+		throw new Error("Codex provider guardian requires a supported Unix boot identity");
+	}
+	return bootSessionSchema.parse(value.trim().toLowerCase());
+}

--- a/node/src/codex-app-server-client.ts
+++ b/node/src/codex-app-server-client.ts
@@ -12,7 +12,11 @@ import {
 	parseCodexReference,
 	parseStartCodexTurnInput,
 } from "./codex-app-server-policy.js";
-import { type CodexAppServerCommand, CodexAppServerError } from "./codex-app-server-process.js";
+import {
+	type CodexAppServerCommand,
+	CodexAppServerError,
+	type CodexAppServerProcessFactory,
+} from "./codex-app-server-process.js";
 import {
 	CODEX_APP_SERVER_CLIENT_NAME,
 	type CodexInitializeResponse,
@@ -42,6 +46,7 @@ export interface CodexAppServerClientOptions {
 	readonly env: NodeJS.ProcessEnv;
 	readonly boundary: CodexProcessBoundary;
 	readonly requestTimeoutMs?: number;
+	readonly processFactory?: CodexAppServerProcessFactory;
 }
 
 export interface CodexAppServerClientEvent {
@@ -81,6 +86,7 @@ export class CodexAppServerClient {
 			env,
 			boundary: options.boundary,
 			requestTimeoutMs: options.requestTimeoutMs,
+			processFactory: options.processFactory,
 			handleServerRequest: denyCodexServerRequest,
 		});
 		const client = new CodexAppServerClient(transport, codexHome);

--- a/node/src/codex-app-server-failures.test.ts
+++ b/node/src/codex-app-server-failures.test.ts
@@ -8,6 +8,7 @@ import { CodexAppServerClient } from "./codex-app-server-client.js";
 
 const fixtures: FakeAppServerFixture[] = [];
 const clients: CodexAppServerClient[] = [];
+const IGNORED_REQUEST_TIMEOUT_MS = 1_000;
 
 afterEach(async () => {
 	await Promise.all(clients.splice(0).map((client) => client.close().catch(() => undefined)));
@@ -30,7 +31,7 @@ describe("Codex app-server failure boundaries", () => {
 
 	it("times out one ignored request and poisons the client", async () => {
 		const fixture = await fakeAppServer({ ignoreRead: true });
-		const client = await openClient(fixture, 100);
+		const client = await openClient(fixture, IGNORED_REQUEST_TIMEOUT_MS);
 		await expect(client.readThread("thread-1")).rejects.toMatchObject({
 			name: "CodexAppServerError",
 			reason: "transport",

--- a/node/src/codex-app-server-process.ts
+++ b/node/src/codex-app-server-process.ts
@@ -30,7 +30,13 @@ export interface CodexAppServerProcess {
 	readonly exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
 	readonly closed: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
 	readonly inputError: Promise<Error>;
+	/** Optional lifecycle owner used when the visible child is a supervising process. */
+	readonly stop?: () => Promise<void>;
 }
+
+export type CodexAppServerProcessFactory = (
+	options: CodexAppServerProcessOptions,
+) => Promise<CodexAppServerProcess>;
 
 export class CodexAppServerError extends Error {
 	constructor(
@@ -90,7 +96,8 @@ export async function startCodexAppServerProcess(
 export function stopCodexAppServerProcess(processRef: CodexAppServerProcess): Promise<void> {
 	const existingStop = processStops.get(processRef.child);
 	if (existingStop !== undefined) return existingStop;
-	const stop = stopProcessGroup(processRef.child, processRef.exited, processRef.closed);
+	const stop =
+		processRef.stop?.() ?? stopProcessGroup(processRef.child, processRef.exited, processRef.closed);
 	processStops.set(processRef.child, stop);
 	return stop;
 }

--- a/node/src/codex-app-server-process.ts
+++ b/node/src/codex-app-server-process.ts
@@ -31,8 +31,10 @@ export interface CodexAppServerProcess {
 	readonly closed: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
 	readonly inputError: Promise<Error>;
 	/** Optional lifecycle owner used when the visible child is a supervising process. */
-	readonly stop?: () => Promise<void>;
+	readonly stop?: (reason?: CodexAppServerStopReason) => Promise<void>;
 }
+
+export type CodexAppServerStopReason = "closed" | "failure" | "unresponsive";
 
 export type CodexAppServerProcessFactory = (
 	options: CodexAppServerProcessOptions,
@@ -93,11 +95,15 @@ export async function startCodexAppServerProcess(
 	return { child, cwd, exited, closed, inputError };
 }
 
-export function stopCodexAppServerProcess(processRef: CodexAppServerProcess): Promise<void> {
+export function stopCodexAppServerProcess(
+	processRef: CodexAppServerProcess,
+	reason: CodexAppServerStopReason = "closed",
+): Promise<void> {
 	const existingStop = processStops.get(processRef.child);
 	if (existingStop !== undefined) return existingStop;
 	const stop =
-		processRef.stop?.() ?? stopProcessGroup(processRef.child, processRef.exited, processRef.closed);
+		processRef.stop?.(reason) ??
+		stopProcessGroup(processRef.child, processRef.exited, processRef.closed);
 	processStops.set(processRef.child, stop);
 	return stop;
 }

--- a/node/src/codex-app-server-transport.ts
+++ b/node/src/codex-app-server-transport.ts
@@ -104,7 +104,7 @@ export class CodexAppServerTransport {
 		});
 		void processRef.exited.then(() => {
 			if (!this.#closing && this.#failure === null) {
-				void stopCodexAppServerProcess(processRef).catch((error) =>
+				void stopCodexAppServerProcess(processRef, "failure").catch((error) =>
 					this.fail(error instanceof Error ? error : new Error(String(error))),
 				);
 			}
@@ -138,7 +138,7 @@ export class CodexAppServerTransport {
 					`Timed out waiting for Codex app-server method ${method}`,
 				);
 				reject(error);
-				this.fail(error);
+				this.fail(error, "unresponsive");
 			}, this.#requestTimeoutMs);
 			this.#pending.set(id, { method, resolve, reject, timeout });
 		});
@@ -267,12 +267,12 @@ export class CodexAppServerTransport {
 		);
 	}
 
-	private fail(error: Error): void {
+	private fail(error: Error, stopReason: "failure" | "unresponsive" = "failure"): void {
 		if (this.#failure !== null) return;
 		this.#failure = error;
 		this.rejectPending(error);
 		this.#events.close(error);
-		void stopCodexAppServerProcess(this.#process).catch(() => undefined);
+		void stopCodexAppServerProcess(this.#process, stopReason).catch(() => undefined);
 	}
 
 	private rejectPending(error: Error): void {

--- a/node/src/codex-app-server-transport.ts
+++ b/node/src/codex-app-server-transport.ts
@@ -4,6 +4,7 @@ import {
 	type CodexAppServerCommand,
 	CodexAppServerError,
 	type CodexAppServerProcess,
+	type CodexAppServerProcessFactory,
 	readCodexLines,
 	startCodexAppServerProcess,
 	stopCodexAppServerProcess,
@@ -24,6 +25,7 @@ export interface CodexAppServerTransportOptions {
 	readonly boundary: CodexProcessBoundary;
 	readonly requestTimeoutMs?: number;
 	readonly handleServerRequest: (request: CodexServerRequest) => CodexServerRequestDecision;
+	readonly processFactory?: CodexAppServerProcessFactory;
 }
 
 export interface CodexServerRequest {
@@ -116,7 +118,7 @@ export class CodexAppServerTransport {
 			.min(100)
 			.max(120_000)
 			.parse(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
-		const processRef = await startCodexAppServerProcess(options);
+		const processRef = await (options.processFactory ?? startCodexAppServerProcess)(options);
 		return new CodexAppServerTransport(processRef, requestTimeoutMs, options.handleServerRequest);
 	}
 

--- a/node/src/codex-capsule-runner-contract.ts
+++ b/node/src/codex-capsule-runner-contract.ts
@@ -23,7 +23,6 @@ export interface CodexCapsuleClient {
 	startReadOnlyTurn(input: StartCodexTurnInput): Promise<CodexTurn>;
 	interruptTurn(threadId: string, turnId: string): Promise<void>;
 	events(): AsyncIterable<CodexAppServerClientEvent>;
-	close(): Promise<void>;
 }
 
 export type CodexProviderTerminationReason =

--- a/node/src/codex-capsule-runner-contract.ts
+++ b/node/src/codex-capsule-runner-contract.ts
@@ -26,15 +26,32 @@ export interface CodexCapsuleClient {
 	close(): Promise<void>;
 }
 
-export interface CodexRecoveryAuthority {
-	assertPreviousProviderProcessQuiescent(reason: "provider_generation_start"): Promise<void>;
+export type CodexProviderTerminationReason =
+	| "capsule_shutdown"
+	| "startup_failure"
+	| "provider_failure"
+	| "authority_revoked"
+	| "deadline_exceeded";
+
+export interface CodexProviderTermination {
+	readonly kind: "stopped" | "crashed" | "unresponsive";
+}
+
+export interface CodexProviderGeneration {
+	readonly generationId: string;
+	readonly client: CodexCapsuleClient;
+	readonly termination: Promise<CodexProviderTermination>;
+	terminate(reason: CodexProviderTerminationReason): Promise<void>;
+}
+
+export interface CodexProviderGuardian {
+	openGeneration(): Promise<CodexProviderGeneration>;
 }
 
 export interface CodexCapsuleRunnerOptions {
 	readonly store: CodexCapsuleStore;
 	readonly cwd: string;
-	readonly clientFactory: () => Promise<CodexCapsuleClient>;
-	readonly recoveryAuthority: CodexRecoveryAuthority;
+	readonly guardian: CodexProviderGuardian;
 	/** Retires the owning Capsule without exposing a provider failure over the wire. */
 	readonly retireGeneration: () => void;
 	readonly eventPollMs?: number;

--- a/node/src/codex-capsule-runner.test.ts
+++ b/node/src/codex-capsule-runner.test.ts
@@ -25,7 +25,10 @@ import { PersistentCapsuleServer } from "./capsule-server.js";
 import {
 	CODEX_CAPSULE_ADAPTER_INFO,
 	CodexCapsuleRunner,
-	type CodexRecoveryAuthority,
+	type CodexProviderGeneration,
+	type CodexProviderGuardian,
+	type CodexProviderTermination,
+	type CodexProviderTerminationReason,
 } from "./codex-capsule-runner.js";
 import { CodexCapsuleStore } from "./codex-capsule-store.js";
 
@@ -109,10 +112,7 @@ describe("CodexCapsuleRunner", () => {
 		expect(firstClient.turnStarts).toHaveLength(1);
 		expect(fixture.client.turnStarts).toHaveLength(0);
 		expect(fixture.client.readCalls).toBe(1);
-		expect(fixture.authority.calls).toEqual([
-			"provider_generation_start",
-			"provider_generation_start",
-		]);
+		expect(fixture.guardian.openCalls).toBe(2);
 	});
 
 	it("fails a bounded zero-match only after provider quiescence and never resends", async () => {
@@ -129,7 +129,7 @@ describe("CodexCapsuleRunner", () => {
 		expect(eventKinds(frames)).toEqual(["accepted", "usage", "failed"]);
 		expect(fixture.client.turnStarts).toHaveLength(0);
 		expect(fixture.client.readCalls).toBe(3);
-		expect(fixture.authority.calls).toEqual(["provider_generation_start"]);
+		expect(fixture.guardian.openCalls).toBe(1);
 
 		const next = turnInput(session, IDS.delivery2);
 		await fixture.store.prepareTurn(next);
@@ -217,10 +217,7 @@ describe("CodexCapsuleRunner", () => {
 		expect(fixture.client.interrupts).toEqual([]);
 		expect(fixture.client.readCalls).toBe(1);
 		expect(JSON.stringify(recovered)).not.toContain(providerTurn.id);
-		expect(fixture.authority.calls).toEqual([
-			"provider_generation_start",
-			"provider_generation_start",
-		]);
+		expect(fixture.guardian.openCalls).toBe(2);
 	});
 
 	it("retires when a detached cancel request loses its interrupt response", async () => {
@@ -260,10 +257,7 @@ describe("CodexCapsuleRunner", () => {
 		expect(firstClient.interrupts).toHaveLength(1);
 		expect(fixture.client.interrupts).toEqual([]);
 		expect(fixture.client.readCalls).toBe(1);
-		expect(fixture.authority.calls).toEqual([
-			"provider_generation_start",
-			"provider_generation_start",
-		]);
+		expect(fixture.guardian.openCalls).toBe(2);
 	});
 
 	it("replaces an unresolved empty session only behind a quiescence proof", async () => {
@@ -277,7 +271,7 @@ describe("CodexCapsuleRunner", () => {
 		expect(session).toMatchObject({ sessionId: expect.stringMatching(/^capsule-session-/) });
 		expect(fixture.client.calls).toContain("startThread");
 		expect(fixture.client.calls).not.toContain("resumeThread");
-		expect(fixture.authority.calls).toEqual(["provider_generation_start"]);
+		expect(fixture.guardian.openCalls).toBe(1);
 	});
 
 	it("retires when detached session startup fails after crossing its durable barrier", async () => {
@@ -307,19 +301,70 @@ describe("CodexCapsuleRunner", () => {
 		expect(session).toMatchObject({ sessionId: expect.stringMatching(/^capsule-session-/) });
 		expect(firstClient.calls.filter((call) => call === "startThread")).toHaveLength(1);
 		expect(fixture.client.calls.filter((call) => call === "startThread")).toHaveLength(1);
-		expect(fixture.authority.calls).toEqual([
-			"provider_generation_start",
-			"provider_generation_start",
-		]);
+		expect(fixture.guardian.openCalls).toBe(2);
 	});
 
-	it("does not create a provider client before generation quiescence is proven", async () => {
+	it("does not receive a provider client when the guardian refuses a generation", async () => {
 		const fixture = await createFixture();
-		fixture.authority.failure = new Error("previous provider may still be live");
+		fixture.guardian.failure = new Error("previous provider may still be live");
 
 		await expect(fixture.startServer()).rejects.toThrow("previous provider may still be live");
-		expect(fixture.clientFactoryCalls).toBe(0);
+		expect(fixture.guardian.openCalls).toBe(1);
+		expect(fixture.guardian.generations).toHaveLength(0);
 		expect(fixture.client.calls).toEqual([]);
+	});
+
+	it("terminates an acquired generation when runner construction fails", async () => {
+		const directory = await realpath(await mkdtemp("/tmp/agentrelay-codex-startup-failure-"));
+		directories.push(directory);
+		const store = await CodexCapsuleStore.open(join(directory, "state"), {
+			capsuleId: IDS.capsule,
+			session: sessionInput(),
+		});
+		const client = new FakeCodexCapsuleClient(directory);
+		const guardian = new RecordingProviderGuardian(() => client);
+
+		await expect(
+			CodexCapsuleRunner.open({
+				store,
+				cwd: "relative",
+				guardian,
+				retireGeneration: () => undefined,
+			}),
+		).rejects.toThrow("Codex Capsule working directory must be absolute and normalized");
+
+		expect(guardian.openCalls).toBe(1);
+		expect(guardian.generations[0]?.terminationReasons).toEqual(["startup_failure"]);
+		expect(client.closeCalls).toBe(1);
+		await store.close();
+	});
+
+	it("terminates one acquired generation on close without retiring it", async () => {
+		const directory = await realpath(await mkdtemp("/tmp/agentrelay-codex-shutdown-"));
+		directories.push(directory);
+		const store = await CodexCapsuleStore.open(join(directory, "state"), {
+			capsuleId: IDS.capsule,
+			session: sessionInput(),
+		});
+		const client = new FakeCodexCapsuleClient(directory);
+		const guardian = new RecordingProviderGuardian(() => client);
+		let retireCalls = 0;
+		const runner = await CodexCapsuleRunner.open({
+			store,
+			cwd: directory,
+			guardian,
+			retireGeneration: () => {
+				retireCalls += 1;
+			},
+		});
+
+		await runner.close();
+		await Promise.resolve();
+
+		expect(guardian.openCalls).toBe(1);
+		expect(guardian.generations[0]?.terminationReasons).toEqual(["capsule_shutdown"]);
+		expect(client.closeCalls).toBe(1);
+		expect(retireCalls).toBe(0);
 	});
 
 	it("fences same-generation admission synchronously after a provider failure", async () => {
@@ -330,13 +375,13 @@ describe("CodexCapsuleRunner", () => {
 			session: sessionInput(),
 		});
 		const client = new FakeCodexCapsuleClient(directory);
+		const guardian = new RecordingProviderGuardian(() => client);
 		client.threadStartFailure = new Error("provider thread/start failed");
 		let retireCalls = 0;
 		const runner = await CodexCapsuleRunner.open({
 			store,
 			cwd: directory,
-			clientFactory: async () => client,
-			recoveryAuthority: new RecordingRecoveryAuthority(),
+			guardian,
 			retireGeneration: () => {
 				retireCalls += 1;
 			},
@@ -354,7 +399,22 @@ describe("CodexCapsuleRunner", () => {
 		expect(client.calls.filter((call) => call === "startThread")).toHaveLength(1);
 		expect(retireCalls).toBe(1);
 		await runner.close();
+		expect(guardian.generations[0]?.terminationReasons).toEqual(["capsule_shutdown"]);
 	});
+
+	it.each<CodexProviderTermination["kind"]>(["stopped", "crashed", "unresponsive"])(
+		"retires when the provider generation terminates unexpectedly as %s",
+		async (kind) => {
+			const fixture = await createFixture();
+			const server = await fixture.startServer();
+
+			fixture.guardian.generations[0]?.finish(kind);
+			await server.waitUntilClosed();
+
+			expect(fixture.guardian.generations[0]?.terminationReasons).toEqual(["capsule_shutdown"]);
+			expect(fixture.client.closeCalls).toBe(1);
+		},
+	);
 
 	it("retires the generation when a detached turn driver later fails", async () => {
 		const fixture = await createFixture();
@@ -409,8 +469,7 @@ async function createFixture(options: FixtureOptions = {}) {
 	}
 	const providerState: FakeCodexProviderState = { turns: [] };
 	let client = new FakeCodexCapsuleClient(directory, "thread-1", providerState);
-	let clientFactoryCalls = 0;
-	const authority = new RecordingRecoveryAuthority();
+	const guardian = new RecordingProviderGuardian(() => client);
 	const startServer = async () => {
 		const server = await PersistentCapsuleServer.start({
 			identity,
@@ -418,11 +477,7 @@ async function createFixture(options: FixtureOptions = {}) {
 				CodexCapsuleRunner.open({
 					store,
 					cwd: directory,
-					clientFactory: async () => {
-						clientFactoryCalls += 1;
-						return client;
-					},
-					recoveryAuthority: authority,
+					guardian,
 					retireGeneration: retire,
 					eventPollMs: 1,
 					providerPollMs: 1,
@@ -435,14 +490,11 @@ async function createFixture(options: FixtureOptions = {}) {
 	return {
 		identity,
 		store,
-		authority,
+		guardian,
 		session,
 		startServer,
 		get client() {
 			return client;
-		},
-		get clientFactoryCalls() {
-			return clientFactoryCalls;
 		},
 		replaceClient() {
 			client = new FakeCodexCapsuleClient(directory, "thread-1", providerState);
@@ -450,13 +502,59 @@ async function createFixture(options: FixtureOptions = {}) {
 	};
 }
 
-class RecordingRecoveryAuthority implements CodexRecoveryAuthority {
-	readonly calls: Array<"provider_generation_start"> = [];
+class RecordingProviderGuardian implements CodexProviderGuardian {
+	readonly generations: RecordingProviderGeneration[] = [];
+	readonly #client: () => FakeCodexCapsuleClient;
 	failure: Error | null = null;
+	openCalls = 0;
 
-	async assertPreviousProviderProcessQuiescent(reason: "provider_generation_start"): Promise<void> {
-		this.calls.push(reason);
+	constructor(client: () => FakeCodexCapsuleClient) {
+		this.#client = client;
+	}
+
+	async openGeneration(): Promise<CodexProviderGeneration> {
+		this.openCalls += 1;
 		if (this.failure !== null) throw this.failure;
+		const generation = new RecordingProviderGeneration(
+			`generation-${this.openCalls}`,
+			this.#client(),
+		);
+		this.generations.push(generation);
+		return generation;
+	}
+}
+
+class RecordingProviderGeneration implements CodexProviderGeneration {
+	readonly termination: Promise<CodexProviderTermination>;
+	readonly terminationReasons: CodexProviderTerminationReason[] = [];
+	readonly #termination: Deferred<CodexProviderTermination>;
+	#terminated = false;
+	#terminating: Promise<void> | null = null;
+
+	constructor(
+		readonly generationId: string,
+		readonly client: FakeCodexCapsuleClient,
+	) {
+		this.#termination = deferred<CodexProviderTermination>();
+		this.termination = this.#termination.promise;
+	}
+
+	terminate(reason: CodexProviderTerminationReason): Promise<void> {
+		if (this.#terminating !== null) return this.#terminating;
+		this.terminationReasons.push(reason);
+		this.#terminating = this.stop();
+		return this.#terminating;
+	}
+
+	finish(kind: CodexProviderTermination["kind"]): void {
+		if (this.#terminated) return;
+		this.#terminated = true;
+		this.#termination.resolve({ kind });
+	}
+
+	private async stop(): Promise<void> {
+		await this.client.close();
+		this.finish("stopped");
 	}
 }
 

--- a/node/src/codex-capsule-runner.ts
+++ b/node/src/codex-capsule-runner.ts
@@ -18,6 +18,7 @@ import {
 	CODEX_CAPSULE_ADAPTER_INFO,
 	type CodexCapsuleClient,
 	type CodexCapsuleRunnerOptions,
+	type CodexProviderGeneration,
 	boundedRunnerMilliseconds,
 	isTerminalHostEvent,
 	sessionInputFromRef,
@@ -32,12 +33,16 @@ export {
 	CODEX_CAPSULE_ADAPTER_INFO,
 	type CodexCapsuleClient,
 	type CodexCapsuleRunnerOptions,
-	type CodexRecoveryAuthority,
+	type CodexProviderGeneration,
+	type CodexProviderGuardian,
+	type CodexProviderTermination,
+	type CodexProviderTerminationReason,
 } from "./codex-capsule-runner-contract.js";
 
 /** Injected Codex orchestration inside one Mission Capsule; not wired to a production CLI. */
 export class CodexCapsuleRunner implements CapsuleRuntime {
 	readonly #store: CodexCapsuleStore;
+	readonly #generation: CodexProviderGeneration;
 	readonly #client: CodexCapsuleClient;
 	readonly #cwd: string;
 	readonly #eventPollMs: number;
@@ -53,9 +58,10 @@ export class CodexCapsuleRunner implements CapsuleRuntime {
 	#retirementRequested = false;
 	#closing: Promise<void> | null = null;
 
-	private constructor(options: CodexCapsuleRunnerOptions, client: CodexCapsuleClient) {
+	private constructor(options: CodexCapsuleRunnerOptions, generation: CodexProviderGeneration) {
 		this.#store = options.store;
-		this.#client = client;
+		this.#generation = generation;
+		this.#client = generation.client;
 		this.#cwd = validateCodexRunnerCwd(options.cwd);
 		this.#eventPollMs = boundedRunnerMilliseconds(options.eventPollMs ?? 20);
 		this.#providerPollMs = boundedRunnerMilliseconds(options.providerPollMs ?? 500);
@@ -66,27 +72,25 @@ export class CodexCapsuleRunner implements CapsuleRuntime {
 			.max(20)
 			.parse(options.zeroMatchReads ?? 3);
 		this.#retireGeneration = options.retireGeneration;
-		this.#providerEvents = new CodexProviderEventSource(client);
+		this.#providerEvents = new CodexProviderEventSource(this.#client);
 		this.#turnExecutor = new CodexTurnExecutor({
 			store: options.store,
-			client,
+			client: this.#client,
 			providerEvents: this.#providerEvents,
 			cwd: this.#cwd,
 			providerPollMs: this.#providerPollMs,
 			zeroMatchReads: this.#zeroMatchReads,
 			shutdownSignal: this.#shutdown.signal,
 		});
+		this.observeProviderTermination();
 	}
 
 	static async open(options: CodexCapsuleRunnerOptions): Promise<CodexCapsuleRunner> {
-		await options.recoveryAuthority.assertPreviousProviderProcessQuiescent(
-			"provider_generation_start",
-		);
-		const client = await options.clientFactory();
+		const generation = await options.guardian.openGeneration();
 		try {
-			return new CodexCapsuleRunner(options, client);
+			return new CodexCapsuleRunner(options, generation);
 		} catch (error) {
-			await client.close().catch(() => undefined);
+			await generation.terminate("startup_failure").catch(() => undefined);
 			throw error;
 		}
 	}
@@ -160,13 +164,21 @@ export class CodexCapsuleRunner implements CapsuleRuntime {
 	private async performClose(): Promise<void> {
 		const failures: unknown[] = [];
 		this.#shutdown.abort();
-		await captureFailure(this.#client.close(), failures);
+		await captureFailure(this.#generation.terminate("capsule_shutdown"), failures);
 		await Promise.allSettled(this.#turnDrivers.values());
 		await captureFailure(this.#providerEvents.close(), failures);
 		await captureFailure(this.#store.close(), failures);
 		if (failures.length > 0) {
 			throw new AggregateError(failures, "Codex Capsule runner shutdown failed");
 		}
+	}
+
+	private observeProviderTermination(): void {
+		void this.#generation.termination.then(
+			() => this.retireAfterFatalFailure(new Error("Codex provider generation terminated")),
+			() =>
+				this.retireAfterFatalFailure(new Error("Codex provider termination was not observable")),
+		);
 	}
 
 	private async openSession(): Promise<HostSessionRef> {

--- a/node/src/codex-provider-generation-state.test.ts
+++ b/node/src/codex-provider-generation-state.test.ts
@@ -10,6 +10,9 @@ import {
 const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
 const FIRST_GENERATION = "10000000-0000-4000-8000-000000000002";
 const SECOND_GENERATION = "10000000-0000-4000-8000-000000000003";
+const FIRST_BOOT = "10000000-0000-4000-8000-000000000004";
+const SECOND_BOOT = "10000000-0000-4000-8000-000000000005";
+const DEADLINE_AT_MS = Date.parse("2026-08-17T01:00:00.000Z");
 const directories: string[] = [];
 
 afterEach(async () => {
@@ -32,7 +35,7 @@ describe("CodexProviderGenerationStore", () => {
 			() => new Date(times.shift()!),
 		);
 
-		await store.begin(FIRST_GENERATION);
+		await store.begin(FIRST_GENERATION, FIRST_BOOT, DEADLINE_AT_MS);
 		await store.markRunning(FIRST_GENERATION);
 		await store.recordHeartbeat(FIRST_GENERATION);
 		await store.requestStop(FIRST_GENERATION, "deadline_exceeded");
@@ -42,8 +45,10 @@ describe("CodexProviderGenerationStore", () => {
 			schema_version: 1,
 			capsule_id: CAPSULE_ID,
 			generation_id: FIRST_GENERATION,
+			boot_session_id: FIRST_BOOT,
 			phase: "quiescent",
 			started_at: "2026-08-17T00:00:00.000Z",
+			deadline_at: "2026-08-17T01:00:00.000Z",
 			updated_at: "2026-08-17T00:00:04.000Z",
 			last_heartbeat_at: "2026-08-17T00:00:02.000Z",
 			stop_cause: "deadline_exceeded",
@@ -59,15 +64,48 @@ describe("CodexProviderGenerationStore", () => {
 	it("admits a replacement only after durable quiescence", async () => {
 		const directory = await temporaryDirectory();
 		const first = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
-		await first.begin(FIRST_GENERATION);
+		await first.begin(FIRST_GENERATION, FIRST_BOOT, DEADLINE_AT_MS);
 
 		const replacement = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
-		await expect(replacement.begin(SECOND_GENERATION)).rejects.toThrow(
+		await expect(replacement.begin(SECOND_GENERATION, FIRST_BOOT, DEADLINE_AT_MS)).rejects.toThrow(
 			"Previous Codex provider generation is not durably quiescent",
 		);
 
 		await first.markQuiescent(FIRST_GENERATION, "owner_lost", "stopped");
-		await expect(replacement.begin(SECOND_GENERATION)).resolves.toMatchObject({
+		await expect(
+			replacement.begin(SECOND_GENERATION, FIRST_BOOT, DEADLINE_AT_MS),
+		).resolves.toMatchObject({
+			generation_id: SECOND_GENERATION,
+			phase: "spawn_maybe_started",
+		});
+	});
+
+	it("reconciles an unowned generation only after the host boot changes", async () => {
+		const directory = await temporaryDirectory();
+		const first = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
+		await first.begin(FIRST_GENERATION, FIRST_BOOT, DEADLINE_AT_MS);
+
+		const replacement = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
+		await expect(
+			replacement.begin(SECOND_GENERATION, SECOND_BOOT, DEADLINE_AT_MS),
+		).resolves.toMatchObject({
+			generation_id: SECOND_GENERATION,
+			boot_session_id: SECOND_BOOT,
+			phase: "spawn_maybe_started",
+		});
+	});
+
+	it("does not rewrite another generation during pre-start cleanup", async () => {
+		const directory = await temporaryDirectory();
+		const store = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
+		await expect(
+			store.markQuiescentIfCurrent(FIRST_GENERATION, "startup_failure", "crashed"),
+		).resolves.toBe(false);
+		await store.begin(SECOND_GENERATION, FIRST_BOOT, DEADLINE_AT_MS);
+		await expect(
+			store.markQuiescentIfCurrent(FIRST_GENERATION, "startup_failure", "crashed"),
+		).resolves.toBe(false);
+		expect(await store.snapshot()).toMatchObject({
 			generation_id: SECOND_GENERATION,
 			phase: "spawn_maybe_started",
 		});
@@ -78,7 +116,9 @@ describe("CodexProviderGenerationStore", () => {
 		const malformedPath = join(malformedDirectory, CODEX_PROVIDER_GENERATION_FILE);
 		await writeFile(malformedPath, "not-json", { mode: 0o600 });
 		const malformed = await CodexProviderGenerationStore.open(malformedDirectory, CAPSULE_ID);
-		await expect(malformed.begin(FIRST_GENERATION)).rejects.toBeDefined();
+		await expect(
+			malformed.begin(FIRST_GENERATION, FIRST_BOOT, DEADLINE_AT_MS),
+		).rejects.toBeDefined();
 
 		const publicDirectory = await temporaryDirectory();
 		const publicPath = join(publicDirectory, CODEX_PROVIDER_GENERATION_FILE);

--- a/node/src/codex-provider-generation-state.test.ts
+++ b/node/src/codex-provider-generation-state.test.ts
@@ -1,0 +1,96 @@
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	CODEX_PROVIDER_GENERATION_FILE,
+	CodexProviderGenerationStore,
+} from "./codex-provider-generation-state.js";
+
+const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
+const FIRST_GENERATION = "10000000-0000-4000-8000-000000000002";
+const SECOND_GENERATION = "10000000-0000-4000-8000-000000000003";
+const directories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+describe("CodexProviderGenerationStore", () => {
+	it("persists a bounded lifecycle and preserves its first stop cause", async () => {
+		const directory = await temporaryDirectory();
+		const times = [
+			"2026-08-17T00:00:00.000Z",
+			"2026-08-17T00:00:01.000Z",
+			"2026-08-17T00:00:02.000Z",
+			"2026-08-17T00:00:03.000Z",
+			"2026-08-17T00:00:04.000Z",
+		];
+		const store = await CodexProviderGenerationStore.open(
+			directory,
+			CAPSULE_ID,
+			() => new Date(times.shift()!),
+		);
+
+		await store.begin(FIRST_GENERATION);
+		await store.markRunning(FIRST_GENERATION);
+		await store.recordHeartbeat(FIRST_GENERATION);
+		await store.requestStop(FIRST_GENERATION, "deadline_exceeded");
+		await store.markQuiescent(FIRST_GENERATION, "provider_failure", "stopped");
+
+		expect(await store.snapshot()).toEqual({
+			schema_version: 1,
+			capsule_id: CAPSULE_ID,
+			generation_id: FIRST_GENERATION,
+			phase: "quiescent",
+			started_at: "2026-08-17T00:00:00.000Z",
+			updated_at: "2026-08-17T00:00:04.000Z",
+			last_heartbeat_at: "2026-08-17T00:00:02.000Z",
+			stop_cause: "deadline_exceeded",
+			observation: "stopped",
+		});
+		const decoded = JSON.parse(
+			await readFile(join(directory, CODEX_PROVIDER_GENERATION_FILE), "utf8"),
+		);
+		expect(JSON.stringify(decoded)).not.toContain("provider_pid");
+		expect(JSON.stringify(decoded)).not.toContain(directory);
+	});
+
+	it("admits a replacement only after durable quiescence", async () => {
+		const directory = await temporaryDirectory();
+		const first = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
+		await first.begin(FIRST_GENERATION);
+
+		const replacement = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
+		await expect(replacement.begin(SECOND_GENERATION)).rejects.toThrow(
+			"Previous Codex provider generation is not durably quiescent",
+		);
+
+		await first.markQuiescent(FIRST_GENERATION, "owner_lost", "stopped");
+		await expect(replacement.begin(SECOND_GENERATION)).resolves.toMatchObject({
+			generation_id: SECOND_GENERATION,
+			phase: "spawn_maybe_started",
+		});
+	});
+
+	it("fails closed on malformed or non-private lifecycle state", async () => {
+		const malformedDirectory = await temporaryDirectory();
+		const malformedPath = join(malformedDirectory, CODEX_PROVIDER_GENERATION_FILE);
+		await writeFile(malformedPath, "not-json", { mode: 0o600 });
+		const malformed = await CodexProviderGenerationStore.open(malformedDirectory, CAPSULE_ID);
+		await expect(malformed.begin(FIRST_GENERATION)).rejects.toBeDefined();
+
+		const publicDirectory = await temporaryDirectory();
+		const publicPath = join(publicDirectory, CODEX_PROVIDER_GENERATION_FILE);
+		await writeFile(publicPath, "{}", { mode: 0o644 });
+		const publicState = await CodexProviderGenerationStore.open(publicDirectory, CAPSULE_ID);
+		await expect(publicState.snapshot()).rejects.toThrow("mode 0600");
+		await chmod(publicPath, 0o600);
+	});
+});
+
+async function temporaryDirectory(): Promise<string> {
+	const directory = await realpath(await mkdtemp(join(tmpdir(), "agentrelay-provider-state-")));
+	directories.push(directory);
+	return directory;
+}

--- a/node/src/codex-provider-generation-state.test.ts
+++ b/node/src/codex-provider-generation-state.test.ts
@@ -111,6 +111,25 @@ describe("CodexProviderGenerationStore", () => {
 		});
 	});
 
+	it("lets the surviving reaper authoritatively finalize only its generation", async () => {
+		const directory = await temporaryDirectory();
+		const store = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
+		await store.begin(FIRST_GENERATION, FIRST_BOOT, DEADLINE_AT_MS);
+		await store.requestStop(FIRST_GENERATION, "owner_lost");
+
+		await expect(
+			store.finalizeQuiescentAsCurrent(SECOND_GENERATION, "provider_failure"),
+		).resolves.toBeNull();
+		await expect(
+			store.finalizeQuiescentAsCurrent(FIRST_GENERATION, "deadline_exceeded"),
+		).resolves.toMatchObject({
+			generation_id: FIRST_GENERATION,
+			phase: "quiescent",
+			stop_cause: "deadline_exceeded",
+			observation: "unresponsive",
+		});
+	});
+
 	it("fails closed on malformed or non-private lifecycle state", async () => {
 		const malformedDirectory = await temporaryDirectory();
 		const malformedPath = join(malformedDirectory, CODEX_PROVIDER_GENERATION_FILE);

--- a/node/src/codex-provider-generation-state.test.ts
+++ b/node/src/codex-provider-generation-state.test.ts
@@ -20,7 +20,7 @@ afterEach(async () => {
 });
 
 describe("CodexProviderGenerationStore", () => {
-	it("persists a bounded lifecycle and preserves its first stop cause", async () => {
+	it("persists a bounded lifecycle and authoritative stop cause", async () => {
 		const directory = await temporaryDirectory();
 		const times = [
 			"2026-08-17T00:00:00.000Z",
@@ -39,7 +39,7 @@ describe("CodexProviderGenerationStore", () => {
 		await store.markRunning(FIRST_GENERATION);
 		await store.recordHeartbeat(FIRST_GENERATION);
 		await store.requestStop(FIRST_GENERATION, "deadline_exceeded");
-		await store.markQuiescent(FIRST_GENERATION, "provider_failure", "stopped");
+		await store.finalizeQuiescentAsCurrent(FIRST_GENERATION, "deadline_exceeded");
 
 		expect(await store.snapshot()).toEqual({
 			schema_version: 1,
@@ -52,7 +52,7 @@ describe("CodexProviderGenerationStore", () => {
 			updated_at: "2026-08-17T00:00:04.000Z",
 			last_heartbeat_at: "2026-08-17T00:00:02.000Z",
 			stop_cause: "deadline_exceeded",
-			observation: "stopped",
+			observation: "unresponsive",
 		});
 		const decoded = JSON.parse(
 			await readFile(join(directory, CODEX_PROVIDER_GENERATION_FILE), "utf8"),
@@ -71,7 +71,7 @@ describe("CodexProviderGenerationStore", () => {
 			"Previous Codex provider generation is not durably quiescent",
 		);
 
-		await first.markQuiescent(FIRST_GENERATION, "owner_lost", "stopped");
+		await first.finalizeQuiescentAsCurrent(FIRST_GENERATION, "owner_lost");
 		await expect(
 			replacement.begin(SECOND_GENERATION, FIRST_BOOT, DEADLINE_AT_MS),
 		).resolves.toMatchObject({
@@ -91,22 +91,6 @@ describe("CodexProviderGenerationStore", () => {
 		).resolves.toMatchObject({
 			generation_id: SECOND_GENERATION,
 			boot_session_id: SECOND_BOOT,
-			phase: "spawn_maybe_started",
-		});
-	});
-
-	it("does not rewrite another generation during pre-start cleanup", async () => {
-		const directory = await temporaryDirectory();
-		const store = await CodexProviderGenerationStore.open(directory, CAPSULE_ID);
-		await expect(
-			store.markQuiescentIfCurrent(FIRST_GENERATION, "startup_failure", "crashed"),
-		).resolves.toBe(false);
-		await store.begin(SECOND_GENERATION, FIRST_BOOT, DEADLINE_AT_MS);
-		await expect(
-			store.markQuiescentIfCurrent(FIRST_GENERATION, "startup_failure", "crashed"),
-		).resolves.toBe(false);
-		expect(await store.snapshot()).toMatchObject({
-			generation_id: SECOND_GENERATION,
 			phase: "spawn_maybe_started",
 		});
 	});

--- a/node/src/codex-provider-generation-state.ts
+++ b/node/src/codex-provider-generation-state.ts
@@ -13,10 +13,12 @@ export const CODEX_PROVIDER_STOP_CAUSES = [
 	"capsule_shutdown",
 	"startup_failure",
 	"provider_failure",
+	"provider_unresponsive",
 	"authority_revoked",
 	"deadline_exceeded",
 	"owner_lost",
 	"heartbeat_timeout",
+	"host_reboot",
 ] as const;
 
 export type CodexProviderStopCause = (typeof CODEX_PROVIDER_STOP_CAUSES)[number];
@@ -29,8 +31,10 @@ const providerGenerationStateSchema = z
 		schema_version: z.literal(1),
 		capsule_id: uuidSchema,
 		generation_id: uuidSchema,
+		boot_session_id: uuidSchema,
 		phase: z.enum(["spawn_maybe_started", "running", "stop_requested", "quiescent"]),
 		started_at: timestampSchema,
+		deadline_at: timestampSchema,
 		updated_at: timestampSchema,
 		last_heartbeat_at: timestampSchema.nullable(),
 		stop_cause: z.enum(CODEX_PROVIDER_STOP_CAUSES).nullable(),
@@ -67,27 +71,49 @@ export class CodexProviderGenerationStore {
 		);
 	}
 
-	async begin(generationIdValue: string): Promise<CodexProviderGenerationState> {
+	async begin(
+		generationIdValue: string,
+		bootSessionIdValue: string,
+		deadlineAtMs: number,
+	): Promise<CodexProviderGenerationState> {
 		const generationId = uuidSchema.parse(generationIdValue);
-		await this.#pendingWrite;
-		const previous = await this.readIfPresent();
-		if (previous !== null && previous.phase !== "quiescent") {
-			throw new Error("Previous Codex provider generation is not durably quiescent");
-		}
-		const timestamp = this.#now().toISOString();
-		const state = providerGenerationStateSchema.parse({
-			schema_version: 1,
-			capsule_id: this.#capsuleId,
-			generation_id: generationId,
-			phase: "spawn_maybe_started",
-			started_at: timestamp,
-			updated_at: timestamp,
-			last_heartbeat_at: null,
-			stop_cause: null,
-			observation: null,
+		const bootSessionId = uuidSchema.parse(bootSessionIdValue);
+		const deadlineAt = new Date(deadlineAtMs).toISOString();
+		const write = this.#pendingWrite.then(async () => {
+			const previous = await this.readIfPresent();
+			if (previous !== null && previous.phase !== "quiescent") {
+				if (previous.boot_session_id === bootSessionId) {
+					throw new Error("Previous Codex provider generation is not durably quiescent");
+				}
+				const rebootedAt = this.#now().toISOString();
+				previous.phase = "quiescent";
+				previous.stop_cause ??= "host_reboot";
+				previous.observation ??= "crashed";
+				previous.updated_at = rebootedAt;
+				await writePrivateJson(this.#path, providerGenerationStateSchema.parse(previous));
+			}
+			const timestamp = this.#now().toISOString();
+			const state = providerGenerationStateSchema.parse({
+				schema_version: 1,
+				capsule_id: this.#capsuleId,
+				generation_id: generationId,
+				boot_session_id: bootSessionId,
+				phase: "spawn_maybe_started",
+				started_at: timestamp,
+				deadline_at: deadlineAt,
+				updated_at: timestamp,
+				last_heartbeat_at: null,
+				stop_cause: null,
+				observation: null,
+			});
+			await writePrivateJson(this.#path, state);
+			return structuredClone(state);
 		});
-		await writePrivateJson(this.#path, state);
-		return structuredClone(state);
+		this.#pendingWrite = write.then(
+			() => undefined,
+			() => undefined,
+		);
+		return write;
 	}
 
 	markRunning(generationId: string): Promise<void> {
@@ -130,6 +156,29 @@ export class CodexProviderGenerationStore {
 	async snapshot(): Promise<CodexProviderGenerationState | null> {
 		await this.#pendingWrite;
 		return this.readIfPresent();
+	}
+
+	async markQuiescentIfCurrent(
+		generationIdValue: string,
+		cause: CodexProviderStopCause,
+		observation: CodexProviderObservation,
+	): Promise<boolean> {
+		const generationId = uuidSchema.parse(generationIdValue);
+		let updated = false;
+		const write = this.#pendingWrite.then(async () => {
+			const state = await this.readIfPresent();
+			if (state === null || state.generation_id !== generationId) return;
+			const timestamp = this.#now().toISOString();
+			state.phase = "quiescent";
+			state.stop_cause ??= cause;
+			state.observation ??= observation;
+			state.updated_at = timestamp;
+			await writePrivateJson(this.#path, providerGenerationStateSchema.parse(state));
+			updated = true;
+		});
+		this.#pendingWrite = write.catch(() => undefined);
+		await write;
+		return updated;
 	}
 
 	private async mutate(

--- a/node/src/codex-provider-generation-state.ts
+++ b/node/src/codex-provider-generation-state.ts
@@ -24,6 +24,22 @@ export const CODEX_PROVIDER_STOP_CAUSES = [
 export type CodexProviderStopCause = (typeof CODEX_PROVIDER_STOP_CAUSES)[number];
 export type CodexProviderObservation = "stopped" | "crashed" | "unresponsive";
 
+export function observationForProviderStopCause(
+	cause: CodexProviderStopCause,
+): CodexProviderObservation {
+	if (
+		cause === "deadline_exceeded" ||
+		cause === "heartbeat_timeout" ||
+		cause === "provider_unresponsive"
+	) {
+		return "unresponsive";
+	}
+	if (cause === "provider_failure" || cause === "startup_failure" || cause === "host_reboot") {
+		return "crashed";
+	}
+	return "stopped";
+}
+
 const timestampSchema = z.string().datetime({ offset: true });
 
 const providerGenerationStateSchema = z
@@ -179,6 +195,30 @@ export class CodexProviderGenerationStore {
 		this.#pendingWrite = write.catch(() => undefined);
 		await write;
 		return updated;
+	}
+
+	/** Called by the surviving reaper after process-group absence has been proven. */
+	async finalizeQuiescentAsCurrent(
+		generationIdValue: string,
+		cause: CodexProviderStopCause,
+	): Promise<CodexProviderGenerationState | null> {
+		const generationId = uuidSchema.parse(generationIdValue);
+		let finalized: CodexProviderGenerationState | null = null;
+		const write = this.#pendingWrite.then(async () => {
+			const state = await this.readIfPresent();
+			if (state === null || state.generation_id !== generationId) return;
+			const timestamp = this.#now().toISOString();
+			state.phase = "quiescent";
+			state.stop_cause = cause;
+			state.observation = observationForProviderStopCause(cause);
+			state.updated_at = timestamp;
+			const parsed = providerGenerationStateSchema.parse(state);
+			await writePrivateJson(this.#path, parsed);
+			finalized = structuredClone(parsed);
+		});
+		this.#pendingWrite = write.catch(() => undefined);
+		await write;
+		return finalized;
 	}
 
 	private async mutate(

--- a/node/src/codex-provider-generation-state.ts
+++ b/node/src/codex-provider-generation-state.ts
@@ -1,0 +1,168 @@
+import { join } from "node:path";
+import { uuidSchema } from "@agentrelay/protocol";
+import { z } from "zod";
+import {
+	ensurePrivateStateDirectory,
+	readPrivateJsonIfPresent,
+	writePrivateJson,
+} from "./private-state-file.js";
+
+export const CODEX_PROVIDER_GENERATION_FILE = "provider-generation.json";
+
+export const CODEX_PROVIDER_STOP_CAUSES = [
+	"capsule_shutdown",
+	"startup_failure",
+	"provider_failure",
+	"authority_revoked",
+	"deadline_exceeded",
+	"owner_lost",
+	"heartbeat_timeout",
+] as const;
+
+export type CodexProviderStopCause = (typeof CODEX_PROVIDER_STOP_CAUSES)[number];
+export type CodexProviderObservation = "stopped" | "crashed" | "unresponsive";
+
+const timestampSchema = z.string().datetime({ offset: true });
+
+const providerGenerationStateSchema = z
+	.object({
+		schema_version: z.literal(1),
+		capsule_id: uuidSchema,
+		generation_id: uuidSchema,
+		phase: z.enum(["spawn_maybe_started", "running", "stop_requested", "quiescent"]),
+		started_at: timestampSchema,
+		updated_at: timestampSchema,
+		last_heartbeat_at: timestampSchema.nullable(),
+		stop_cause: z.enum(CODEX_PROVIDER_STOP_CAUSES).nullable(),
+		observation: z.enum(["stopped", "crashed", "unresponsive"]).nullable(),
+	})
+	.strict();
+
+export type CodexProviderGenerationState = z.infer<typeof providerGenerationStateSchema>;
+
+/** Private, bounded lifecycle evidence. Kernel ownership remains the authority. */
+export class CodexProviderGenerationStore {
+	readonly #path: string;
+	readonly #capsuleId: string;
+	readonly #now: () => Date;
+	#pendingWrite: Promise<void> = Promise.resolve();
+
+	private constructor(path: string, capsuleId: string, now: () => Date) {
+		this.#path = path;
+		this.#capsuleId = capsuleId;
+		this.#now = now;
+	}
+
+	static async open(
+		directory: string,
+		capsuleIdValue: string,
+		now: () => Date = () => new Date(),
+	): Promise<CodexProviderGenerationStore> {
+		const capsuleId = uuidSchema.parse(capsuleIdValue);
+		await ensurePrivateStateDirectory(directory);
+		return new CodexProviderGenerationStore(
+			join(directory, CODEX_PROVIDER_GENERATION_FILE),
+			capsuleId,
+			now,
+		);
+	}
+
+	async begin(generationIdValue: string): Promise<CodexProviderGenerationState> {
+		const generationId = uuidSchema.parse(generationIdValue);
+		await this.#pendingWrite;
+		const previous = await this.readIfPresent();
+		if (previous !== null && previous.phase !== "quiescent") {
+			throw new Error("Previous Codex provider generation is not durably quiescent");
+		}
+		const timestamp = this.#now().toISOString();
+		const state = providerGenerationStateSchema.parse({
+			schema_version: 1,
+			capsule_id: this.#capsuleId,
+			generation_id: generationId,
+			phase: "spawn_maybe_started",
+			started_at: timestamp,
+			updated_at: timestamp,
+			last_heartbeat_at: null,
+			stop_cause: null,
+			observation: null,
+		});
+		await writePrivateJson(this.#path, state);
+		return structuredClone(state);
+	}
+
+	markRunning(generationId: string): Promise<void> {
+		return this.mutate(generationId, (state, timestamp) => {
+			if (state.phase !== "spawn_maybe_started") {
+				throw new Error("Codex provider generation cannot become running from its current phase");
+			}
+			state.phase = "running";
+			state.last_heartbeat_at = timestamp;
+		});
+	}
+
+	recordHeartbeat(generationId: string): Promise<void> {
+		return this.mutate(generationId, (state, timestamp) => {
+			if (state.phase !== "running") return;
+			state.last_heartbeat_at = timestamp;
+		});
+	}
+
+	requestStop(generationId: string, cause: CodexProviderStopCause): Promise<void> {
+		return this.mutate(generationId, (state) => {
+			if (state.phase === "quiescent") return;
+			state.phase = "stop_requested";
+			state.stop_cause ??= cause;
+		});
+	}
+
+	markQuiescent(
+		generationId: string,
+		cause: CodexProviderStopCause,
+		observation: CodexProviderObservation,
+	): Promise<void> {
+		return this.mutate(generationId, (state) => {
+			state.phase = "quiescent";
+			state.stop_cause ??= cause;
+			state.observation ??= observation;
+		});
+	}
+
+	async snapshot(): Promise<CodexProviderGenerationState | null> {
+		await this.#pendingWrite;
+		return this.readIfPresent();
+	}
+
+	private async mutate(
+		generationIdValue: string,
+		mutator: (state: CodexProviderGenerationState, timestamp: string) => void,
+	): Promise<void> {
+		const generationId = uuidSchema.parse(generationIdValue);
+		const write = this.#pendingWrite.then(async () => {
+			const state = await this.requireGeneration(generationId);
+			const timestamp = this.#now().toISOString();
+			mutator(state, timestamp);
+			state.updated_at = timestamp;
+			await writePrivateJson(this.#path, providerGenerationStateSchema.parse(state));
+		});
+		this.#pendingWrite = write.catch(() => undefined);
+		await write;
+	}
+
+	private async requireGeneration(generationId: string): Promise<CodexProviderGenerationState> {
+		const state = await this.readIfPresent();
+		if (state === null || state.generation_id !== generationId) {
+			throw new Error("Codex provider generation identity changed");
+		}
+		return state;
+	}
+
+	private async readIfPresent(): Promise<CodexProviderGenerationState | null> {
+		const decoded = await readPrivateJsonIfPresent(this.#path);
+		if (decoded === null) return null;
+		const state = providerGenerationStateSchema.parse(decoded);
+		if (state.capsule_id !== this.#capsuleId) {
+			throw new Error("Codex provider generation belongs to another Capsule");
+		}
+		return state;
+	}
+}

--- a/node/src/codex-provider-generation-state.ts
+++ b/node/src/codex-provider-generation-state.ts
@@ -157,44 +157,9 @@ export class CodexProviderGenerationStore {
 		});
 	}
 
-	markQuiescent(
-		generationId: string,
-		cause: CodexProviderStopCause,
-		observation: CodexProviderObservation,
-	): Promise<void> {
-		return this.mutate(generationId, (state) => {
-			state.phase = "quiescent";
-			state.stop_cause ??= cause;
-			state.observation ??= observation;
-		});
-	}
-
 	async snapshot(): Promise<CodexProviderGenerationState | null> {
 		await this.#pendingWrite;
 		return this.readIfPresent();
-	}
-
-	async markQuiescentIfCurrent(
-		generationIdValue: string,
-		cause: CodexProviderStopCause,
-		observation: CodexProviderObservation,
-	): Promise<boolean> {
-		const generationId = uuidSchema.parse(generationIdValue);
-		let updated = false;
-		const write = this.#pendingWrite.then(async () => {
-			const state = await this.readIfPresent();
-			if (state === null || state.generation_id !== generationId) return;
-			const timestamp = this.#now().toISOString();
-			state.phase = "quiescent";
-			state.stop_cause ??= cause;
-			state.observation ??= observation;
-			state.updated_at = timestamp;
-			await writePrivateJson(this.#path, providerGenerationStateSchema.parse(state));
-			updated = true;
-		});
-		this.#pendingWrite = write.catch(() => undefined);
-		await write;
-		return updated;
 	}
 
 	/** Called by the surviving reaper after process-group absence has been proven. */

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -56,7 +56,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 
 		const replacement = await createGuardian(fixture).openGeneration();
 		await replacement.terminate("capsule_shutdown");
-	});
+	}, 10_000);
 
 	it("revokes provider authority when the Capsule heartbeat stalls", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true });

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -40,103 +40,119 @@ afterEach(async () => {
 });
 
 describe.runIf(process.platform !== "win32")("Codex provider guardian owner death", () => {
-	it("leaves no durable start barrier when its owner dies before guardian spawn", async () => {
-		const fixture = await fakeAppServer();
-		const prepareStartedPath = join(fixture.directory, "prepare-started");
-		const owner = startOwner(fixture, { prepareDelayMs: 5_000, prepareStartedPath });
-		await waitForFile(prepareStartedPath);
+	it(
+		"leaves no durable start barrier when its owner dies before guardian spawn",
+		async () => {
+			const fixture = await fakeAppServer();
+			const prepareStartedPath = join(fixture.directory, "prepare-started");
+			const owner = startOwner(fixture, { prepareDelayMs: 5_000, prepareStartedPath });
+			await waitForFile(prepareStartedPath);
 
-		owner.kill("SIGKILL");
-		await childClose(owner);
-		await expect(
-			readFile(join(fixture.directory, CODEX_PROVIDER_GENERATION_FILE), "utf8"),
-		).rejects.toMatchObject({ code: "ENOENT" });
-		const replacement = await openGeneration(fixture);
-		await replacement.terminate("capsule_shutdown");
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			owner.kill("SIGKILL");
+			await childClose(owner);
+			await expect(
+				readFile(join(fixture.directory, CODEX_PROVIDER_GENERATION_FILE), "utf8"),
+			).rejects.toMatchObject({ code: "ENOENT" });
+			const replacement = await openGeneration(fixture);
+			await replacement.terminate("capsule_shutdown");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
-	it("records owner loss when death races the version probe", async () => {
-		const fixture = await fakeAppServer({ versionDelayMs: 1_000 });
-		const owner = startOwner(fixture);
-		await expect
-			.poll(() => generationState(fixture), { timeout: 5_000 })
-			.toMatchObject({ phase: "spawn_maybe_started" });
+	it(
+		"records owner loss when death races the version probe",
+		async () => {
+			const fixture = await fakeAppServer({ versionDelayMs: 1_000 });
+			const owner = startOwner(fixture);
+			await expect
+				.poll(() => generationState(fixture), { timeout: 5_000 })
+				.toMatchObject({ phase: "spawn_maybe_started" });
 
-		owner.kill("SIGKILL");
-		await childClose(owner);
-		await expect
-			.poll(() => generationState(fixture), { timeout: 5_000 })
-			.toMatchObject({
-				phase: "quiescent",
-				stop_cause: "owner_lost",
-				observation: "stopped",
+			owner.kill("SIGKILL");
+			await childClose(owner);
+			await expect
+				.poll(() => generationState(fixture), { timeout: 5_000 })
+				.toMatchObject({
+					phase: "quiescent",
+					stop_cause: "owner_lost",
+					observation: "stopped",
+				});
+			const replacement = await openGeneration(fixture);
+			await replacement.terminate("capsule_shutdown");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"kills the provider tree when its Capsule owner is SIGKILLed",
+		async () => {
+			const fixture = await fakeAppServer({
+				spawnDescendant: true,
+				ignoreSigterm: true,
+				continuousOutput: true,
+				gateContinuousOutput: true,
 			});
-		const replacement = await openGeneration(fixture);
-		await replacement.terminate("capsule_shutdown");
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			const owner = startOwner(fixture);
+			await waitForOwner(fixture);
+			const descendantPid = await waitForPid(fixture.childPidPath);
 
-	it("kills the provider tree when its Capsule owner is SIGKILLed", async () => {
-		const fixture = await fakeAppServer({
-			spawnDescendant: true,
-			ignoreSigterm: true,
-			continuousOutput: true,
-			gateContinuousOutput: true,
-		});
-		const owner = startOwner(fixture);
-		await waitForOwner(fixture);
-		const descendantPid = await waitForPid(fixture.childPidPath);
+			owner.kill("SIGKILL");
+			await childClose(owner);
+			await writeFile(fixture.continuousOutputGatePath, "go", { mode: 0o600 });
+			await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+				reason: "ownership",
+			});
+			await waitForProcessExit(descendantPid, 5_000);
+			await expect
+				.poll(() => generationState(fixture), { timeout: 5_000 })
+				.toMatchObject({
+					phase: "quiescent",
+					stop_cause: "owner_lost",
+					observation: "stopped",
+				});
 
-		owner.kill("SIGKILL");
-		await childClose(owner);
-		await writeFile(fixture.continuousOutputGatePath, "go", { mode: 0o600 });
-		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
-			reason: "ownership",
-		});
-		await waitForProcessExit(descendantPid, 5_000);
-		await expect
-			.poll(() => generationState(fixture), { timeout: 5_000 })
-			.toMatchObject({
-				phase: "quiescent",
-				stop_cause: "owner_lost",
-				observation: "stopped",
+			const replacement = await openGeneration(fixture);
+			await replacement.terminate("capsule_shutdown");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"revokes provider authority when the Capsule heartbeat stalls",
+		async () => {
+			const fixture = await fakeAppServer({ spawnDescendant: true });
+			const owner = startOwner(fixture);
+			await waitForOwner(fixture);
+			const descendantPid = await waitForPid(fixture.childPidPath);
+
+			owner.kill("SIGSTOP");
+			await waitForProcessExit(descendantPid);
+			await expect
+				.poll(() => generationState(fixture))
+				.toMatchObject({
+					phase: "stop_requested",
+					stop_cause: "heartbeat_timeout",
+					observation: null,
+				});
+			await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+				reason: "ownership",
 			});
 
-		const replacement = await openGeneration(fixture);
-		await replacement.terminate("capsule_shutdown");
-	}, GUARDIAN_TEST_TIMEOUT_MS);
-
-	it("revokes provider authority when the Capsule heartbeat stalls", async () => {
-		const fixture = await fakeAppServer({ spawnDescendant: true });
-		const owner = startOwner(fixture);
-		await waitForOwner(fixture);
-		const descendantPid = await waitForPid(fixture.childPidPath);
-
-		owner.kill("SIGSTOP");
-		await waitForProcessExit(descendantPid);
-		await expect
-			.poll(() => generationState(fixture))
-			.toMatchObject({
-				phase: "stop_requested",
-				stop_cause: "heartbeat_timeout",
-				observation: null,
-			});
-		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
-			reason: "ownership",
-		});
-
-		owner.kill("SIGCONT");
-		await expect
-			.poll(() => generationState(fixture), { timeout: 15_000 })
-			.toMatchObject({
-				phase: "quiescent",
-				stop_cause: "heartbeat_timeout",
-				observation: "unresponsive",
-			});
-		owner.kill("SIGKILL");
-		await childClose(owner);
-		const replacement = await openGeneration(fixture);
-		await replacement.terminate("capsule_shutdown");
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			owner.kill("SIGCONT");
+			await expect
+				.poll(() => generationState(fixture), { timeout: 15_000 })
+				.toMatchObject({
+					phase: "quiescent",
+					stop_cause: "heartbeat_timeout",
+					observation: "unresponsive",
+				});
+			owner.kill("SIGKILL");
+			await childClose(owner);
+			const replacement = await openGeneration(fixture);
+			await replacement.terminate("capsule_shutdown");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
 	it.runIf(process.platform === "linux")(
 		"kills remaining descendants when the guardian itself is SIGKILLed",

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -17,7 +17,10 @@ import {
 	CODEX_PROVIDER_GENERATION_FILE,
 	type CodexProviderGenerationState,
 } from "./codex-provider-generation-state.js";
-import { SupervisedCodexProviderGuardian } from "./codex-provider-guardian.js";
+import {
+	CodexProviderGuardianError,
+	SupervisedCodexProviderGuardian,
+} from "./codex-provider-guardian.js";
 import type { CodexSupervisorCommand } from "./codex-supervised-process.js";
 
 const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
@@ -53,7 +56,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			await expect(
 				readFile(join(fixture.directory, CODEX_PROVIDER_GENERATION_FILE), "utf8"),
 			).rejects.toMatchObject({ code: "ENOENT" });
-			const replacement = await openGeneration(fixture);
+			const replacement = await openGenerationWhenAvailable(fixture);
 			await replacement.terminate("capsule_shutdown");
 		},
 		GUARDIAN_TEST_TIMEOUT_MS,
@@ -77,7 +80,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 					stop_cause: "owner_lost",
 					observation: "stopped",
 				});
-			const replacement = await openGeneration(fixture);
+			const replacement = await openGenerationWhenAvailable(fixture);
 			await replacement.terminate("capsule_shutdown");
 		},
 		GUARDIAN_TEST_TIMEOUT_MS,
@@ -111,7 +114,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 					observation: "stopped",
 				});
 
-			const replacement = await openGeneration(fixture);
+			const replacement = await openGenerationWhenAvailable(fixture);
 			await replacement.terminate("capsule_shutdown");
 		},
 		GUARDIAN_TEST_TIMEOUT_MS,
@@ -126,7 +129,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			const descendantPid = await waitForPid(fixture.childPidPath);
 
 			owner.kill("SIGSTOP");
-			await waitForProcessExit(descendantPid);
+			await waitForProcessExit(descendantPid, 5_000);
 			await expect
 				.poll(() => generationState(fixture))
 				.toMatchObject({
@@ -148,7 +151,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 				});
 			owner.kill("SIGKILL");
 			await childClose(owner);
-			const replacement = await openGeneration(fixture);
+			const replacement = await openGenerationWhenAvailable(fixture);
 			await replacement.terminate("capsule_shutdown");
 		},
 		GUARDIAN_TEST_TIMEOUT_MS,
@@ -173,7 +176,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 					observation: "crashed",
 				});
 
-			const replacement = await openGeneration(fixture);
+			const replacement = await openGenerationWhenAvailable(fixture);
 			await replacement.terminate("capsule_shutdown");
 			owner.kill("SIGKILL");
 			await childClose(owner);
@@ -207,7 +210,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 					observation: "crashed",
 				});
 
-			const replacement = await openGeneration(fixture);
+			const replacement = await openGenerationWhenAvailable(fixture);
 			await replacement.terminate("capsule_shutdown");
 		},
 		GUARDIAN_TEST_TIMEOUT_MS,
@@ -272,10 +275,6 @@ function createGuardian(fixture: FakeAppServerFixture): SupervisedCodexProviderG
 		boundary: directCodexProcessBoundaryForTests,
 		deadlineAtMs: Date.now() + 60_000,
 		supervisor: sourceSupervisorCommand(),
-		startupTimeoutMs: 5_000,
-		heartbeatIntervalMs: 50,
-		heartbeatTimeoutMs: 500,
-		heartbeatRecordMs: 100,
 	});
 }
 
@@ -283,6 +282,23 @@ async function openGeneration(fixture: FakeAppServerFixture): Promise<CodexProvi
 	const generation = await createGuardian(fixture).openGeneration();
 	generations.push(generation);
 	return generation;
+}
+
+async function openGenerationWhenAvailable(
+	fixture: FakeAppServerFixture,
+): Promise<CodexProviderGeneration> {
+	const deadline = Date.now() + 5_000;
+	for (;;) {
+		try {
+			return await openGeneration(fixture);
+		} catch (error) {
+			if (!(error instanceof CodexProviderGuardianError) || error.reason !== "ownership") {
+				throw error;
+			}
+			if (Date.now() >= deadline) throw error;
+			await delay(10);
+		}
+	}
 }
 
 function sourceSupervisorCommand(): CodexSupervisorCommand {

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -9,6 +9,7 @@ import { directCodexProcessBoundaryForTests } from "../test-support/direct-codex
 import {
 	type FakeAppServerFixture,
 	createFakeAppServer,
+	isProcessAlive,
 	waitForPid,
 	waitForProcessExit,
 } from "../test-support/fake-codex-app-server.js";
@@ -28,6 +29,7 @@ const GUARDIAN_TEST_TIMEOUT_MS = 30_000;
 const fixtures: FakeAppServerFixture[] = [];
 const owners: ChildProcess[] = [];
 const generations: CodexProviderGeneration[] = [];
+const failClosedReapers = new Set<number>();
 
 afterEach(async () => {
 	for (const owner of owners.splice(0)) {
@@ -39,6 +41,7 @@ afterEach(async () => {
 	await Promise.allSettled(
 		generations.splice(0).map((generation) => generation.terminate("capsule_shutdown")),
 	);
+	await Promise.all([...failClosedReapers].map(stopFailClosedReaper));
 	await Promise.all(fixtures.splice(0).map((fixture) => fixture.remove()));
 });
 
@@ -215,7 +218,71 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 		},
 		GUARDIAN_TEST_TIMEOUT_MS,
 	);
+
+	it.runIf(process.platform === "linux")(
+		"retains ownership when durable generation state disappears after startup",
+		async () => {
+			await expectCorruptedStateToFailClosed("missing");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
+
+	it.runIf(process.platform === "linux")(
+		"retains ownership when durable generation identity changes after startup",
+		async () => {
+			await expectCorruptedStateToFailClosed("replaced");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 });
+
+async function expectCorruptedStateToFailClosed(mode: "missing" | "replaced"): Promise<void> {
+	const fixture = await fakeAppServer({ spawnDescendant: true });
+	const owner = startOwner(fixture);
+	await waitForOwner(fixture);
+	const guardianPid = await directChildPid(owner.pid!);
+	const reaperPid = await childPidContaining(guardianPid, "--reaper");
+	failClosedReapers.add(reaperPid);
+
+	owner.kill("SIGSTOP");
+	await waitForStoppedProcess(owner.pid!);
+	await corruptGenerationState(fixture, mode);
+	owner.kill("SIGKILL");
+	await childClose(owner);
+	await waitForProcessExit(guardianPid, 5_000);
+
+	await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+		reason: "ownership",
+	});
+	expect(isProcessAlive(reaperPid)).toBe(true);
+
+	await stopFailClosedReaper(reaperPid);
+	const replacement = await openGenerationWhenAvailable(fixture);
+	await replacement.terminate("capsule_shutdown");
+}
+
+async function corruptGenerationState(
+	fixture: FakeAppServerFixture,
+	mode: "missing" | "replaced",
+): Promise<void> {
+	const path = join(fixture.directory, CODEX_PROVIDER_GENERATION_FILE);
+	if (mode === "missing") {
+		await rm(path);
+		return;
+	}
+	const state = JSON.parse(await readFile(path, "utf8")) as CodexProviderGenerationState;
+	await writeFile(
+		path,
+		`${JSON.stringify({
+			...state,
+			generation_id: "10000000-0000-4000-8000-000000000099",
+			phase: "quiescent",
+			stop_cause: "owner_lost",
+			observation: "stopped",
+		})}\n`,
+		{ mode: 0o600 },
+	);
+}
 
 function startOwner(
 	fixture: FakeAppServerFixture,
@@ -342,6 +409,29 @@ async function directChildPid(ownerPid: number): Promise<number> {
 		await delay(10);
 	}
 	throw new Error("Could not identify the direct guardian child");
+}
+
+async function childPidContaining(parentPid: number, marker: string): Promise<number> {
+	const path = `/proc/${parentPid}/task/${parentPid}/children`;
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		const children = (await readFile(path, "utf8")).trim().split(/\s+/).filter(Boolean).map(Number);
+		for (const pid of children) {
+			const command = await readFile(`/proc/${pid}/cmdline`, "utf8").catch(() => "");
+			if (command.includes(marker)) return pid;
+		}
+		await delay(10);
+	}
+	throw new Error(`Could not identify child process containing ${marker}`);
+}
+
+async function stopFailClosedReaper(pid: number): Promise<void> {
+	const command = await readFile(`/proc/${pid}/cmdline`, "utf8").catch(() => "");
+	if (command.includes("--reaper")) {
+		process.kill(pid, "SIGKILL");
+		await waitForProcessExit(pid, 5_000);
+	}
+	failClosedReapers.delete(pid);
 }
 
 async function waitForStoppedProcess(pid: number): Promise<void> {

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -35,14 +35,17 @@ afterEach(async () => {
 
 describe.runIf(process.platform !== "win32")("Codex provider guardian owner death", () => {
 	it("kills the provider tree when its Capsule owner is SIGKILLed", async () => {
-		const fixture = await fakeAppServer({ spawnDescendant: true });
+		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
 		const owner = startOwner(fixture);
 		await waitForOwner(fixture);
 		const descendantPid = await waitForPid(fixture.childPidPath);
 
 		owner.kill("SIGKILL");
 		await childClose(owner);
-		await waitForProcessExit(descendantPid);
+		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+			reason: "ownership",
+		});
+		await waitForProcessExit(descendantPid, 5_000);
 		await expect
 			.poll(() => generationState(fixture))
 			.toMatchObject({

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -172,7 +172,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			process.kill(guardianPid, "SIGKILL");
 			await waitForProcessExit(descendantPid);
 			await expect
-				.poll(() => generationState(fixture))
+				.poll(() => generationState(fixture), { timeout: 5_000 })
 				.toMatchObject({
 					phase: "quiescent",
 					stop_cause: "provider_failure",

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -47,21 +47,24 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 
 		owner.kill("SIGKILL");
 		await childClose(owner);
+		await expect(
+			readFile(join(fixture.directory, CODEX_PROVIDER_GENERATION_FILE), "utf8"),
+		).rejects.toMatchObject({ code: "ENOENT" });
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	}, 10_000);
+	}, 15_000);
 
 	it("records owner loss when death races the version probe", async () => {
 		const fixture = await fakeAppServer({ versionDelayMs: 1_000 });
 		const owner = startOwner(fixture);
 		await expect
-			.poll(() => generationState(fixture))
+			.poll(() => generationState(fixture), { timeout: 5_000 })
 			.toMatchObject({ phase: "spawn_maybe_started" });
 
 		owner.kill("SIGKILL");
 		await childClose(owner);
 		await expect
-			.poll(() => generationState(fixture))
+			.poll(() => generationState(fixture), { timeout: 5_000 })
 			.toMatchObject({
 				phase: "quiescent",
 				stop_cause: "owner_lost",
@@ -69,22 +72,28 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			});
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	}, 10_000);
+	}, 15_000);
 
 	it("kills the provider tree when its Capsule owner is SIGKILLed", async () => {
-		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
+		const fixture = await fakeAppServer({
+			spawnDescendant: true,
+			ignoreSigterm: true,
+			continuousOutput: true,
+			gateContinuousOutput: true,
+		});
 		const owner = startOwner(fixture);
 		await waitForOwner(fixture);
 		const descendantPid = await waitForPid(fixture.childPidPath);
 
 		owner.kill("SIGKILL");
 		await childClose(owner);
+		await writeFile(fixture.continuousOutputGatePath, "go", { mode: 0o600 });
 		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
 			reason: "ownership",
 		});
 		await waitForProcessExit(descendantPid, 5_000);
 		await expect
-			.poll(() => generationState(fixture))
+			.poll(() => generationState(fixture), { timeout: 5_000 })
 			.toMatchObject({
 				phase: "quiescent",
 				stop_cause: "owner_lost",
@@ -93,7 +102,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	}, 10_000);
+	}, 15_000);
 
 	it("revokes provider authority when the Capsule heartbeat stalls", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true });
@@ -106,9 +115,9 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 		await expect
 			.poll(() => generationState(fixture))
 			.toMatchObject({
-				phase: "quiescent",
+				phase: "stop_requested",
 				stop_cause: "heartbeat_timeout",
-				observation: "unresponsive",
+				observation: null,
 			});
 		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
 			reason: "ownership",
@@ -116,9 +125,16 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 
 		owner.kill("SIGKILL");
 		await childClose(owner);
+		await expect
+			.poll(() => generationState(fixture), { timeout: 5_000 })
+			.toMatchObject({
+				phase: "quiescent",
+				stop_cause: "heartbeat_timeout",
+				observation: "unresponsive",
+			});
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	});
+	}, 15_000);
 
 	it.runIf(process.platform === "linux")(
 		"kills remaining descendants when the guardian itself is SIGKILLed",
@@ -144,6 +160,39 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			owner.kill("SIGKILL");
 			await childClose(owner);
 		},
+		15_000,
+	);
+
+	it.runIf(process.platform === "linux")(
+		"uses the teardown witness when Capsule and guardian die together",
+		async () => {
+			const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
+			const owner = startOwner(fixture);
+			await waitForOwner(fixture);
+			const descendantPid = await waitForPid(fixture.childPidPath);
+			const guardianPid = await directChildPid(owner.pid!);
+
+			owner.kill("SIGSTOP");
+			await waitForStoppedProcess(owner.pid!);
+			process.kill(guardianPid, "SIGKILL");
+			owner.kill("SIGKILL");
+			await childClose(owner);
+			await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+				reason: "ownership",
+			});
+			await waitForProcessExit(descendantPid, 5_000);
+			await expect
+				.poll(() => generationState(fixture), { timeout: 5_000 })
+				.toMatchObject({
+					phase: "quiescent",
+					stop_cause: "provider_failure",
+					observation: "crashed",
+				});
+
+			const replacement = await openGeneration(fixture);
+			await replacement.terminate("capsule_shutdown");
+		},
+		15_000,
 	);
 });
 
@@ -259,4 +308,15 @@ async function directChildPid(ownerPid: number): Promise<number> {
 		await delay(10);
 	}
 	throw new Error("Could not identify the direct guardian child");
+}
+
+async function waitForStoppedProcess(pid: number): Promise<void> {
+	const path = `/proc/${pid}/status`;
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		const status = await readFile(path, "utf8");
+		if (/^State:\s+T/m.test(status)) return;
+		await delay(10);
+	}
+	throw new Error(`Process ${pid} did not stop`);
 }

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -1,0 +1,207 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { directCodexProcessBoundaryForTests } from "../test-support/direct-codex-process-boundary.js";
+import {
+	type FakeAppServerFixture,
+	createFakeAppServer,
+	waitForPid,
+	waitForProcessExit,
+} from "../test-support/fake-codex-app-server.js";
+import {
+	CODEX_PROVIDER_GENERATION_FILE,
+	type CodexProviderGenerationState,
+} from "./codex-provider-generation-state.js";
+import { SupervisedCodexProviderGuardian } from "./codex-provider-guardian.js";
+import type { CodexSupervisorCommand } from "./codex-supervised-process.js";
+
+const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
+const fixtures: FakeAppServerFixture[] = [];
+const owners: ChildProcess[] = [];
+
+afterEach(async () => {
+	for (const owner of owners.splice(0)) {
+		if (owner.exitCode !== null || owner.signalCode !== null) continue;
+		owner.kill("SIGCONT");
+		owner.kill("SIGKILL");
+		await Promise.race([childClose(owner), delay(2_000)]);
+	}
+	await Promise.all(fixtures.splice(0).map((fixture) => fixture.remove()));
+});
+
+describe.runIf(process.platform !== "win32")("Codex provider guardian owner death", () => {
+	it("kills the provider tree when its Capsule owner is SIGKILLed", async () => {
+		const fixture = await fakeAppServer({ spawnDescendant: true });
+		const owner = startOwner(fixture);
+		await waitForOwner(fixture);
+		const descendantPid = await waitForPid(fixture.childPidPath);
+
+		owner.kill("SIGKILL");
+		await childClose(owner);
+		await waitForProcessExit(descendantPid);
+		await expect
+			.poll(() => generationState(fixture))
+			.toMatchObject({
+				phase: "quiescent",
+				stop_cause: "owner_lost",
+				observation: "stopped",
+			});
+
+		const replacement = await createGuardian(fixture).openGeneration();
+		await replacement.terminate("capsule_shutdown");
+	});
+
+	it("revokes provider authority when the Capsule heartbeat stalls", async () => {
+		const fixture = await fakeAppServer({ spawnDescendant: true });
+		const owner = startOwner(fixture);
+		await waitForOwner(fixture);
+		const descendantPid = await waitForPid(fixture.childPidPath);
+
+		owner.kill("SIGSTOP");
+		await waitForProcessExit(descendantPid);
+		await expect
+			.poll(() => generationState(fixture))
+			.toMatchObject({
+				phase: "quiescent",
+				stop_cause: "heartbeat_timeout",
+				observation: "unresponsive",
+			});
+		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+			reason: "ownership",
+		});
+
+		owner.kill("SIGKILL");
+		await childClose(owner);
+		const replacement = await createGuardian(fixture).openGeneration();
+		await replacement.terminate("capsule_shutdown");
+	});
+
+	it.runIf(process.platform === "linux")(
+		"kills remaining descendants when the guardian itself is SIGKILLed",
+		async () => {
+			const fixture = await fakeAppServer({ spawnDescendant: true });
+			const owner = startOwner(fixture);
+			await waitForOwner(fixture);
+			const descendantPid = await waitForPid(fixture.childPidPath);
+			const guardianPid = await directChildPid(owner.pid!);
+
+			process.kill(guardianPid, "SIGKILL");
+			await waitForProcessExit(descendantPid);
+			await expect
+				.poll(() => generationState(fixture))
+				.toMatchObject({
+					phase: "quiescent",
+					stop_cause: "provider_failure",
+					observation: "crashed",
+				});
+
+			const replacement = await createGuardian(fixture).openGeneration();
+			await replacement.terminate("capsule_shutdown");
+			owner.kill("SIGKILL");
+			await childClose(owner);
+		},
+	);
+});
+
+function startOwner(fixture: FakeAppServerFixture): ChildProcess {
+	const owner = spawn(
+		process.execPath,
+		[
+			"--import",
+			createRequire(import.meta.url).resolve("tsx"),
+			fileURLToPath(new URL("../test-support/codex-guardian-owner-worker.ts", import.meta.url)),
+		],
+		{
+			cwd: fixture.directory,
+			env: {
+				PATH: process.env.PATH,
+				TMPDIR: process.env.TMPDIR,
+				LANG: process.env.LANG,
+				TZ: process.env.TZ,
+				AGENTRELAY_TEST_CAPSULE_ID: CAPSULE_ID,
+				AGENTRELAY_TEST_CAPSULE_DIRECTORY: fixture.directory,
+				AGENTRELAY_TEST_CODEX_BIN: fixture.scriptPath,
+				AGENTRELAY_TEST_READY_PATH: join(fixture.directory, "owner-ready.json"),
+				AGENTRELAY_NODE_TOKEN: "owner-death-token-canary",
+				OPENAI_API_KEY: "owner-death-openai-canary",
+			},
+			stdio: "ignore",
+		},
+	);
+	owners.push(owner);
+	return owner;
+}
+
+async function waitForOwner(fixture: FakeAppServerFixture): Promise<void> {
+	const path = join(fixture.directory, "owner-ready.json");
+	const deadline = Date.now() + 5_000;
+	while (Date.now() < deadline) {
+		const ready = await readFile(path, "utf8").catch(() => "");
+		if (ready !== "") return;
+		await delay(10);
+	}
+	throw new Error("Timed out waiting for the guardian owner worker");
+}
+
+function createGuardian(fixture: FakeAppServerFixture): SupervisedCodexProviderGuardian {
+	return new SupervisedCodexProviderGuardian({
+		capsuleId: CAPSULE_ID,
+		command: { executable: fixture.scriptPath },
+		cwd: fixture.directory,
+		capsuleDirectory: fixture.directory,
+		env: fixture.env,
+		boundary: directCodexProcessBoundaryForTests,
+		supervisor: sourceSupervisorCommand(),
+		startupTimeoutMs: 5_000,
+		heartbeatIntervalMs: 50,
+		heartbeatTimeoutMs: 500,
+		heartbeatRecordMs: 100,
+	});
+}
+
+function sourceSupervisorCommand(): CodexSupervisorCommand {
+	return {
+		executable: process.execPath,
+		args: [
+			"--import",
+			createRequire(import.meta.url).resolve("tsx"),
+			fileURLToPath(new URL("./bin/agentrelay-codex-guardian.ts", import.meta.url)),
+		],
+	};
+}
+
+async function generationState(
+	fixture: FakeAppServerFixture,
+): Promise<CodexProviderGenerationState> {
+	return JSON.parse(
+		await readFile(join(fixture.directory, CODEX_PROVIDER_GENERATION_FILE), "utf8"),
+	) as CodexProviderGenerationState;
+}
+
+async function fakeAppServer(
+	options: Parameters<typeof createFakeAppServer>[0] = {},
+): Promise<FakeAppServerFixture> {
+	const fixture = await createFakeAppServer(options);
+	fixtures.push(fixture);
+	return fixture;
+}
+
+function childClose(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+	return new Promise((resolve) => child.once("close", () => resolve()));
+}
+
+async function directChildPid(ownerPid: number): Promise<number> {
+	const path = `/proc/${ownerPid}/task/${ownerPid}/children`;
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		const children = (await readFile(path, "utf8")).trim().split(/\s+/).filter(Boolean).map(Number);
+		if (children.length === 1 && Number.isInteger(children[0])) return children[0]!;
+		await delay(10);
+	}
+	throw new Error("Could not identify the direct guardian child");
+}

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -12,6 +12,7 @@ import {
 	waitForPid,
 	waitForProcessExit,
 } from "../test-support/fake-codex-app-server.js";
+import type { CodexProviderGeneration } from "./codex-capsule-runner-contract.js";
 import {
 	CODEX_PROVIDER_GENERATION_FILE,
 	type CodexProviderGenerationState,
@@ -22,6 +23,7 @@ import type { CodexSupervisorCommand } from "./codex-supervised-process.js";
 const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
 const fixtures: FakeAppServerFixture[] = [];
 const owners: ChildProcess[] = [];
+const generations: CodexProviderGeneration[] = [];
 
 afterEach(async () => {
 	for (const owner of owners.splice(0)) {
@@ -30,10 +32,45 @@ afterEach(async () => {
 		owner.kill("SIGKILL");
 		await Promise.race([childClose(owner), delay(2_000)]);
 	}
+	await Promise.allSettled(
+		generations.splice(0).map((generation) => generation.terminate("capsule_shutdown")),
+	);
 	await Promise.all(fixtures.splice(0).map((fixture) => fixture.remove()));
 });
 
 describe.runIf(process.platform !== "win32")("Codex provider guardian owner death", () => {
+	it("leaves no durable start barrier when its owner dies before guardian spawn", async () => {
+		const fixture = await fakeAppServer();
+		const prepareStartedPath = join(fixture.directory, "prepare-started");
+		const owner = startOwner(fixture, { prepareDelayMs: 5_000, prepareStartedPath });
+		await waitForFile(prepareStartedPath);
+
+		owner.kill("SIGKILL");
+		await childClose(owner);
+		const replacement = await openGeneration(fixture);
+		await replacement.terminate("capsule_shutdown");
+	}, 10_000);
+
+	it("records owner loss when death races the version probe", async () => {
+		const fixture = await fakeAppServer({ versionDelayMs: 1_000 });
+		const owner = startOwner(fixture);
+		await expect
+			.poll(() => generationState(fixture))
+			.toMatchObject({ phase: "spawn_maybe_started" });
+
+		owner.kill("SIGKILL");
+		await childClose(owner);
+		await expect
+			.poll(() => generationState(fixture))
+			.toMatchObject({
+				phase: "quiescent",
+				stop_cause: "owner_lost",
+				observation: "stopped",
+			});
+		const replacement = await openGeneration(fixture);
+		await replacement.terminate("capsule_shutdown");
+	}, 10_000);
+
 	it("kills the provider tree when its Capsule owner is SIGKILLed", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
 		const owner = startOwner(fixture);
@@ -54,7 +91,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 				observation: "stopped",
 			});
 
-		const replacement = await createGuardian(fixture).openGeneration();
+		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
 	}, 10_000);
 
@@ -79,7 +116,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 
 		owner.kill("SIGKILL");
 		await childClose(owner);
-		const replacement = await createGuardian(fixture).openGeneration();
+		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
 	});
 
@@ -102,7 +139,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 					observation: "crashed",
 				});
 
-			const replacement = await createGuardian(fixture).openGeneration();
+			const replacement = await openGeneration(fixture);
 			await replacement.terminate("capsule_shutdown");
 			owner.kill("SIGKILL");
 			await childClose(owner);
@@ -110,7 +147,10 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 	);
 });
 
-function startOwner(fixture: FakeAppServerFixture): ChildProcess {
+function startOwner(
+	fixture: FakeAppServerFixture,
+	options: { readonly prepareDelayMs?: number; readonly prepareStartedPath?: string } = {},
+): ChildProcess {
 	const owner = spawn(
 		process.execPath,
 		[
@@ -129,6 +169,8 @@ function startOwner(fixture: FakeAppServerFixture): ChildProcess {
 				AGENTRELAY_TEST_CAPSULE_DIRECTORY: fixture.directory,
 				AGENTRELAY_TEST_CODEX_BIN: fixture.scriptPath,
 				AGENTRELAY_TEST_READY_PATH: join(fixture.directory, "owner-ready.json"),
+				AGENTRELAY_TEST_PREPARE_DELAY_MS: String(options.prepareDelayMs ?? 0),
+				AGENTRELAY_TEST_PREPARE_STARTED_PATH: options.prepareStartedPath,
 				AGENTRELAY_NODE_TOKEN: "owner-death-token-canary",
 				OPENAI_API_KEY: "owner-death-openai-canary",
 			},
@@ -140,14 +182,17 @@ function startOwner(fixture: FakeAppServerFixture): ChildProcess {
 }
 
 async function waitForOwner(fixture: FakeAppServerFixture): Promise<void> {
-	const path = join(fixture.directory, "owner-ready.json");
+	await waitForFile(join(fixture.directory, "owner-ready.json"));
+}
+
+async function waitForFile(path: string): Promise<void> {
 	const deadline = Date.now() + 5_000;
 	while (Date.now() < deadline) {
 		const ready = await readFile(path, "utf8").catch(() => "");
 		if (ready !== "") return;
 		await delay(10);
 	}
-	throw new Error("Timed out waiting for the guardian owner worker");
+	throw new Error(`Timed out waiting for ${path}`);
 }
 
 function createGuardian(fixture: FakeAppServerFixture): SupervisedCodexProviderGuardian {
@@ -158,12 +203,19 @@ function createGuardian(fixture: FakeAppServerFixture): SupervisedCodexProviderG
 		capsuleDirectory: fixture.directory,
 		env: fixture.env,
 		boundary: directCodexProcessBoundaryForTests,
+		deadlineAtMs: Date.now() + 60_000,
 		supervisor: sourceSupervisorCommand(),
 		startupTimeoutMs: 5_000,
 		heartbeatIntervalMs: 50,
 		heartbeatTimeoutMs: 500,
 		heartbeatRecordMs: 100,
 	});
+}
+
+async function openGeneration(fixture: FakeAppServerFixture): Promise<CodexProviderGeneration> {
+	const generation = await createGuardian(fixture).openGeneration();
+	generations.push(generation);
+	return generation;
 }
 
 function sourceSupervisorCommand(): CodexSupervisorCommand {

--- a/node/src/codex-provider-guardian.process.test.ts
+++ b/node/src/codex-provider-guardian.process.test.ts
@@ -21,6 +21,7 @@ import { SupervisedCodexProviderGuardian } from "./codex-provider-guardian.js";
 import type { CodexSupervisorCommand } from "./codex-supervised-process.js";
 
 const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
+const GUARDIAN_TEST_TIMEOUT_MS = 30_000;
 const fixtures: FakeAppServerFixture[] = [];
 const owners: ChildProcess[] = [];
 const generations: CodexProviderGeneration[] = [];
@@ -52,7 +53,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 		).rejects.toMatchObject({ code: "ENOENT" });
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	}, 15_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("records owner loss when death races the version probe", async () => {
 		const fixture = await fakeAppServer({ versionDelayMs: 1_000 });
@@ -72,7 +73,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			});
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	}, 15_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("kills the provider tree when its Capsule owner is SIGKILLed", async () => {
 		const fixture = await fakeAppServer({
@@ -102,7 +103,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	}, 15_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("revokes provider authority when the Capsule heartbeat stalls", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true });
@@ -123,18 +124,19 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			reason: "ownership",
 		});
 
-		owner.kill("SIGKILL");
-		await childClose(owner);
+		owner.kill("SIGCONT");
 		await expect
-			.poll(() => generationState(fixture), { timeout: 5_000 })
+			.poll(() => generationState(fixture), { timeout: 15_000 })
 			.toMatchObject({
 				phase: "quiescent",
 				stop_cause: "heartbeat_timeout",
 				observation: "unresponsive",
 			});
+		owner.kill("SIGKILL");
+		await childClose(owner);
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	}, 15_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it.runIf(process.platform === "linux")(
 		"kills remaining descendants when the guardian itself is SIGKILLed",
@@ -160,7 +162,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			owner.kill("SIGKILL");
 			await childClose(owner);
 		},
-		15_000,
+		GUARDIAN_TEST_TIMEOUT_MS,
 	);
 
 	it.runIf(process.platform === "linux")(
@@ -192,7 +194,7 @@ describe.runIf(process.platform !== "win32")("Codex provider guardian owner deat
 			const replacement = await openGeneration(fixture);
 			await replacement.terminate("capsule_shutdown");
 		},
-		15_000,
+		GUARDIAN_TEST_TIMEOUT_MS,
 	);
 });
 

--- a/node/src/codex-provider-guardian.test.ts
+++ b/node/src/codex-provider-guardian.test.ts
@@ -6,28 +6,36 @@ import { directCodexProcessBoundaryForTests } from "../test-support/direct-codex
 import {
 	type FakeAppServerFixture,
 	createFakeAppServer,
+	waitForEnvironment,
 	waitForPid,
 	waitForProcessExit,
 } from "../test-support/fake-codex-app-server.js";
+import type { CodexProviderGeneration } from "./codex-capsule-runner-contract.js";
 import {
 	CODEX_PROVIDER_GENERATION_FILE,
 	type CodexProviderGenerationState,
 } from "./codex-provider-generation-state.js";
-import { SupervisedCodexProviderGuardian } from "./codex-provider-guardian.js";
+import {
+	type CodexProviderGuardianOptions,
+	SupervisedCodexProviderGuardian,
+} from "./codex-provider-guardian.js";
 import type { CodexSupervisorCommand } from "./codex-supervised-process.js";
 
 const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
 const fixtures: FakeAppServerFixture[] = [];
+const generations: CodexProviderGeneration[] = [];
 
 afterEach(async () => {
+	await Promise.allSettled(
+		generations.splice(0).map((generation) => generation.terminate("capsule_shutdown")),
+	);
 	await Promise.all(fixtures.splice(0).map((fixture) => fixture.remove()));
 });
 
 describe("SupervisedCodexProviderGuardian", () => {
-	it("owns one real provider process lifecycle and records redacted quiescence", async () => {
+	it("owns one OS provider process lifecycle and records redacted quiescence", async () => {
 		const fixture = await fakeAppServer();
-		const guardian = createGuardian(fixture);
-		const generation = await guardian.openGeneration();
+		const generation = await openGeneration(fixture);
 
 		expect(await generation.client.startThread()).toMatchObject({
 			thread: { id: "thread-1" },
@@ -46,30 +54,61 @@ describe("SupervisedCodexProviderGuardian", () => {
 		expect(serialized).not.toContain(fixture.directory);
 		expect(serialized).not.toContain("pid");
 		expect(serialized).not.toContain("OPENAI_API_KEY");
+		const providerEnvironment = await waitForEnvironment(fixture.environmentPath);
+		expect(providerEnvironment).not.toHaveProperty("AGENTRELAY_NODE_TOKEN");
+		expect(providerEnvironment).not.toHaveProperty("OPENAI_API_KEY");
+		expect(providerEnvironment).not.toHaveProperty("CODEX_API_KEY");
 	});
 
-	it("allows only one concurrent generation owner", async () => {
+	it("allows only one concurrent generation owner across guardian instances", async () => {
 		const fixture = await fakeAppServer();
-		const first = await createGuardian(fixture).openGeneration();
-
-		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+		const contenders = await Promise.allSettled([
+			createGuardian(fixture).openGeneration(),
+			createGuardian(fixture).openGeneration(),
+		]);
+		const admitted = contenders.filter(
+			(result): result is PromiseFulfilledResult<CodexProviderGeneration> =>
+				result.status === "fulfilled",
+		);
+		const rejected = contenders.filter(
+			(result): result is PromiseRejectedResult => result.status === "rejected",
+		);
+		expect(admitted).toHaveLength(1);
+		expect(rejected).toHaveLength(1);
+		expect(rejected[0]?.reason).toMatchObject({
 			name: "CodexProviderGuardianError",
 			reason: "ownership",
 			message: "Codex provider generation ownership is unavailable",
 		});
+		const first = admitted[0]!.value;
+		generations.push(first);
 
 		await first.terminate("capsule_shutdown");
-		const replacement = await createGuardian(fixture).openGeneration();
+		const replacement = await openGeneration(fixture);
 		expect(replacement.generationId).not.toBe(first.generationId);
 		await replacement.terminate("capsule_shutdown");
 	});
 
+	it("rejects a second open while the same guardian is still opening", async () => {
+		const fixture = await fakeAppServer();
+		const guardian = createGuardian(fixture);
+		const firstOpening = guardian.openGeneration();
+
+		await expect(guardian.openGeneration()).rejects.toMatchObject({
+			reason: "ownership",
+		});
+		const generation = await firstOpening;
+		generations.push(generation);
+	});
+
 	it("kills provider descendants when authority is revoked", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
-		const generation = await createGuardian(fixture).openGeneration();
+		const authority = new AbortController();
+		const generation = await openGeneration(fixture, { authoritySignal: authority.signal });
 		const descendantPid = await waitForPid(fixture.childPidPath);
 
-		await generation.terminate("authority_revoked");
+		authority.abort();
+		await generation.termination;
 		await waitForProcessExit(descendantPid, 5_000);
 		expect(await generation.termination).toEqual({ kind: "stopped" });
 		expect(await generationState(fixture)).toMatchObject({
@@ -78,9 +117,38 @@ describe("SupervisedCodexProviderGuardian", () => {
 		});
 	});
 
+	it("enforces its absolute deadline against an unresponsive provider tree", async () => {
+		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
+		const generation = await openGeneration(fixture, { deadlineAtMs: Date.now() + 1_000 });
+		const descendantPid = await waitForPid(fixture.childPidPath);
+
+		await expect(generation.termination).resolves.toEqual({ kind: "unresponsive" });
+		await waitForProcessExit(descendantPid, 5_000);
+		expect(await generationState(fixture)).toMatchObject({
+			phase: "quiescent",
+			stop_cause: "deadline_exceeded",
+			observation: "unresponsive",
+		});
+	}, 8_000);
+
+	it("classifies an unresponsive provider request and tears down its authority", async () => {
+		const fixture = await fakeAppServer({ ignoreRead: true });
+		const generation = await openGeneration(fixture, { requestTimeoutMs: 100 });
+
+		await expect(generation.client.readThread("thread-1")).rejects.toThrow(
+			"Timed out waiting for Codex app-server method thread/read",
+		);
+		await expect(generation.termination).resolves.toEqual({ kind: "unresponsive" });
+		expect(await generationState(fixture)).toMatchObject({
+			phase: "quiescent",
+			stop_cause: "provider_unresponsive",
+			observation: "unresponsive",
+		});
+	});
+
 	it("classifies an unexpected provider exit and leaves no reusable authority", async () => {
 		const fixture = await fakeAppServer({ exitAfterRead: true });
-		const generation = await createGuardian(fixture).openGeneration();
+		const generation = await openGeneration(fixture);
 
 		await expect(generation.client.readThread("thread-1")).resolves.toMatchObject({
 			id: "thread-1",
@@ -92,9 +160,33 @@ describe("SupervisedCodexProviderGuardian", () => {
 			observation: "crashed",
 		});
 	});
+
+	it("redacts startup failure details and durably closes the generation", async () => {
+		const fixture = await fakeAppServer({ version: "0.0.0-secret-path" });
+
+		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+			name: "CodexProviderGuardianError",
+			reason: "startup",
+			message: "Codex provider generation failed to start",
+		});
+		const state = await generationState(fixture);
+		expect(state).toMatchObject({
+			phase: "quiescent",
+			stop_cause: "startup_failure",
+			observation: "crashed",
+		});
+		expect(JSON.stringify(state)).not.toContain(fixture.directory);
+	});
 });
 
-function createGuardian(fixture: FakeAppServerFixture): SupervisedCodexProviderGuardian {
+type GuardianOverrides = Partial<
+	Pick<CodexProviderGuardianOptions, "authoritySignal" | "deadlineAtMs" | "requestTimeoutMs">
+>;
+
+function createGuardian(
+	fixture: FakeAppServerFixture,
+	overrides: GuardianOverrides = {},
+): SupervisedCodexProviderGuardian {
 	return new SupervisedCodexProviderGuardian({
 		capsuleId: CAPSULE_ID,
 		command: { executable: fixture.scriptPath },
@@ -102,12 +194,23 @@ function createGuardian(fixture: FakeAppServerFixture): SupervisedCodexProviderG
 		capsuleDirectory: fixture.directory,
 		env: fixture.env,
 		boundary: directCodexProcessBoundaryForTests,
+		deadlineAtMs: Date.now() + 60_000,
 		supervisor: sourceSupervisorCommand(),
 		startupTimeoutMs: 5_000,
 		heartbeatIntervalMs: 50,
 		heartbeatTimeoutMs: 500,
 		heartbeatRecordMs: 100,
+		...overrides,
 	});
+}
+
+async function openGeneration(
+	fixture: FakeAppServerFixture,
+	overrides: GuardianOverrides = {},
+): Promise<CodexProviderGeneration> {
+	const generation = await createGuardian(fixture, overrides).openGeneration();
+	generations.push(generation);
+	return generation;
 }
 
 function sourceSupervisorCommand(): CodexSupervisorCommand {

--- a/node/src/codex-provider-guardian.test.ts
+++ b/node/src/codex-provider-guardian.test.ts
@@ -285,10 +285,6 @@ function createGuardian(
 		boundary: directCodexProcessBoundaryForTests,
 		deadlineAtMs: Date.now() + 60_000,
 		supervisor: sourceSupervisorCommand(),
-		startupTimeoutMs: 5_000,
-		heartbeatIntervalMs: 50,
-		heartbeatTimeoutMs: 500,
-		heartbeatRecordMs: 100,
 		...overrides,
 	});
 }

--- a/node/src/codex-provider-guardian.test.ts
+++ b/node/src/codex-provider-guardian.test.ts
@@ -34,89 +34,105 @@ afterEach(async () => {
 });
 
 describe("SupervisedCodexProviderGuardian", () => {
-	it("owns one OS provider process lifecycle and records redacted quiescence", async () => {
-		const fixture = await fakeAppServer();
-		const generation = await openGeneration(fixture);
+	it(
+		"owns one OS provider process lifecycle and records redacted quiescence",
+		async () => {
+			const fixture = await fakeAppServer();
+			const generation = await openGeneration(fixture);
 
-		expect(await generation.client.startThread()).toMatchObject({
-			thread: { id: "thread-1" },
-		});
-		await generation.terminate("capsule_shutdown");
-		await expect(generation.termination).resolves.toEqual({ kind: "stopped" });
+			expect(await generation.client.startThread()).toMatchObject({
+				thread: { id: "thread-1" },
+			});
+			await generation.terminate("capsule_shutdown");
+			await expect(generation.termination).resolves.toEqual({ kind: "stopped" });
 
-		const state = await generationState(fixture);
-		expect(state).toMatchObject({
-			generation_id: generation.generationId,
-			phase: "quiescent",
-			stop_cause: "capsule_shutdown",
-			observation: "stopped",
-		});
-		const serialized = JSON.stringify(state);
-		expect(serialized).not.toContain(fixture.directory);
-		expect(serialized).not.toContain("pid");
-		expect(serialized).not.toContain("OPENAI_API_KEY");
-		const providerEnvironment = await waitForEnvironment(fixture.environmentPath);
-		expect(providerEnvironment).not.toHaveProperty("AGENTRELAY_NODE_TOKEN");
-		expect(providerEnvironment).not.toHaveProperty("OPENAI_API_KEY");
-		expect(providerEnvironment).not.toHaveProperty("CODEX_API_KEY");
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			const state = await generationState(fixture);
+			expect(state).toMatchObject({
+				generation_id: generation.generationId,
+				phase: "quiescent",
+				stop_cause: "capsule_shutdown",
+				observation: "stopped",
+			});
+			const serialized = JSON.stringify(state);
+			expect(serialized).not.toContain(fixture.directory);
+			expect(serialized).not.toContain("pid");
+			expect(serialized).not.toContain("OPENAI_API_KEY");
+			const providerEnvironment = await waitForEnvironment(fixture.environmentPath);
+			expect(providerEnvironment).not.toHaveProperty("AGENTRELAY_NODE_TOKEN");
+			expect(providerEnvironment).not.toHaveProperty("OPENAI_API_KEY");
+			expect(providerEnvironment).not.toHaveProperty("CODEX_API_KEY");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
-	it("allows only one concurrent generation owner across guardian instances", async () => {
-		const fixture = await fakeAppServer();
-		const contenders = await Promise.allSettled([
-			createGuardian(fixture).openGeneration(),
-			createGuardian(fixture).openGeneration(),
-		]);
-		const admitted = contenders.filter(
-			(result): result is PromiseFulfilledResult<CodexProviderGeneration> =>
-				result.status === "fulfilled",
-		);
-		const rejected = contenders.filter(
-			(result): result is PromiseRejectedResult => result.status === "rejected",
-		);
-		expect(admitted).toHaveLength(1);
-		expect(rejected).toHaveLength(1);
-		expect(rejected[0]?.reason).toMatchObject({
-			name: "CodexProviderGuardianError",
-			reason: "ownership",
-			message: "Codex provider generation ownership is unavailable",
-		});
-		const first = admitted[0]!.value;
-		generations.push(first);
+	it(
+		"allows only one concurrent generation owner across guardian instances",
+		async () => {
+			const fixture = await fakeAppServer();
+			const contenders = await Promise.allSettled([
+				createGuardian(fixture).openGeneration(),
+				createGuardian(fixture).openGeneration(),
+			]);
+			const admitted = contenders.filter(
+				(result): result is PromiseFulfilledResult<CodexProviderGeneration> =>
+					result.status === "fulfilled",
+			);
+			const rejected = contenders.filter(
+				(result): result is PromiseRejectedResult => result.status === "rejected",
+			);
+			expect(admitted).toHaveLength(1);
+			expect(rejected).toHaveLength(1);
+			expect(rejected[0]?.reason).toMatchObject({
+				name: "CodexProviderGuardianError",
+				reason: "ownership",
+				message: "Codex provider generation ownership is unavailable",
+			});
+			const first = admitted[0]!.value;
+			generations.push(first);
 
-		await first.terminate("capsule_shutdown");
-		const replacement = await openGeneration(fixture);
-		expect(replacement.generationId).not.toBe(first.generationId);
-		await replacement.terminate("capsule_shutdown");
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			await first.terminate("capsule_shutdown");
+			const replacement = await openGeneration(fixture);
+			expect(replacement.generationId).not.toBe(first.generationId);
+			await replacement.terminate("capsule_shutdown");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
-	it("rejects a second open while the same guardian is still opening", async () => {
-		const fixture = await fakeAppServer();
-		const guardian = createGuardian(fixture);
-		const firstOpening = guardian.openGeneration();
+	it(
+		"rejects a second open while the same guardian is still opening",
+		async () => {
+			const fixture = await fakeAppServer();
+			const guardian = createGuardian(fixture);
+			const firstOpening = guardian.openGeneration();
 
-		await expect(guardian.openGeneration()).rejects.toMatchObject({
-			reason: "ownership",
-		});
-		const generation = await firstOpening;
-		generations.push(generation);
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			await expect(guardian.openGeneration()).rejects.toMatchObject({
+				reason: "ownership",
+			});
+			const generation = await firstOpening;
+			generations.push(generation);
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
-	it("kills provider descendants when authority is revoked", async () => {
-		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
-		const authority = new AbortController();
-		const generation = await openGeneration(fixture, { authoritySignal: authority.signal });
-		const descendantPid = await waitForPid(fixture.childPidPath);
+	it(
+		"kills provider descendants when authority is revoked",
+		async () => {
+			const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
+			const authority = new AbortController();
+			const generation = await openGeneration(fixture, { authoritySignal: authority.signal });
+			const descendantPid = await waitForPid(fixture.childPidPath);
 
-		authority.abort();
-		await generation.termination;
-		await waitForProcessExit(descendantPid, 5_000);
-		expect(await generation.termination).toEqual({ kind: "stopped" });
-		expect(await generationState(fixture)).toMatchObject({
-			stop_cause: "authority_revoked",
-			phase: "quiescent",
-		});
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			authority.abort();
+			await generation.termination;
+			await waitForProcessExit(descendantPid, 5_000);
+			expect(await generation.termination).toEqual({ kind: "stopped" });
+			expect(await generationState(fixture)).toMatchObject({
+				stop_cause: "authority_revoked",
+				phase: "quiescent",
+			});
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
 	it("does not admit a provider when authority is revoked during preparation", async () => {
 		const fixture = await fakeAppServer();
@@ -143,90 +159,110 @@ describe("SupervisedCodexProviderGuardian", () => {
 		await expect(readFile(fixture.argvPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
 	});
 
-	it("writes no start barrier when the teardown witness cannot arm", async () => {
-		const fixture = await fakeAppServer();
+	it(
+		"writes no start barrier when the teardown witness cannot arm",
+		async () => {
+			const fixture = await fakeAppServer();
 
-		await expect(
-			createGuardian(fixture, {
-				reaper: {
-					executable: process.execPath,
-					args: ["--eval", "process.exit(1)"],
-				},
-			}).openGeneration(),
-		).rejects.toMatchObject({
-			name: "CodexProviderGuardianError",
-			reason: "startup",
-			message: "Codex provider generation failed to start",
-		});
-		await expect(
-			readFile(`${fixture.directory}/${CODEX_PROVIDER_GENERATION_FILE}`, "utf8"),
-		).rejects.toMatchObject({ code: "ENOENT" });
-		await expect(readFile(fixture.argvPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+			await expect(
+				createGuardian(fixture, {
+					reaper: {
+						executable: process.execPath,
+						args: ["--eval", "process.exit(1)"],
+					},
+				}).openGeneration(),
+			).rejects.toMatchObject({
+				name: "CodexProviderGuardianError",
+				reason: "startup",
+				message: "Codex provider generation failed to start",
+			});
+			await expect(
+				readFile(`${fixture.directory}/${CODEX_PROVIDER_GENERATION_FILE}`, "utf8"),
+			).rejects.toMatchObject({ code: "ENOENT" });
+			await expect(readFile(fixture.argvPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
 
-		const replacement = await openGeneration(fixture);
-		await replacement.terminate("capsule_shutdown");
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			const replacement = await openGeneration(fixture);
+			await replacement.terminate("capsule_shutdown");
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
-	it("enforces its absolute deadline against an unresponsive provider tree", async () => {
-		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
-		const generation = await openGeneration(fixture, { deadlineAtMs: Date.now() + 1_000 });
-		const descendantPid = await waitForPid(fixture.childPidPath);
+	it(
+		"enforces its absolute deadline against an unresponsive provider tree",
+		async () => {
+			const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
+			const generation = await openGeneration(fixture, { deadlineAtMs: Date.now() + 1_000 });
+			const descendantPid = await waitForPid(fixture.childPidPath);
 
-		await expect(generation.termination).resolves.toEqual({ kind: "unresponsive" });
-		await waitForProcessExit(descendantPid, 5_000);
-		expect(await generationState(fixture)).toMatchObject({
-			phase: "quiescent",
-			stop_cause: "deadline_exceeded",
-			observation: "unresponsive",
-		});
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			await expect(generation.termination).resolves.toEqual({ kind: "unresponsive" });
+			await waitForProcessExit(descendantPid, 5_000);
+			expect(await generationState(fixture)).toMatchObject({
+				phase: "quiescent",
+				stop_cause: "deadline_exceeded",
+				observation: "unresponsive",
+			});
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
-	it("classifies an unresponsive provider request and tears down its authority", async () => {
-		const fixture = await fakeAppServer({ ignoreRead: true });
-		const generation = await openGeneration(fixture, { requestTimeoutMs: 100 });
+	it(
+		"classifies an unresponsive provider request and tears down its authority",
+		async () => {
+			const fixture = await fakeAppServer({ ignoreRead: true });
+			const generation = await openGeneration(fixture, { requestTimeoutMs: 100 });
 
-		await expect(generation.client.readThread("thread-1")).rejects.toThrow(
-			"Timed out waiting for Codex app-server method thread/read",
-		);
-		await expect(generation.termination).resolves.toEqual({ kind: "unresponsive" });
-		expect(await generationState(fixture)).toMatchObject({
-			phase: "quiescent",
-			stop_cause: "provider_unresponsive",
-			observation: "unresponsive",
-		});
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			await expect(generation.client.readThread("thread-1")).rejects.toThrow(
+				"Timed out waiting for Codex app-server method thread/read",
+			);
+			await expect(generation.termination).resolves.toEqual({ kind: "unresponsive" });
+			expect(await generationState(fixture)).toMatchObject({
+				phase: "quiescent",
+				stop_cause: "provider_unresponsive",
+				observation: "unresponsive",
+			});
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
-	it("classifies an unexpected provider exit and leaves no reusable authority", async () => {
-		const fixture = await fakeAppServer({ exitAfterRead: true });
-		const generation = await openGeneration(fixture);
+	it(
+		"classifies an unexpected provider exit and leaves no reusable authority",
+		async () => {
+			const fixture = await fakeAppServer({ exitAfterRead: true });
+			const generation = await openGeneration(fixture);
 
-		await expect(generation.client.readThread("thread-1")).resolves.toMatchObject({
-			id: "thread-1",
-		});
-		await expect(generation.termination).resolves.toEqual({ kind: "crashed" });
-		expect(await generationState(fixture)).toMatchObject({
-			phase: "quiescent",
-			stop_cause: "provider_failure",
-			observation: "crashed",
-		});
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			await expect(generation.client.readThread("thread-1")).resolves.toMatchObject({
+				id: "thread-1",
+			});
+			await expect(generation.termination).resolves.toEqual({ kind: "crashed" });
+			expect(await generationState(fixture)).toMatchObject({
+				phase: "quiescent",
+				stop_cause: "provider_failure",
+				observation: "crashed",
+			});
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 
-	it("redacts startup failure details and durably closes the generation", async () => {
-		const fixture = await fakeAppServer({ version: "0.0.0-secret-path" });
+	it(
+		"redacts startup failure details and durably closes the generation",
+		async () => {
+			const fixture = await fakeAppServer({ version: "0.0.0-secret-path" });
 
-		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
-			name: "CodexProviderGuardianError",
-			reason: "startup",
-			message: "Codex provider generation failed to start",
-		});
-		const state = await generationState(fixture);
-		expect(state).toMatchObject({
-			phase: "quiescent",
-			stop_cause: "startup_failure",
-			observation: "crashed",
-		});
-		expect(JSON.stringify(state)).not.toContain(fixture.directory);
-	}, GUARDIAN_TEST_TIMEOUT_MS);
+			await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+				name: "CodexProviderGuardianError",
+				reason: "startup",
+				message: "Codex provider generation failed to start",
+			});
+			const state = await generationState(fixture);
+			expect(state).toMatchObject({
+				phase: "quiescent",
+				stop_cause: "startup_failure",
+				observation: "crashed",
+			});
+			expect(JSON.stringify(state)).not.toContain(fixture.directory);
+		},
+		GUARDIAN_TEST_TIMEOUT_MS,
+	);
 });
 
 type GuardianOverrides = Partial<

--- a/node/src/codex-provider-guardian.test.ts
+++ b/node/src/codex-provider-guardian.test.ts
@@ -58,7 +58,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 		expect(providerEnvironment).not.toHaveProperty("AGENTRELAY_NODE_TOKEN");
 		expect(providerEnvironment).not.toHaveProperty("OPENAI_API_KEY");
 		expect(providerEnvironment).not.toHaveProperty("CODEX_API_KEY");
-	});
+	}, 12_000);
 
 	it("allows only one concurrent generation owner across guardian instances", async () => {
 		const fixture = await fakeAppServer();
@@ -87,7 +87,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 		const replacement = await openGeneration(fixture);
 		expect(replacement.generationId).not.toBe(first.generationId);
 		await replacement.terminate("capsule_shutdown");
-	});
+	}, 12_000);
 
 	it("rejects a second open while the same guardian is still opening", async () => {
 		const fixture = await fakeAppServer();
@@ -142,6 +142,30 @@ describe("SupervisedCodexProviderGuardian", () => {
 		await expect(readFile(fixture.argvPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
 	});
 
+	it("writes no start barrier when the teardown witness cannot arm", async () => {
+		const fixture = await fakeAppServer();
+
+		await expect(
+			createGuardian(fixture, {
+				reaper: {
+					executable: process.execPath,
+					args: ["--eval", "process.exit(1)"],
+				},
+			}).openGeneration(),
+		).rejects.toMatchObject({
+			name: "CodexProviderGuardianError",
+			reason: "startup",
+			message: "Codex provider generation failed to start",
+		});
+		await expect(
+			readFile(`${fixture.directory}/${CODEX_PROVIDER_GENERATION_FILE}`, "utf8"),
+		).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(readFile(fixture.argvPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+		const replacement = await openGeneration(fixture);
+		await replacement.terminate("capsule_shutdown");
+	}, 15_000);
+
 	it("enforces its absolute deadline against an unresponsive provider tree", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
 		const generation = await openGeneration(fixture, { deadlineAtMs: Date.now() + 1_000 });
@@ -184,7 +208,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 			stop_cause: "provider_failure",
 			observation: "crashed",
 		});
-	});
+	}, 12_000);
 
 	it("redacts startup failure details and durably closes the generation", async () => {
 		const fixture = await fakeAppServer({ version: "0.0.0-secret-path" });
@@ -207,7 +231,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 type GuardianOverrides = Partial<
 	Pick<
 		CodexProviderGuardianOptions,
-		"authoritySignal" | "boundary" | "deadlineAtMs" | "requestTimeoutMs"
+		"authoritySignal" | "boundary" | "deadlineAtMs" | "reaper" | "requestTimeoutMs"
 	>
 >;
 

--- a/node/src/codex-provider-guardian.test.ts
+++ b/node/src/codex-provider-guardian.test.ts
@@ -65,12 +65,12 @@ describe("SupervisedCodexProviderGuardian", () => {
 	});
 
 	it("kills provider descendants when authority is revoked", async () => {
-		const fixture = await fakeAppServer({ spawnDescendant: true });
+		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
 		const generation = await createGuardian(fixture).openGeneration();
 		const descendantPid = await waitForPid(fixture.childPidPath);
 
 		await generation.terminate("authority_revoked");
-		await waitForProcessExit(descendantPid);
+		await waitForProcessExit(descendantPid, 5_000);
 		expect(await generation.termination).toEqual({ kind: "stopped" });
 		expect(await generationState(fixture)).toMatchObject({
 			stop_cause: "authority_revoked",

--- a/node/src/codex-provider-guardian.test.ts
+++ b/node/src/codex-provider-guardian.test.ts
@@ -1,0 +1,138 @@
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { directCodexProcessBoundaryForTests } from "../test-support/direct-codex-process-boundary.js";
+import {
+	type FakeAppServerFixture,
+	createFakeAppServer,
+	waitForPid,
+	waitForProcessExit,
+} from "../test-support/fake-codex-app-server.js";
+import {
+	CODEX_PROVIDER_GENERATION_FILE,
+	type CodexProviderGenerationState,
+} from "./codex-provider-generation-state.js";
+import { SupervisedCodexProviderGuardian } from "./codex-provider-guardian.js";
+import type { CodexSupervisorCommand } from "./codex-supervised-process.js";
+
+const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
+const fixtures: FakeAppServerFixture[] = [];
+
+afterEach(async () => {
+	await Promise.all(fixtures.splice(0).map((fixture) => fixture.remove()));
+});
+
+describe("SupervisedCodexProviderGuardian", () => {
+	it("owns one real provider process lifecycle and records redacted quiescence", async () => {
+		const fixture = await fakeAppServer();
+		const guardian = createGuardian(fixture);
+		const generation = await guardian.openGeneration();
+
+		expect(await generation.client.startThread()).toMatchObject({
+			thread: { id: "thread-1" },
+		});
+		await generation.terminate("capsule_shutdown");
+		await expect(generation.termination).resolves.toEqual({ kind: "stopped" });
+
+		const state = await generationState(fixture);
+		expect(state).toMatchObject({
+			generation_id: generation.generationId,
+			phase: "quiescent",
+			stop_cause: "capsule_shutdown",
+			observation: "stopped",
+		});
+		const serialized = JSON.stringify(state);
+		expect(serialized).not.toContain(fixture.directory);
+		expect(serialized).not.toContain("pid");
+		expect(serialized).not.toContain("OPENAI_API_KEY");
+	});
+
+	it("allows only one concurrent generation owner", async () => {
+		const fixture = await fakeAppServer();
+		const first = await createGuardian(fixture).openGeneration();
+
+		await expect(createGuardian(fixture).openGeneration()).rejects.toMatchObject({
+			name: "CodexProviderGuardianError",
+			reason: "ownership",
+			message: "Codex provider generation ownership is unavailable",
+		});
+
+		await first.terminate("capsule_shutdown");
+		const replacement = await createGuardian(fixture).openGeneration();
+		expect(replacement.generationId).not.toBe(first.generationId);
+		await replacement.terminate("capsule_shutdown");
+	});
+
+	it("kills provider descendants when authority is revoked", async () => {
+		const fixture = await fakeAppServer({ spawnDescendant: true });
+		const generation = await createGuardian(fixture).openGeneration();
+		const descendantPid = await waitForPid(fixture.childPidPath);
+
+		await generation.terminate("authority_revoked");
+		await waitForProcessExit(descendantPid);
+		expect(await generation.termination).toEqual({ kind: "stopped" });
+		expect(await generationState(fixture)).toMatchObject({
+			stop_cause: "authority_revoked",
+			phase: "quiescent",
+		});
+	});
+
+	it("classifies an unexpected provider exit and leaves no reusable authority", async () => {
+		const fixture = await fakeAppServer({ exitAfterRead: true });
+		const generation = await createGuardian(fixture).openGeneration();
+
+		await expect(generation.client.readThread("thread-1")).resolves.toMatchObject({
+			id: "thread-1",
+		});
+		await expect(generation.termination).resolves.toEqual({ kind: "crashed" });
+		expect(await generationState(fixture)).toMatchObject({
+			phase: "quiescent",
+			stop_cause: "provider_failure",
+			observation: "crashed",
+		});
+	});
+});
+
+function createGuardian(fixture: FakeAppServerFixture): SupervisedCodexProviderGuardian {
+	return new SupervisedCodexProviderGuardian({
+		capsuleId: CAPSULE_ID,
+		command: { executable: fixture.scriptPath },
+		cwd: fixture.directory,
+		capsuleDirectory: fixture.directory,
+		env: fixture.env,
+		boundary: directCodexProcessBoundaryForTests,
+		supervisor: sourceSupervisorCommand(),
+		startupTimeoutMs: 5_000,
+		heartbeatIntervalMs: 50,
+		heartbeatTimeoutMs: 500,
+		heartbeatRecordMs: 100,
+	});
+}
+
+function sourceSupervisorCommand(): CodexSupervisorCommand {
+	return {
+		executable: process.execPath,
+		args: [
+			"--import",
+			createRequire(import.meta.url).resolve("tsx"),
+			fileURLToPath(new URL("./bin/agentrelay-codex-guardian.ts", import.meta.url)),
+		],
+	};
+}
+
+async function fakeAppServer(
+	options: Parameters<typeof createFakeAppServer>[0] = {},
+): Promise<FakeAppServerFixture> {
+	const fixture = await createFakeAppServer(options);
+	fixtures.push(fixture);
+	return fixture;
+}
+
+async function generationState(
+	fixture: FakeAppServerFixture,
+): Promise<CodexProviderGenerationState> {
+	return JSON.parse(
+		await readFile(`${fixture.directory}/${CODEX_PROVIDER_GENERATION_FILE}`, "utf8"),
+	) as CodexProviderGenerationState;
+}

--- a/node/src/codex-provider-guardian.test.ts
+++ b/node/src/codex-provider-guardian.test.ts
@@ -117,6 +117,31 @@ describe("SupervisedCodexProviderGuardian", () => {
 		});
 	});
 
+	it("does not admit a provider when authority is revoked during preparation", async () => {
+		const fixture = await fakeAppServer();
+		const authority = new AbortController();
+		let prepareCalls = 0;
+		const boundary = {
+			async prepare(request: Parameters<typeof directCodexProcessBoundaryForTests.prepare>[0]) {
+				prepareCalls += 1;
+				if (prepareCalls === 1) authority.abort();
+				return directCodexProcessBoundaryForTests.prepare(request);
+			},
+		};
+
+		await expect(
+			createGuardian(fixture, {
+				authoritySignal: authority.signal,
+				boundary,
+			}).openGeneration(),
+		).rejects.toMatchObject({
+			name: "CodexProviderGuardianError",
+			reason: "authority",
+			message: "Codex provider authority is revoked",
+		});
+		await expect(readFile(fixture.argvPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
 	it("enforces its absolute deadline against an unresponsive provider tree", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
 		const generation = await openGeneration(fixture, { deadlineAtMs: Date.now() + 1_000 });
@@ -180,7 +205,10 @@ describe("SupervisedCodexProviderGuardian", () => {
 });
 
 type GuardianOverrides = Partial<
-	Pick<CodexProviderGuardianOptions, "authoritySignal" | "deadlineAtMs" | "requestTimeoutMs">
+	Pick<
+		CodexProviderGuardianOptions,
+		"authoritySignal" | "boundary" | "deadlineAtMs" | "requestTimeoutMs"
+	>
 >;
 
 function createGuardian(

--- a/node/src/codex-provider-guardian.test.ts
+++ b/node/src/codex-provider-guardian.test.ts
@@ -22,6 +22,7 @@ import {
 import type { CodexSupervisorCommand } from "./codex-supervised-process.js";
 
 const CAPSULE_ID = "10000000-0000-4000-8000-000000000001";
+const GUARDIAN_TEST_TIMEOUT_MS = 30_000;
 const fixtures: FakeAppServerFixture[] = [];
 const generations: CodexProviderGeneration[] = [];
 
@@ -58,7 +59,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 		expect(providerEnvironment).not.toHaveProperty("AGENTRELAY_NODE_TOKEN");
 		expect(providerEnvironment).not.toHaveProperty("OPENAI_API_KEY");
 		expect(providerEnvironment).not.toHaveProperty("CODEX_API_KEY");
-	}, 12_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("allows only one concurrent generation owner across guardian instances", async () => {
 		const fixture = await fakeAppServer();
@@ -87,7 +88,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 		const replacement = await openGeneration(fixture);
 		expect(replacement.generationId).not.toBe(first.generationId);
 		await replacement.terminate("capsule_shutdown");
-	}, 12_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("rejects a second open while the same guardian is still opening", async () => {
 		const fixture = await fakeAppServer();
@@ -99,7 +100,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 		});
 		const generation = await firstOpening;
 		generations.push(generation);
-	});
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("kills provider descendants when authority is revoked", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
@@ -115,7 +116,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 			stop_cause: "authority_revoked",
 			phase: "quiescent",
 		});
-	});
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("does not admit a provider when authority is revoked during preparation", async () => {
 		const fixture = await fakeAppServer();
@@ -164,7 +165,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 
 		const replacement = await openGeneration(fixture);
 		await replacement.terminate("capsule_shutdown");
-	}, 15_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("enforces its absolute deadline against an unresponsive provider tree", async () => {
 		const fixture = await fakeAppServer({ spawnDescendant: true, ignoreSigterm: true });
@@ -178,7 +179,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 			stop_cause: "deadline_exceeded",
 			observation: "unresponsive",
 		});
-	}, 8_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("classifies an unresponsive provider request and tears down its authority", async () => {
 		const fixture = await fakeAppServer({ ignoreRead: true });
@@ -193,7 +194,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 			stop_cause: "provider_unresponsive",
 			observation: "unresponsive",
 		});
-	});
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("classifies an unexpected provider exit and leaves no reusable authority", async () => {
 		const fixture = await fakeAppServer({ exitAfterRead: true });
@@ -208,7 +209,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 			stop_cause: "provider_failure",
 			observation: "crashed",
 		});
-	}, 12_000);
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 
 	it("redacts startup failure details and durably closes the generation", async () => {
 		const fixture = await fakeAppServer({ version: "0.0.0-secret-path" });
@@ -225,7 +226,7 @@ describe("SupervisedCodexProviderGuardian", () => {
 			observation: "crashed",
 		});
 		expect(JSON.stringify(state)).not.toContain(fixture.directory);
-	});
+	}, GUARDIAN_TEST_TIMEOUT_MS);
 });
 
 type GuardianOverrides = Partial<

--- a/node/src/codex-provider-guardian.ts
+++ b/node/src/codex-provider-guardian.ts
@@ -26,6 +26,7 @@ export interface CodexProviderGuardianOptions extends CodexAppServerClientOption
 	readonly deadlineAtMs: number;
 	readonly authoritySignal?: AbortSignal;
 	readonly supervisor?: CodexSupervisorCommand;
+	readonly reaper?: CodexSupervisorCommand;
 	readonly startupTimeoutMs?: number;
 	readonly heartbeatIntervalMs?: number;
 	readonly heartbeatTimeoutMs?: number;
@@ -47,12 +48,21 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 	readonly #options: CodexProviderGuardianOptions;
 	#opening: Promise<CodexProviderGeneration> | null = null;
 	#active: CodexProviderGeneration | null = null;
+	#failedClosed = false;
 
 	constructor(options: CodexProviderGuardianOptions) {
 		this.#options = { ...options, capsuleId: uuidSchema.parse(options.capsuleId) };
 	}
 
 	openGeneration(): Promise<CodexProviderGeneration> {
+		if (this.#failedClosed) {
+			return Promise.reject(
+				new CodexProviderGuardianError(
+					"state",
+					"Codex provider guardian is fail-closed after unproven teardown",
+				),
+			);
+		}
 		if (this.#options.authoritySignal?.aborted === true) {
 			return Promise.reject(
 				new CodexProviderGuardianError("authority", "Codex provider authority is revoked"),
@@ -119,6 +129,7 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 							capsuleDirectory: this.#options.capsuleDirectory,
 							generationId,
 							supervisor: this.#options.supervisor ?? defaultSupervisorCommand(),
+							reaper: this.#options.reaper,
 							process: processOptions,
 							lock,
 							store,
@@ -153,6 +164,7 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 					if (this.#active === generation) this.#active = null;
 				},
 				() => {
+					this.#failedClosed = true;
 					removeAuthorityListener();
 					if (this.#active === generation) this.#active = null;
 				},
@@ -164,7 +176,9 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 			if (supervised === null) {
 				await lock.release().catch(() => undefined);
 			} else {
-				await supervised.stop("startup_failure").catch(() => undefined);
+				await supervised.stop("startup_failure").catch(() => {
+					this.#failedClosed = true;
+				});
 			}
 			if (
 				error instanceof CodexProviderGuardianError ||

--- a/node/src/codex-provider-guardian.ts
+++ b/node/src/codex-provider-guardian.ts
@@ -140,6 +140,10 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 				},
 			});
 			const supervised = requireSupervisedProcess(supervisedRef.value);
+			if (this.#options.authoritySignal?.aborted === true) {
+				await supervised.stop("authority_revoked");
+				throw new CodexProviderGuardianError("authority", "Codex provider authority is revoked");
+			}
 			supervised.activate();
 			const generation = providerGeneration(generationId, client, supervised);
 			this.#active = generation;
@@ -154,13 +158,19 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 				},
 			);
 			return generation;
-		} catch {
+		} catch (error) {
 			removeAuthorityListener();
 			const supervised = supervisedRef.value;
 			if (supervised === null) {
 				await lock.release().catch(() => undefined);
 			} else {
 				await supervised.stop("startup_failure").catch(() => undefined);
+			}
+			if (
+				error instanceof CodexProviderGuardianError ||
+				this.#options.authoritySignal?.aborted === true
+			) {
+				throw new CodexProviderGuardianError("authority", "Codex provider authority is revoked");
 			}
 			throw new CodexProviderGuardianError("startup", "Codex provider generation failed to start");
 		}

--- a/node/src/codex-provider-guardian.ts
+++ b/node/src/codex-provider-guardian.ts
@@ -23,6 +23,8 @@ export const CODEX_PROVIDER_LOCK_FILE = "provider.lock";
 
 export interface CodexProviderGuardianOptions extends CodexAppServerClientOptions {
 	readonly capsuleId: string;
+	readonly deadlineAtMs: number;
+	readonly authoritySignal?: AbortSignal;
 	readonly supervisor?: CodexSupervisorCommand;
 	readonly startupTimeoutMs?: number;
 	readonly heartbeatIntervalMs?: number;
@@ -32,7 +34,7 @@ export interface CodexProviderGuardianOptions extends CodexAppServerClientOption
 
 export class CodexProviderGuardianError extends Error {
 	constructor(
-		readonly reason: "ownership" | "startup" | "state",
+		readonly reason: "authority" | "ownership" | "startup" | "state",
 		message: string,
 	) {
 		super(message);
@@ -51,15 +53,21 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 	}
 
 	openGeneration(): Promise<CodexProviderGeneration> {
-		if (this.#active !== null) {
+		if (this.#options.authoritySignal?.aborted === true) {
+			return Promise.reject(
+				new CodexProviderGuardianError("authority", "Codex provider authority is revoked"),
+			);
+		}
+		if (this.#opening !== null || this.#active !== null) {
 			return Promise.reject(
 				new CodexProviderGuardianError("ownership", "Codex provider generation is already active"),
 			);
 		}
-		this.#opening ??= this.performOpen().finally(() => {
-			this.#opening = null;
+		const opening = this.performOpen();
+		this.#opening = opening;
+		return opening.finally(() => {
+			if (this.#opening === opening) this.#opening = null;
 		});
-		return this.#opening;
 	}
 
 	private async performOpen(): Promise<CodexProviderGeneration> {
@@ -83,7 +91,6 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 				this.#options.capsuleDirectory,
 				this.#options.capsuleId,
 			);
-			await store.begin(generationId);
 		} catch {
 			await lock.release().catch(() => undefined);
 			throw new CodexProviderGuardianError(
@@ -93,6 +100,7 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 		}
 
 		const supervisedRef: { value: CodexSupervisedProcess | null } = { value: null };
+		let removeAuthorityListener: () => void = () => undefined;
 		try {
 			const client = await CodexAppServerClient.start({
 				command: this.#options.command,
@@ -105,19 +113,29 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 					if (supervisedRef.value !== null) {
 						throw new Error("Codex provider process was requested twice");
 					}
-					supervisedRef.value = await CodexSupervisedProcess.start({
-						capsuleId: this.#options.capsuleId,
-						capsuleDirectory: this.#options.capsuleDirectory,
-						generationId,
-						supervisor: this.#options.supervisor ?? defaultSupervisorCommand(),
-						process: processOptions,
-						lock,
-						store,
-						startupTimeoutMs: this.#options.startupTimeoutMs,
-						heartbeatIntervalMs: this.#options.heartbeatIntervalMs,
-						heartbeatTimeoutMs: this.#options.heartbeatTimeoutMs,
-						heartbeatRecordMs: this.#options.heartbeatRecordMs,
-					});
+					supervisedRef.value = await CodexSupervisedProcess.start(
+						{
+							capsuleId: this.#options.capsuleId,
+							capsuleDirectory: this.#options.capsuleDirectory,
+							generationId,
+							supervisor: this.#options.supervisor ?? defaultSupervisorCommand(),
+							process: processOptions,
+							lock,
+							store,
+							deadlineAtMs: this.#options.deadlineAtMs,
+							startupTimeoutMs: this.#options.startupTimeoutMs,
+							heartbeatIntervalMs: this.#options.heartbeatIntervalMs,
+							heartbeatTimeoutMs: this.#options.heartbeatTimeoutMs,
+							heartbeatRecordMs: this.#options.heartbeatRecordMs,
+						},
+						(supervised) => {
+							supervisedRef.value = supervised;
+							removeAuthorityListener = bindAuthoritySignal(
+								this.#options.authoritySignal,
+								supervised,
+							);
+						},
+					);
 					return supervisedRef.value.process;
 				},
 			});
@@ -125,16 +143,21 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 			supervised.activate();
 			const generation = providerGeneration(generationId, client, supervised);
 			this.#active = generation;
-			void generation.termination.then(() => {
-				if (this.#active === generation) this.#active = null;
-			});
+			void generation.termination.then(
+				() => {
+					removeAuthorityListener();
+					if (this.#active === generation) this.#active = null;
+				},
+				() => {
+					removeAuthorityListener();
+					if (this.#active === generation) this.#active = null;
+				},
+			);
 			return generation;
 		} catch {
+			removeAuthorityListener();
 			const supervised = supervisedRef.value;
 			if (supervised === null) {
-				await store
-					.markQuiescent(generationId, "startup_failure", "crashed")
-					.catch(() => undefined);
 				await lock.release().catch(() => undefined);
 			} else {
 				await supervised.stop("startup_failure").catch(() => undefined);
@@ -142,6 +165,19 @@ export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
 			throw new CodexProviderGuardianError("startup", "Codex provider generation failed to start");
 		}
 	}
+}
+
+function bindAuthoritySignal(
+	signal: AbortSignal | undefined,
+	supervised: CodexSupervisedProcess,
+): () => void {
+	if (signal === undefined) return () => undefined;
+	const revoke = () => {
+		void supervised.stop("authority_revoked").catch(() => undefined);
+	};
+	signal.addEventListener("abort", revoke, { once: true });
+	if (signal.aborted) revoke();
+	return () => signal.removeEventListener("abort", revoke);
 }
 
 function requireSupervisedProcess(value: CodexSupervisedProcess | null): CodexSupervisedProcess {

--- a/node/src/codex-provider-guardian.ts
+++ b/node/src/codex-provider-guardian.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { uuidSchema } from "@agentrelay/protocol";
+import { CodexAppServerClient } from "./codex-app-server-client.js";
+import type { CodexAppServerClientOptions } from "./codex-app-server-client.js";
+import type {
+	CodexCapsuleClient,
+	CodexProviderGeneration,
+	CodexProviderGuardian,
+	CodexProviderTerminationReason,
+} from "./codex-capsule-runner-contract.js";
+import { CodexProviderGenerationStore } from "./codex-provider-generation-state.js";
+import { CodexSupervisedProcess } from "./codex-supervised-process.js";
+import type { CodexSupervisorCommand } from "./codex-supervised-process.js";
+import {
+	PROVIDER_GENERATION_LOCK_KIND,
+	type ProcessLock,
+	acquireProcessLock,
+} from "./process-lock.js";
+
+export const CODEX_PROVIDER_LOCK_FILE = "provider.lock";
+
+export interface CodexProviderGuardianOptions extends CodexAppServerClientOptions {
+	readonly capsuleId: string;
+	readonly supervisor?: CodexSupervisorCommand;
+	readonly startupTimeoutMs?: number;
+	readonly heartbeatIntervalMs?: number;
+	readonly heartbeatTimeoutMs?: number;
+	readonly heartbeatRecordMs?: number;
+}
+
+export class CodexProviderGuardianError extends Error {
+	constructor(
+		readonly reason: "ownership" | "startup" | "state",
+		message: string,
+	) {
+		super(message);
+		this.name = "CodexProviderGuardianError";
+	}
+}
+
+/** Owns exactly one supervised Codex provider generation for one Capsule. */
+export class SupervisedCodexProviderGuardian implements CodexProviderGuardian {
+	readonly #options: CodexProviderGuardianOptions;
+	#opening: Promise<CodexProviderGeneration> | null = null;
+	#active: CodexProviderGeneration | null = null;
+
+	constructor(options: CodexProviderGuardianOptions) {
+		this.#options = { ...options, capsuleId: uuidSchema.parse(options.capsuleId) };
+	}
+
+	openGeneration(): Promise<CodexProviderGeneration> {
+		if (this.#active !== null) {
+			return Promise.reject(
+				new CodexProviderGuardianError("ownership", "Codex provider generation is already active"),
+			);
+		}
+		this.#opening ??= this.performOpen().finally(() => {
+			this.#opening = null;
+		});
+		return this.#opening;
+	}
+
+	private async performOpen(): Promise<CodexProviderGeneration> {
+		const generationId = randomUUID();
+		let lock: ProcessLock;
+		try {
+			lock = await acquireProcessLock(
+				join(this.#options.capsuleDirectory, CODEX_PROVIDER_LOCK_FILE),
+				{ kind: PROVIDER_GENERATION_LOCK_KIND },
+			);
+		} catch {
+			throw new CodexProviderGuardianError(
+				"ownership",
+				"Codex provider generation ownership is unavailable",
+			);
+		}
+
+		let store: CodexProviderGenerationStore;
+		try {
+			store = await CodexProviderGenerationStore.open(
+				this.#options.capsuleDirectory,
+				this.#options.capsuleId,
+			);
+			await store.begin(generationId);
+		} catch {
+			await lock.release().catch(() => undefined);
+			throw new CodexProviderGuardianError(
+				"state",
+				"Codex provider generation state is not safely recoverable",
+			);
+		}
+
+		const supervisedRef: { value: CodexSupervisedProcess | null } = { value: null };
+		try {
+			const client = await CodexAppServerClient.start({
+				command: this.#options.command,
+				cwd: this.#options.cwd,
+				capsuleDirectory: this.#options.capsuleDirectory,
+				env: this.#options.env,
+				boundary: this.#options.boundary,
+				requestTimeoutMs: this.#options.requestTimeoutMs,
+				processFactory: async (processOptions) => {
+					if (supervisedRef.value !== null) {
+						throw new Error("Codex provider process was requested twice");
+					}
+					supervisedRef.value = await CodexSupervisedProcess.start({
+						capsuleId: this.#options.capsuleId,
+						capsuleDirectory: this.#options.capsuleDirectory,
+						generationId,
+						supervisor: this.#options.supervisor ?? defaultSupervisorCommand(),
+						process: processOptions,
+						lock,
+						store,
+						startupTimeoutMs: this.#options.startupTimeoutMs,
+						heartbeatIntervalMs: this.#options.heartbeatIntervalMs,
+						heartbeatTimeoutMs: this.#options.heartbeatTimeoutMs,
+						heartbeatRecordMs: this.#options.heartbeatRecordMs,
+					});
+					return supervisedRef.value.process;
+				},
+			});
+			const supervised = requireSupervisedProcess(supervisedRef.value);
+			supervised.activate();
+			const generation = providerGeneration(generationId, client, supervised);
+			this.#active = generation;
+			void generation.termination.then(() => {
+				if (this.#active === generation) this.#active = null;
+			});
+			return generation;
+		} catch {
+			const supervised = supervisedRef.value;
+			if (supervised === null) {
+				await store
+					.markQuiescent(generationId, "startup_failure", "crashed")
+					.catch(() => undefined);
+				await lock.release().catch(() => undefined);
+			} else {
+				await supervised.stop("startup_failure").catch(() => undefined);
+			}
+			throw new CodexProviderGuardianError("startup", "Codex provider generation failed to start");
+		}
+	}
+}
+
+function requireSupervisedProcess(value: CodexSupervisedProcess | null): CodexSupervisedProcess {
+	if (value === null) throw new Error("Codex provider supervisor was not created");
+	return value;
+}
+
+function providerGeneration(
+	generationId: string,
+	client: CodexAppServerClient,
+	supervised: CodexSupervisedProcess,
+): CodexProviderGeneration {
+	let termination: Promise<void> | null = null;
+	return Object.freeze({
+		generationId,
+		client: client as CodexCapsuleClient,
+		termination: supervised.termination,
+		terminate(reason: CodexProviderTerminationReason): Promise<void> {
+			supervised.setStopCause(reason);
+			termination ??= client.close().then(() => supervised.stop(reason));
+			return termination;
+		},
+	});
+}
+
+function defaultSupervisorCommand(): CodexSupervisorCommand {
+	return {
+		executable: process.execPath,
+		args: [fileURLToPath(new URL("./bin/agentrelay-codex-guardian.js", import.meta.url))],
+	};
+}

--- a/node/src/codex-provider-lock.ts
+++ b/node/src/codex-provider-lock.ts
@@ -1,0 +1,24 @@
+import { fstatSync, lstatSync, readFileSync } from "node:fs";
+
+export const INHERITED_PROVIDER_LOCK_FD = 4;
+
+/** Proves that a trusted lifecycle child retained the guardian's exact kernel lock. */
+export function assertInheritedProviderLock(path: string): void {
+	const descriptor = fstatSync(INHERITED_PROVIDER_LOCK_FD);
+	const published = lstatSync(path);
+	if (
+		published.isSymbolicLink() ||
+		!published.isFile() ||
+		descriptor.dev !== published.dev ||
+		descriptor.ino !== published.ino ||
+		descriptor.nlink !== 1 ||
+		(published.mode & 0o777) !== 0o600 ||
+		(process.getuid !== undefined && published.uid !== process.getuid())
+	) {
+		throw new Error("Codex provider lifecycle child did not inherit the expected private lock");
+	}
+	const decoded = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+	if (decoded.schema_version !== 2 || decoded.kind !== "agentrelay_provider_generation_lock") {
+		throw new Error("Codex provider lifecycle lock kind is invalid");
+	}
+}

--- a/node/src/codex-provider-reaper-client.ts
+++ b/node/src/codex-provider-reaper-client.ts
@@ -1,0 +1,135 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import type { CodexProviderStopCause } from "./codex-provider-generation-state.js";
+import { INHERITED_PROVIDER_LOCK_FD } from "./codex-provider-lock.js";
+import {
+	type CodexProviderReaperCommand,
+	heartbeatReaperCommand,
+	initializeReaperCommand,
+	parseCodexProviderReaperEvent,
+	stopReaperCommand,
+} from "./codex-provider-reaper-protocol.js";
+import type { CodexPreparedProcess } from "./codex-provider-supervisor-protocol.js";
+import {
+	childClose,
+	childExit,
+	stopSupervisorProcessGroup,
+	waitForChildSpawn,
+} from "./codex-supervisor-owner.js";
+
+const REAPER_STARTUP_TIMEOUT_MS = 5_000;
+
+export interface CodexProviderReaperOptions {
+	readonly command: CodexPreparedProcess;
+	readonly capsuleId: string;
+	readonly generationId: string;
+	readonly lockPath: string;
+	readonly stateDirectory: string;
+	readonly deadlineAtMs: number;
+	readonly heartbeatTimeoutMs: number;
+}
+
+/** Guardian-side handle for the detached teardown witness. */
+export class CodexProviderReaperClient {
+	readonly termination: Promise<void>;
+	readonly #generationId: string;
+	readonly #child: ChildProcessWithoutNullStreams;
+
+	private constructor(
+		generationId: string,
+		child: ChildProcessWithoutNullStreams,
+		termination: Promise<void>,
+	) {
+		this.#generationId = generationId;
+		this.#child = child;
+		this.termination = termination;
+	}
+
+	static async start(options: CodexProviderReaperOptions): Promise<CodexProviderReaperClient> {
+		const child = spawn(options.command.executable, [...options.command.argv], {
+			cwd: options.command.cwd,
+			detached: true,
+			env: { ...options.command.env },
+			stdio: ["ignore", "ignore", "ignore", "ipc", INHERITED_PROVIDER_LOCK_FD],
+			shell: false,
+		}) as ChildProcessWithoutNullStreams;
+		const exited = childExit(child);
+		const closed = childClose(child).then(() => undefined);
+		try {
+			await waitForChildSpawn(child);
+			const ready = waitForReady(child, options.generationId, closed);
+			await sendReaperCommand(
+				child,
+				initializeReaperCommand({
+					capsuleId: options.capsuleId,
+					generationId: options.generationId,
+					lockPath: options.lockPath,
+					stateDirectory: options.stateDirectory,
+					targetProcessGroupId: process.pid,
+					deadlineAtMs: options.deadlineAtMs,
+					heartbeatTimeoutMs: options.heartbeatTimeoutMs,
+				}),
+			);
+			await ready;
+			return new CodexProviderReaperClient(options.generationId, child, closed);
+		} catch (error) {
+			await stopSupervisorProcessGroup(child, exited, closed).catch(() => undefined);
+			throw error;
+		}
+	}
+
+	heartbeat(): Promise<void> {
+		return sendReaperCommand(this.#child, heartbeatReaperCommand(this.#generationId));
+	}
+
+	async stop(cause: CodexProviderStopCause): Promise<never> {
+		await sendReaperCommand(this.#child, stopReaperCommand(this.#generationId, cause));
+		await this.termination;
+		throw new Error("Codex provider reaper exited before terminating its process group");
+	}
+}
+
+function sendReaperCommand(
+	child: ChildProcessWithoutNullStreams,
+	command: CodexProviderReaperCommand,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (!child.connected || child.send === undefined) {
+			reject(new Error("Codex provider reaper control channel is closed"));
+			return;
+		}
+		child.send(command, (error) => (error === null ? resolve() : reject(error)));
+	});
+}
+
+function waitForReady(
+	child: ChildProcessWithoutNullStreams,
+	generationId: string,
+	closed: Promise<void>,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			cleanup();
+			reject(new Error("Codex provider reaper timed out during startup"));
+		}, REAPER_STARTUP_TIMEOUT_MS);
+		const onMessage = (value: unknown) => {
+			try {
+				const event = parseCodexProviderReaperEvent(value);
+				if (event.generation_id !== generationId) return;
+				cleanup();
+				resolve();
+			} catch {
+				cleanup();
+				reject(new Error("Codex provider reaper returned an invalid control event"));
+			}
+		};
+		const cleanup = () => {
+			clearTimeout(timer);
+			child.removeListener("message", onMessage);
+		};
+		child.on("message", onMessage);
+		void closed.then(() => {
+			cleanup();
+			reject(new Error("Codex provider reaper exited during startup"));
+		});
+	});
+}

--- a/node/src/codex-provider-reaper-protocol.ts
+++ b/node/src/codex-provider-reaper-protocol.ts
@@ -1,0 +1,102 @@
+import { uuidSchema } from "@agentrelay/protocol";
+import { z } from "zod";
+import {
+	CODEX_PROVIDER_STOP_CAUSES,
+	type CodexProviderStopCause,
+} from "./codex-provider-generation-state.js";
+import { absolutePathSchema } from "./codex-provider-supervisor-protocol.js";
+
+const initializeSchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("initialize"),
+		capsule_id: uuidSchema,
+		generation_id: uuidSchema,
+		lock_path: absolutePathSchema,
+		state_directory: absolutePathSchema,
+		target_process_group_id: z.number().int().positive(),
+		deadline_at_ms: z.number().int().safe().positive(),
+		heartbeat_timeout_ms: z.number().int().min(250).max(60_000),
+	})
+	.strict();
+
+const heartbeatSchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("heartbeat"),
+		generation_id: uuidSchema,
+	})
+	.strict();
+
+const stopSchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("stop"),
+		generation_id: uuidSchema,
+		cause: z.enum(CODEX_PROVIDER_STOP_CAUSES),
+	})
+	.strict();
+
+const commandSchema = z.discriminatedUnion("kind", [initializeSchema, heartbeatSchema, stopSchema]);
+
+const readySchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("ready"),
+		generation_id: uuidSchema,
+	})
+	.strict();
+
+export type CodexProviderReaperCommand = z.infer<typeof commandSchema>;
+export type CodexProviderReaperInit = z.infer<typeof initializeSchema>;
+export type CodexProviderReaperEvent = z.infer<typeof readySchema>;
+
+export function parseCodexProviderReaperCommand(value: unknown): CodexProviderReaperCommand {
+	return commandSchema.parse(value);
+}
+
+export function parseCodexProviderReaperEvent(value: unknown): CodexProviderReaperEvent {
+	return readySchema.parse(value);
+}
+
+export function initializeReaperCommand(input: {
+	readonly capsuleId: string;
+	readonly generationId: string;
+	readonly lockPath: string;
+	readonly stateDirectory: string;
+	readonly targetProcessGroupId: number;
+	readonly deadlineAtMs: number;
+	readonly heartbeatTimeoutMs: number;
+}): CodexProviderReaperCommand {
+	return initializeSchema.parse({
+		version: 1,
+		kind: "initialize",
+		capsule_id: input.capsuleId,
+		generation_id: input.generationId,
+		lock_path: input.lockPath,
+		state_directory: input.stateDirectory,
+		target_process_group_id: input.targetProcessGroupId,
+		deadline_at_ms: input.deadlineAtMs,
+		heartbeat_timeout_ms: input.heartbeatTimeoutMs,
+	});
+}
+
+export function heartbeatReaperCommand(generationId: string): CodexProviderReaperCommand {
+	return heartbeatSchema.parse({ version: 1, kind: "heartbeat", generation_id: generationId });
+}
+
+export function stopReaperCommand(
+	generationId: string,
+	cause: CodexProviderStopCause,
+): CodexProviderReaperCommand {
+	return stopSchema.parse({
+		version: 1,
+		kind: "stop",
+		generation_id: generationId,
+		cause,
+	});
+}
+
+export function readyReaperEvent(generationId: string): CodexProviderReaperEvent {
+	return readySchema.parse({ version: 1, kind: "ready", generation_id: generationId });
+}

--- a/node/src/codex-provider-reaper.ts
+++ b/node/src/codex-provider-reaper.ts
@@ -116,7 +116,10 @@ export class CodexProviderReaper {
 			await delay(GROUP_POLL_MS);
 		}
 		await stopRequested;
-		await store.finalizeQuiescentAsCurrent(init.generation_id, cause);
+		const finalized = await store.finalizeQuiescentAsCurrent(init.generation_id, cause);
+		if (finalized === null) {
+			throw new Error("Codex provider generation state changed before quiescence was recorded");
+		}
 		closeSync(INHERITED_PROVIDER_LOCK_FD);
 		if (process.connected) process.disconnect();
 	}

--- a/node/src/codex-provider-reaper.ts
+++ b/node/src/codex-provider-reaper.ts
@@ -31,7 +31,7 @@ export class CodexProviderReaper {
 		startupTimer.unref();
 		process.on("message", (value) => {
 			void this.handleMessage(value, startupTimer).catch(() =>
-				this.reap("provider_failure", false).catch(() => this.failClosed()),
+				this.reap("provider_failure").catch(() => this.failClosed()),
 			);
 		});
 		process.once("disconnect", () => {
@@ -39,7 +39,7 @@ export class CodexProviderReaper {
 				process.exit(1);
 				return;
 			}
-			void this.reap("provider_failure", false).catch(() => this.failClosed());
+			void this.reap("provider_failure").catch(() => this.failClosed());
 		});
 	}
 
@@ -66,7 +66,7 @@ export class CodexProviderReaper {
 			this.#lastHeartbeat = performance.now();
 			return;
 		}
-		await this.reap(command.cause, false);
+		await this.reap(command.cause);
 	}
 
 	private armWatchdogs(command: CodexProviderReaperInit): void {
@@ -74,7 +74,7 @@ export class CodexProviderReaper {
 		const intervalMs = Math.max(50, Math.floor(command.heartbeat_timeout_ms / 4));
 		this.#heartbeatTimer = setInterval(() => {
 			if (performance.now() - this.#lastHeartbeat >= command.heartbeat_timeout_ms) {
-				void this.reap("heartbeat_timeout", false).catch(() => this.failClosed());
+				void this.reap("heartbeat_timeout").catch(() => this.failClosed());
 			}
 		}, intervalMs);
 		this.#heartbeatTimer.unref();
@@ -84,7 +84,7 @@ export class CodexProviderReaper {
 	private armDeadline(deadlineAtMs: number): void {
 		const remainingMs = deadlineAtMs - Date.now();
 		if (remainingMs <= 0) {
-			void this.reap("deadline_exceeded", false).catch(() => this.failClosed());
+			void this.reap("deadline_exceeded").catch(() => this.failClosed());
 			return;
 		}
 		this.#deadlineTimer = setTimeout(
@@ -94,15 +94,12 @@ export class CodexProviderReaper {
 		this.#deadlineTimer.unref();
 	}
 
-	private reap(cause: CodexProviderStopCause, providerGraceElapsed: boolean): Promise<void> {
-		this.#reaping ??= this.performReap(cause, providerGraceElapsed);
+	private reap(cause: CodexProviderStopCause): Promise<void> {
+		this.#reaping ??= this.performReap(cause);
 		return this.#reaping;
 	}
 
-	private async performReap(
-		cause: CodexProviderStopCause,
-		providerGraceElapsed: boolean,
-	): Promise<void> {
+	private async performReap(cause: CodexProviderStopCause): Promise<void> {
 		if (this.#heartbeatTimer !== null) clearInterval(this.#heartbeatTimer);
 		if (this.#deadlineTimer !== null) clearTimeout(this.#deadlineTimer);
 		const init = this.#init;
@@ -110,10 +107,8 @@ export class CodexProviderReaper {
 		if (init === null || store === null) throw new Error("Codex provider reaper is not armed");
 
 		await store.requestStop(init.generation_id, cause).catch(() => undefined);
-		if (!providerGraceElapsed) {
-			signalProcessGroup(init.target_process_group_id, "SIGTERM");
-			await delay(STOP_GRACE_MS);
-		}
+		signalProcessGroup(init.target_process_group_id, "SIGTERM");
+		await delay(STOP_GRACE_MS);
 		if (isSupervisorProcessGroupAlive(init.target_process_group_id)) {
 			signalProcessGroup(init.target_process_group_id, "SIGKILL");
 		}

--- a/node/src/codex-provider-reaper.ts
+++ b/node/src/codex-provider-reaper.ts
@@ -106,7 +106,7 @@ export class CodexProviderReaper {
 		const store = this.#store;
 		if (init === null || store === null) throw new Error("Codex provider reaper is not armed");
 
-		await store.requestStop(init.generation_id, cause).catch(() => undefined);
+		const stopRequested = store.requestStop(init.generation_id, cause).catch(() => undefined);
 		signalProcessGroup(init.target_process_group_id, "SIGTERM");
 		await delay(STOP_GRACE_MS);
 		if (isSupervisorProcessGroupAlive(init.target_process_group_id)) {
@@ -115,6 +115,7 @@ export class CodexProviderReaper {
 		while (isSupervisorProcessGroupAlive(init.target_process_group_id)) {
 			await delay(GROUP_POLL_MS);
 		}
+		await stopRequested;
 		await store.finalizeQuiescentAsCurrent(init.generation_id, cause);
 		closeSync(INHERITED_PROVIDER_LOCK_FD);
 		if (process.connected) process.disconnect();

--- a/node/src/codex-provider-reaper.ts
+++ b/node/src/codex-provider-reaper.ts
@@ -1,0 +1,145 @@
+import { closeSync } from "node:fs";
+import { performance } from "node:perf_hooks";
+import { setTimeout as delay } from "node:timers/promises";
+import { CodexProviderGenerationStore } from "./codex-provider-generation-state.js";
+import type { CodexProviderStopCause } from "./codex-provider-generation-state.js";
+import { assertInheritedProviderLock } from "./codex-provider-lock.js";
+import { INHERITED_PROVIDER_LOCK_FD } from "./codex-provider-lock.js";
+import {
+	type CodexProviderReaperInit,
+	parseCodexProviderReaperCommand,
+	readyReaperEvent,
+} from "./codex-provider-reaper-protocol.js";
+import { isSupervisorProcessGroupAlive, signalProcessGroup } from "./codex-supervisor-owner.js";
+
+const STARTUP_TIMEOUT_MS = 5_000;
+const STOP_GRACE_MS = 2_000;
+const GROUP_POLL_MS = 10;
+
+/** Survives outside the provider group and finalizes only after proving group absence. */
+export class CodexProviderReaper {
+	#init: CodexProviderReaperInit | null = null;
+	#store: CodexProviderGenerationStore | null = null;
+	#lastHeartbeat = performance.now();
+	#heartbeatTimer: NodeJS.Timeout | null = null;
+	#deadlineTimer: NodeJS.Timeout | null = null;
+	#reaping: Promise<void> | null = null;
+	#failClosedTimer: NodeJS.Timeout | null = null;
+
+	run(): void {
+		const startupTimer = setTimeout(() => process.exit(1), STARTUP_TIMEOUT_MS);
+		startupTimer.unref();
+		process.on("message", (value) => {
+			void this.handleMessage(value, startupTimer).catch(() =>
+				this.reap("provider_failure", false).catch(() => this.failClosed()),
+			);
+		});
+		process.once("disconnect", () => {
+			if (this.#init === null) {
+				process.exit(1);
+				return;
+			}
+			void this.reap("provider_failure", false).catch(() => this.failClosed());
+		});
+	}
+
+	private async handleMessage(value: unknown, startupTimer: NodeJS.Timeout): Promise<void> {
+		const command = parseCodexProviderReaperCommand(value);
+		if (command.kind === "initialize") {
+			if (this.#init !== null) throw new Error("Codex provider reaper initialized twice");
+			if (command.target_process_group_id === process.pid) {
+				throw new Error("Codex provider reaper cannot target its own process group");
+			}
+			assertInheritedProviderLock(command.lock_path);
+			this.#store = await CodexProviderGenerationStore.open(
+				command.state_directory,
+				command.capsule_id,
+			);
+			this.#init = command;
+			clearTimeout(startupTimer);
+			this.armWatchdogs(command);
+			await this.sendReady(command.generation_id);
+			return;
+		}
+		if (this.#init === null || command.generation_id !== this.#init.generation_id) return;
+		if (command.kind === "heartbeat") {
+			this.#lastHeartbeat = performance.now();
+			return;
+		}
+		await this.reap(command.cause, false);
+	}
+
+	private armWatchdogs(command: CodexProviderReaperInit): void {
+		this.#lastHeartbeat = performance.now();
+		const intervalMs = Math.max(50, Math.floor(command.heartbeat_timeout_ms / 4));
+		this.#heartbeatTimer = setInterval(() => {
+			if (performance.now() - this.#lastHeartbeat >= command.heartbeat_timeout_ms) {
+				void this.reap("heartbeat_timeout", false).catch(() => this.failClosed());
+			}
+		}, intervalMs);
+		this.#heartbeatTimer.unref();
+		this.armDeadline(command.deadline_at_ms);
+	}
+
+	private armDeadline(deadlineAtMs: number): void {
+		const remainingMs = deadlineAtMs - Date.now();
+		if (remainingMs <= 0) {
+			void this.reap("deadline_exceeded", false).catch(() => this.failClosed());
+			return;
+		}
+		this.#deadlineTimer = setTimeout(
+			() => this.armDeadline(deadlineAtMs),
+			Math.min(remainingMs, 2_147_483_647),
+		);
+		this.#deadlineTimer.unref();
+	}
+
+	private reap(cause: CodexProviderStopCause, providerGraceElapsed: boolean): Promise<void> {
+		this.#reaping ??= this.performReap(cause, providerGraceElapsed);
+		return this.#reaping;
+	}
+
+	private async performReap(
+		cause: CodexProviderStopCause,
+		providerGraceElapsed: boolean,
+	): Promise<void> {
+		if (this.#heartbeatTimer !== null) clearInterval(this.#heartbeatTimer);
+		if (this.#deadlineTimer !== null) clearTimeout(this.#deadlineTimer);
+		const init = this.#init;
+		const store = this.#store;
+		if (init === null || store === null) throw new Error("Codex provider reaper is not armed");
+
+		await store.requestStop(init.generation_id, cause).catch(() => undefined);
+		if (!providerGraceElapsed) {
+			signalProcessGroup(init.target_process_group_id, "SIGTERM");
+			await delay(STOP_GRACE_MS);
+		}
+		if (isSupervisorProcessGroupAlive(init.target_process_group_id)) {
+			signalProcessGroup(init.target_process_group_id, "SIGKILL");
+		}
+		while (isSupervisorProcessGroupAlive(init.target_process_group_id)) {
+			await delay(GROUP_POLL_MS);
+		}
+		await store.finalizeQuiescentAsCurrent(init.generation_id, cause);
+		closeSync(INHERITED_PROVIDER_LOCK_FD);
+		if (process.connected) process.disconnect();
+	}
+
+	private failClosed(): void {
+		if (this.#heartbeatTimer !== null) clearInterval(this.#heartbeatTimer);
+		if (this.#deadlineTimer !== null) clearTimeout(this.#deadlineTimer);
+		this.#failClosedTimer ??= setInterval(() => undefined, 60_000);
+	}
+
+	private sendReady(generationId: string): Promise<void> {
+		return new Promise((resolve, reject) => {
+			if (!process.connected || process.send === undefined) {
+				reject(new Error("Codex provider reaper control channel is closed"));
+				return;
+			}
+			process.send(readyReaperEvent(generationId), (error) =>
+				error === null ? resolve() : reject(error),
+			);
+		});
+	}
+}

--- a/node/src/codex-provider-supervisor-process.ts
+++ b/node/src/codex-provider-supervisor-process.ts
@@ -1,0 +1,128 @@
+import { type ChildProcess, type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import { SUPPORTED_CODEX_CLI_VERSION } from "./codex-app-server-protocol.js";
+import type { CodexPreparedProcess } from "./codex-provider-supervisor-protocol.js";
+
+const VERSION_PROBE_TIMEOUT_MS = 5_000;
+export const PROVIDER_STOP_GRACE_MS = 2_000;
+
+export class CodexSupervisorProcessError extends Error {
+	constructor(
+		readonly code: "version" | "spawn",
+		message: string,
+		options: ErrorOptions = {},
+	) {
+		super(message, options);
+		this.name = "CodexSupervisorProcessError";
+	}
+}
+
+export async function verifyPreparedCodexVersion(command: CodexPreparedProcess): Promise<void> {
+	const child = spawnPrepared(command, ["ignore", "pipe", "pipe"]);
+	const closed = childClose(child);
+	child.stderr.resume();
+	let stdout = "";
+	child.stdout.setEncoding("utf8");
+	child.stdout.on("data", (chunk: string) => {
+		stdout += chunk;
+		if (Buffer.byteLength(stdout, "utf8") > 1_024) child.kill("SIGKILL");
+	});
+
+	try {
+		await waitForSpawn(child);
+		const result = await Promise.race([
+			closed,
+			delay(VERSION_PROBE_TIMEOUT_MS).then(() => {
+				throw new CodexSupervisorProcessError("version", "Codex version probe timed out");
+			}),
+		]);
+		if (
+			result.code !== 0 ||
+			result.signal !== null ||
+			stdout.trim() !== `codex-cli ${SUPPORTED_CODEX_CLI_VERSION}`
+		) {
+			throw new CodexSupervisorProcessError("version", "Codex version probe failed");
+		}
+	} catch (error) {
+		child.kill("SIGKILL");
+		if (error instanceof CodexSupervisorProcessError) throw error;
+		throw new CodexSupervisorProcessError("spawn", "Codex version probe could not start", {
+			cause: error,
+		});
+	}
+}
+
+export async function startPreparedCodexProvider(
+	command: CodexPreparedProcess,
+): Promise<ChildProcessWithoutNullStreams> {
+	const child = spawnPrepared(command, ["pipe", "pipe", "pipe"]);
+	try {
+		await waitForSpawn(child);
+		return child;
+	} catch (error) {
+		throw new CodexSupervisorProcessError("spawn", "Codex app-server could not start", {
+			cause: error,
+		});
+	}
+}
+
+export async function requestProviderStop(child: ChildProcess | null): Promise<void> {
+	if (child?.pid === undefined || child.exitCode !== null || child.signalCode !== null) return;
+	child.kill("SIGTERM");
+	await Promise.race([childClose(child), delay(PROVIDER_STOP_GRACE_MS)]);
+}
+
+/** The supervisor is the group leader; this terminates it and every remaining descendant. */
+export function killSupervisorProcessGroup(): never {
+	process.kill(-process.pid, "SIGKILL");
+	throw new Error("Codex supervisor process group survived SIGKILL");
+}
+
+export function assertSupervisorProcessGroup(): void {
+	try {
+		process.kill(-process.pid, 0);
+	} catch (error) {
+		throw new CodexSupervisorProcessError(
+			"spawn",
+			"Codex supervisor is not its process-group leader",
+			{ cause: error },
+		);
+	}
+}
+
+function spawnPrepared(
+	command: CodexPreparedProcess,
+	stdio: ["ignore" | "pipe", "pipe", "pipe"],
+): ChildProcessWithoutNullStreams {
+	return spawn(command.executable, [...command.argv], {
+		cwd: command.cwd,
+		detached: false,
+		env: { ...command.env },
+		stdio,
+		shell: false,
+	}) as ChildProcessWithoutNullStreams;
+}
+
+function waitForSpawn(child: ChildProcess): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const onSpawn = () => {
+			child.removeListener("error", onError);
+			resolve();
+		};
+		const onError = (error: Error) => {
+			child.removeListener("spawn", onSpawn);
+			reject(error);
+		};
+		child.once("spawn", onSpawn);
+		child.once("error", onError);
+	});
+}
+
+function childClose(
+	child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+	}
+	return new Promise((resolve) => child.once("close", (code, signal) => resolve({ code, signal })));
+}

--- a/node/src/codex-provider-supervisor-process.ts
+++ b/node/src/codex-provider-supervisor-process.ts
@@ -4,7 +4,6 @@ import { SUPPORTED_CODEX_CLI_VERSION } from "./codex-app-server-protocol.js";
 import type { CodexPreparedProcess } from "./codex-provider-supervisor-protocol.js";
 
 const VERSION_PROBE_TIMEOUT_MS = 5_000;
-export const PROVIDER_STOP_GRACE_MS = 2_000;
 
 export class CodexSupervisorProcessError extends Error {
 	constructor(
@@ -64,18 +63,6 @@ export async function startPreparedCodexProvider(
 			cause: error,
 		});
 	}
-}
-
-export async function requestProviderStop(child: ChildProcess | null): Promise<void> {
-	if (child?.pid === undefined || child.exitCode !== null || child.signalCode !== null) return;
-	child.kill("SIGTERM");
-	await Promise.race([childClose(child), delay(PROVIDER_STOP_GRACE_MS, undefined, { ref: false })]);
-}
-
-/** The supervisor is the group leader; this terminates it and every remaining descendant. */
-export function killSupervisorProcessGroup(): never {
-	process.kill(-process.pid, "SIGKILL");
-	throw new Error("Codex supervisor process group survived SIGKILL");
 }
 
 export function assertSupervisorProcessGroup(): void {

--- a/node/src/codex-provider-supervisor-process.ts
+++ b/node/src/codex-provider-supervisor-process.ts
@@ -32,7 +32,7 @@ export async function verifyPreparedCodexVersion(command: CodexPreparedProcess):
 		await waitForSpawn(child);
 		const result = await Promise.race([
 			closed,
-			delay(VERSION_PROBE_TIMEOUT_MS).then(() => {
+			delay(VERSION_PROBE_TIMEOUT_MS, undefined, { ref: false }).then(() => {
 				throw new CodexSupervisorProcessError("version", "Codex version probe timed out");
 			}),
 		]);
@@ -69,7 +69,7 @@ export async function startPreparedCodexProvider(
 export async function requestProviderStop(child: ChildProcess | null): Promise<void> {
 	if (child?.pid === undefined || child.exitCode !== null || child.signalCode !== null) return;
 	child.kill("SIGTERM");
-	await Promise.race([childClose(child), delay(PROVIDER_STOP_GRACE_MS)]);
+	await Promise.race([childClose(child), delay(PROVIDER_STOP_GRACE_MS, undefined, { ref: false })]);
 }
 
 /** The supervisor is the group leader; this terminates it and every remaining descendant. */

--- a/node/src/codex-provider-supervisor-protocol.ts
+++ b/node/src/codex-provider-supervisor-protocol.ts
@@ -7,7 +7,7 @@ import {
 	type CodexProviderStopCause,
 } from "./codex-provider-generation-state.js";
 
-const absolutePathSchema = z
+export const absolutePathSchema = z
 	.string()
 	.min(1)
 	.max(4_096)
@@ -48,6 +48,7 @@ const initSchema = z
 		deadline_at_ms: z.number().int().safe().positive(),
 		heartbeat_timeout_ms: z.number().int().min(250).max(60_000),
 		heartbeat_record_ms: z.number().int().min(100).max(60_000),
+		reaper: codexPreparedProcessSchema,
 		version_probe: codexPreparedProcessSchema,
 		app_server: codexPreparedProcessSchema,
 	})

--- a/node/src/codex-provider-supervisor-protocol.ts
+++ b/node/src/codex-provider-supervisor-protocol.ts
@@ -1,0 +1,155 @@
+import { isAbsolute, normalize } from "node:path";
+import { uuidSchema } from "@agentrelay/protocol";
+import { z } from "zod";
+import {
+	CODEX_PROVIDER_STOP_CAUSES,
+	type CodexProviderObservation,
+	type CodexProviderStopCause,
+} from "./codex-provider-generation-state.js";
+
+const absolutePathSchema = z
+	.string()
+	.min(1)
+	.max(4_096)
+	.refine((value) => isAbsolute(value) && normalize(value) === value && !value.includes("\0"));
+const argumentSchema = z
+	.string()
+	.max(16_384)
+	.refine((value) => !value.includes("\0"));
+const environmentSchema = z
+	.record(
+		z
+			.string()
+			.max(65_536)
+			.refine((value) => !value.includes("\0")),
+	)
+	.refine((value) => Object.keys(value).length <= 128);
+
+export const codexPreparedProcessSchema = z
+	.object({
+		executable: absolutePathSchema,
+		argv: z.array(argumentSchema).max(256),
+		cwd: absolutePathSchema,
+		env: environmentSchema,
+	})
+	.strict();
+
+export type CodexPreparedProcess = z.infer<typeof codexPreparedProcessSchema>;
+
+const initSchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("initialize"),
+		capsule_id: uuidSchema,
+		generation_id: uuidSchema,
+		owner_pid: z.number().int().positive(),
+		lock_path: absolutePathSchema,
+		state_directory: absolutePathSchema,
+		heartbeat_timeout_ms: z.number().int().min(250).max(60_000),
+		heartbeat_record_ms: z.number().int().min(100).max(60_000),
+		version_probe: codexPreparedProcessSchema,
+		app_server: codexPreparedProcessSchema,
+	})
+	.strict();
+
+const heartbeatSchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("heartbeat"),
+		generation_id: uuidSchema,
+	})
+	.strict();
+
+const terminateSchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("terminate"),
+		generation_id: uuidSchema,
+		cause: z.enum(CODEX_PROVIDER_STOP_CAUSES),
+	})
+	.strict();
+
+const supervisorCommandSchema = z.discriminatedUnion("kind", [
+	initSchema,
+	heartbeatSchema,
+	terminateSchema,
+]);
+
+export type CodexProviderSupervisorInit = z.infer<typeof initSchema>;
+export type CodexProviderSupervisorCommand = z.infer<typeof supervisorCommandSchema>;
+
+const readySchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("ready"),
+		generation_id: uuidSchema,
+	})
+	.strict();
+
+const terminalSchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("terminal"),
+		generation_id: uuidSchema,
+		observation: z.enum(["stopped", "crashed", "unresponsive"]),
+	})
+	.strict();
+
+const failureSchema = z
+	.object({
+		version: z.literal(1),
+		kind: z.literal("failure"),
+		generation_id: uuidSchema,
+		code: z.enum(["invalid_startup", "version", "spawn", "state", "internal"]),
+	})
+	.strict();
+
+const supervisorEventSchema = z.discriminatedUnion("kind", [
+	readySchema,
+	terminalSchema,
+	failureSchema,
+]);
+
+export type CodexProviderSupervisorEvent = z.infer<typeof supervisorEventSchema>;
+
+export function parseCodexProviderSupervisorCommand(
+	value: unknown,
+): CodexProviderSupervisorCommand {
+	return supervisorCommandSchema.parse(value);
+}
+
+export function parseCodexProviderSupervisorEvent(value: unknown): CodexProviderSupervisorEvent {
+	return supervisorEventSchema.parse(value);
+}
+
+export function terminalSupervisorEvent(
+	generationId: string,
+	observation: CodexProviderObservation,
+): CodexProviderSupervisorEvent {
+	return terminalSchema.parse({
+		version: 1,
+		kind: "terminal",
+		generation_id: generationId,
+		observation,
+	});
+}
+
+export function terminateSupervisorCommand(
+	generationId: string,
+	cause: CodexProviderStopCause,
+): CodexProviderSupervisorCommand {
+	return terminateSchema.parse({
+		version: 1,
+		kind: "terminate",
+		generation_id: generationId,
+		cause,
+	});
+}
+
+export function sanitizePreparedEnvironment(env: NodeJS.ProcessEnv): Record<string, string> {
+	return environmentSchema.parse(
+		Object.fromEntries(
+			Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+		),
+	);
+}

--- a/node/src/codex-provider-supervisor-protocol.ts
+++ b/node/src/codex-provider-supervisor-protocol.ts
@@ -45,6 +45,7 @@ const initSchema = z
 		owner_pid: z.number().int().positive(),
 		lock_path: absolutePathSchema,
 		state_directory: absolutePathSchema,
+		deadline_at_ms: z.number().int().safe().positive(),
 		heartbeat_timeout_ms: z.number().int().min(250).max(60_000),
 		heartbeat_record_ms: z.number().int().min(100).max(60_000),
 		version_probe: codexPreparedProcessSchema,
@@ -91,6 +92,7 @@ const terminalSchema = z
 		version: z.literal(1),
 		kind: z.literal("terminal"),
 		generation_id: uuidSchema,
+		cause: z.enum(CODEX_PROVIDER_STOP_CAUSES),
 		observation: z.enum(["stopped", "crashed", "unresponsive"]),
 	})
 	.strict();
@@ -124,12 +126,14 @@ export function parseCodexProviderSupervisorEvent(value: unknown): CodexProvider
 
 export function terminalSupervisorEvent(
 	generationId: string,
+	cause: CodexProviderStopCause,
 	observation: CodexProviderObservation,
 ): CodexProviderSupervisorEvent {
 	return terminalSchema.parse({
 		version: 1,
 		kind: "terminal",
 		generation_id: generationId,
+		cause,
 		observation,
 	});
 }

--- a/node/src/codex-provider-supervisor.ts
+++ b/node/src/codex-provider-supervisor.ts
@@ -149,6 +149,7 @@ export class CodexProviderSupervisor {
 				if (this.#stopping === null) void this.stop("provider_failure", "crashed");
 			});
 			await this.#store.markRunning(command.generation_id);
+			this.assertAuthorityActive();
 			await this.send({
 				version: 1,
 				kind: "ready",
@@ -264,9 +265,6 @@ export class CodexProviderSupervisor {
 		const reaper = this.#reaper;
 		if (generationId === null || reaper === null) process.exit(1);
 		const reaping = reaper.stop(cause);
-		if (generationId !== null && this.#store !== null) {
-			await this.#store.requestStop(generationId, cause).catch(() => undefined);
-		}
 		await this.send(terminalSupervisorEvent(generationId, cause, observation)).catch(
 			() => undefined,
 		);

--- a/node/src/codex-provider-supervisor.ts
+++ b/node/src/codex-provider-supervisor.ts
@@ -1,17 +1,19 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { fstatSync, lstatSync, readFileSync } from "node:fs";
 import { performance } from "node:perf_hooks";
 import { currentBootSessionId } from "./boot-session.js";
-import { CodexProviderGenerationStore } from "./codex-provider-generation-state.js";
+import {
+	CodexProviderGenerationStore,
+	observationForProviderStopCause,
+} from "./codex-provider-generation-state.js";
 import type {
 	CodexProviderObservation,
 	CodexProviderStopCause,
 } from "./codex-provider-generation-state.js";
+import { assertInheritedProviderLock } from "./codex-provider-lock.js";
+import { CodexProviderReaperClient } from "./codex-provider-reaper-client.js";
 import {
 	CodexSupervisorProcessError,
 	assertSupervisorProcessGroup,
-	killSupervisorProcessGroup,
-	requestProviderStop,
 	startPreparedCodexProvider,
 	verifyPreparedCodexVersion,
 } from "./codex-provider-supervisor-process.js";
@@ -21,8 +23,6 @@ import {
 	parseCodexProviderSupervisorCommand,
 	terminalSupervisorEvent,
 } from "./codex-provider-supervisor-protocol.js";
-
-const PROVIDER_LOCK_FD = 4;
 const STARTUP_MESSAGE_TIMEOUT_MS = 5_000;
 
 /** Runs only in the dedicated guardian process started by CodexProviderGuardian. */
@@ -30,6 +30,7 @@ export class CodexProviderSupervisor {
 	#generationId: string | null = null;
 	#ownerPid: number | null = null;
 	#store: CodexProviderGenerationStore | null = null;
+	#reaper: CodexProviderReaperClient | null = null;
 	#provider: ChildProcessWithoutNullStreams | null = null;
 	#lastHeartbeat = performance.now();
 	#lastRecordedHeartbeat = performance.now();
@@ -43,19 +44,22 @@ export class CodexProviderSupervisor {
 	} | null = null;
 	#stopping: Promise<never> | null = null;
 	#initialized = false;
+	#readyPublished = false;
 
 	run(): void {
 		assertSupervisorProcessGroup();
 		const startupTimer = setTimeout(() => process.exit(1), STARTUP_MESSAGE_TIMEOUT_MS);
 		startupTimer.unref();
 		process.on("message", (value) => {
-			void this.handleMessage(value, startupTimer).catch(() =>
-				this.fail("internal", "startup_failure", "crashed"),
-			);
+			void this.handleMessage(value, startupTimer).catch(() => {
+				const cause = this.#readyPublished ? "provider_failure" : "startup_failure";
+				return this.fail("internal", cause, "crashed");
+			});
 		});
 		process.once("disconnect", () => void this.stop("owner_lost", "stopped"));
 		process.stdin.once("end", () => void this.stop("owner_lost", "stopped"));
 		process.stdin.once("error", () => void this.stop("owner_lost", "stopped"));
+		process.stdout.once("error", () => void this.stop("owner_lost", "stopped"));
 		process.once("SIGINT", () => void this.stop("owner_lost", "stopped"));
 		process.once("SIGTERM", () => void this.stop(this.#stopCause ?? "owner_lost", "stopped"));
 	}
@@ -80,10 +84,10 @@ export class CodexProviderSupervisor {
 		}
 		if (command.generation_id !== this.#generationId) return;
 		if (command.kind === "heartbeat") {
-			await this.recordHeartbeat();
+			await Promise.all([this.recordHeartbeat(), this.#reaper?.heartbeat()]);
 			return;
 		}
-		await this.stop(command.cause, terminationObservation(command.cause));
+		await this.stop(command.cause, observationForProviderStopCause(command.cause));
 	}
 
 	private async initialize(command: CodexProviderSupervisorInit): Promise<void> {
@@ -96,10 +100,24 @@ export class CodexProviderSupervisor {
 				}
 				return this.stop(
 					this.#pendingTermination.cause,
-					terminationObservation(this.#pendingTermination.cause),
+					observationForProviderStopCause(this.#pendingTermination.cause),
 				);
 			}
 			assertInheritedProviderLock(command.lock_path);
+			this.assertOwnerAlive();
+			const reaper = await CodexProviderReaperClient.start({
+				command: command.reaper,
+				capsuleId: command.capsule_id,
+				generationId: command.generation_id,
+				lockPath: command.lock_path,
+				stateDirectory: command.state_directory,
+				deadlineAtMs: command.deadline_at_ms,
+				heartbeatTimeoutMs: command.heartbeat_timeout_ms,
+			});
+			this.#reaper = reaper;
+			void reaper.termination.then(() => {
+				if (this.#stopping === null) void this.stop("provider_failure", "crashed");
+			});
 			this.assertOwnerAlive();
 			this.#store = await CodexProviderGenerationStore.open(
 				command.state_directory,
@@ -127,12 +145,16 @@ export class CodexProviderSupervisor {
 			provider.stdin.once("error", () => {
 				if (this.#stopping === null) void this.stop("provider_failure", "crashed");
 			});
+			provider.stdout.once("error", () => {
+				if (this.#stopping === null) void this.stop("provider_failure", "crashed");
+			});
 			await this.#store.markRunning(command.generation_id);
 			await this.send({
 				version: 1,
 				kind: "ready",
 				generation_id: command.generation_id,
 			});
+			this.#readyPublished = true;
 		} catch (error) {
 			const code =
 				error instanceof CodexSupervisorProcessError
@@ -239,17 +261,20 @@ export class CodexProviderSupervisor {
 		if (this.#heartbeatTimer !== null) clearInterval(this.#heartbeatTimer);
 		if (this.#deadlineTimer !== null) clearTimeout(this.#deadlineTimer);
 		const generationId = this.#generationId;
+		const reaper = this.#reaper;
+		if (generationId === null || reaper === null) process.exit(1);
+		const reaping = reaper.stop(cause);
 		if (generationId !== null && this.#store !== null) {
 			await this.#store.requestStop(generationId, cause).catch(() => undefined);
 		}
-		await requestProviderStop(this.#provider).catch(() => undefined);
-		if (generationId !== null && this.#store !== null) {
-			await this.#store.markQuiescent(generationId, cause, observation).catch(() => undefined);
-			await this.send(terminalSupervisorEvent(generationId, cause, observation)).catch(
-				() => undefined,
-			);
+		await this.send(terminalSupervisorEvent(generationId, cause, observation)).catch(
+			() => undefined,
+		);
+		try {
+			return await reaping;
+		} catch {
+			process.exit(1);
 		}
-		return killSupervisorProcessGroup();
 	}
 
 	private send(event: CodexProviderSupervisorEvent): Promise<void> {
@@ -261,36 +286,4 @@ export class CodexProviderSupervisor {
 			process.send(event, (error) => (error === null ? resolve() : reject(error)));
 		});
 	}
-}
-
-function assertInheritedProviderLock(path: string): void {
-	const descriptor = fstatSync(PROVIDER_LOCK_FD);
-	const published = lstatSync(path);
-	if (
-		published.isSymbolicLink() ||
-		!published.isFile() ||
-		descriptor.dev !== published.dev ||
-		descriptor.ino !== published.ino ||
-		descriptor.nlink !== 1 ||
-		(published.mode & 0o777) !== 0o600 ||
-		(process.getuid !== undefined && published.uid !== process.getuid())
-	) {
-		throw new Error("Codex provider supervisor did not inherit the expected private lock");
-	}
-	const decoded = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
-	if (decoded.schema_version !== 2 || decoded.kind !== "agentrelay_provider_generation_lock") {
-		throw new Error("Codex provider supervisor lock kind is invalid");
-	}
-}
-
-function terminationObservation(cause: CodexProviderStopCause): CodexProviderObservation {
-	if (
-		cause === "deadline_exceeded" ||
-		cause === "heartbeat_timeout" ||
-		cause === "provider_unresponsive"
-	) {
-		return "unresponsive";
-	}
-	if (cause === "provider_failure" || cause === "startup_failure") return "crashed";
-	return "stopped";
 }

--- a/node/src/codex-provider-supervisor.ts
+++ b/node/src/codex-provider-supervisor.ts
@@ -37,6 +37,10 @@ export class CodexProviderSupervisor {
 	#deadlineAtMs: number | null = null;
 	#deadlineTimer: NodeJS.Timeout | null = null;
 	#stopCause: CodexProviderStopCause | null = null;
+	#pendingTermination: {
+		readonly generationId: string;
+		readonly cause: CodexProviderStopCause;
+	} | null = null;
 	#stopping: Promise<never> | null = null;
 	#initialized = false;
 
@@ -65,7 +69,16 @@ export class CodexProviderSupervisor {
 			await this.initialize(command);
 			return;
 		}
-		if (this.#generationId === null || command.generation_id !== this.#generationId) return;
+		if (this.#generationId === null) {
+			if (command.kind === "terminate") {
+				this.#pendingTermination ??= {
+					generationId: command.generation_id,
+					cause: command.cause,
+				};
+			}
+			return;
+		}
+		if (command.generation_id !== this.#generationId) return;
 		if (command.kind === "heartbeat") {
 			await this.recordHeartbeat();
 			return;
@@ -77,6 +90,15 @@ export class CodexProviderSupervisor {
 		this.#generationId = command.generation_id;
 		this.#ownerPid = command.owner_pid;
 		try {
+			if (this.#pendingTermination !== null) {
+				if (this.#pendingTermination.generationId !== command.generation_id) {
+					throw new Error("Codex provider supervisor termination generation did not match");
+				}
+				return this.stop(
+					this.#pendingTermination.cause,
+					terminationObservation(this.#pendingTermination.cause),
+				);
+			}
 			assertInheritedProviderLock(command.lock_path);
 			this.assertOwnerAlive();
 			this.#store = await CodexProviderGenerationStore.open(

--- a/node/src/codex-provider-supervisor.ts
+++ b/node/src/codex-provider-supervisor.ts
@@ -160,7 +160,7 @@ export class CodexProviderSupervisor {
 			const code =
 				error instanceof CodexSupervisorProcessError
 					? error.code
-					: this.#store === null
+					: this.#reaper === null
 						? "invalid_startup"
 						: "state";
 			await this.fail(code, "startup_failure", "crashed");

--- a/node/src/codex-provider-supervisor.ts
+++ b/node/src/codex-provider-supervisor.ts
@@ -1,6 +1,7 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { fstatSync, lstatSync, readFileSync } from "node:fs";
 import { performance } from "node:perf_hooks";
+import { currentBootSessionId } from "./boot-session.js";
 import { CodexProviderGenerationStore } from "./codex-provider-generation-state.js";
 import type {
 	CodexProviderObservation,
@@ -33,6 +34,8 @@ export class CodexProviderSupervisor {
 	#lastHeartbeat = performance.now();
 	#lastRecordedHeartbeat = performance.now();
 	#heartbeatTimer: NodeJS.Timeout | null = null;
+	#deadlineAtMs: number | null = null;
+	#deadlineTimer: NodeJS.Timeout | null = null;
 	#stopCause: CodexProviderStopCause | null = null;
 	#stopping: Promise<never> | null = null;
 	#initialized = false;
@@ -80,15 +83,19 @@ export class CodexProviderSupervisor {
 				command.state_directory,
 				command.capsule_id,
 			);
-			const state = await this.#store.snapshot();
-			if (state?.generation_id !== command.generation_id || state.phase !== "spawn_maybe_started") {
-				throw new Error("Codex provider generation start barrier is missing");
-			}
+			await this.#store.begin(
+				command.generation_id,
+				await currentBootSessionId(),
+				command.deadline_at_ms,
+			);
+			this.startDeadlineWatchdog(command.deadline_at_ms);
+			this.assertAuthorityActive();
 			this.startHeartbeatWatchdog(command);
 			await verifyPreparedCodexVersion(command.version_probe);
-			this.assertOwnerAlive();
+			this.assertAuthorityActive();
 			const provider = await startPreparedCodexProvider(command.app_server);
 			this.#provider = provider;
+			this.assertAuthorityActive();
 			provider.stderr.resume();
 			process.stdin.pipe(provider.stdin);
 			provider.stdout.pipe(process.stdout);
@@ -128,6 +135,25 @@ export class CodexProviderSupervisor {
 		this.#heartbeatRecordMs = command.heartbeat_record_ms;
 	}
 
+	private startDeadlineWatchdog(deadlineAtMs: number): void {
+		this.#deadlineAtMs = deadlineAtMs;
+		this.armDeadlineTimer();
+	}
+
+	private armDeadlineTimer(): void {
+		if (this.#deadlineAtMs === null || this.#stopping !== null) return;
+		const remainingMs = this.#deadlineAtMs - Date.now();
+		if (remainingMs <= 0) {
+			void this.stop("deadline_exceeded", "unresponsive");
+			return;
+		}
+		this.#deadlineTimer = setTimeout(
+			() => this.armDeadlineTimer(),
+			Math.min(remainingMs, 2_147_483_647),
+		);
+		this.#deadlineTimer.unref();
+	}
+
 	#heartbeatRecordMs = 1_000;
 
 	private async recordHeartbeat(): Promise<void> {
@@ -146,6 +172,16 @@ export class CodexProviderSupervisor {
 	private assertOwnerAlive(): void {
 		if (this.#ownerPid === null || process.ppid !== this.#ownerPid || !process.connected) {
 			throw new Error("Codex provider supervisor owner disappeared during startup");
+		}
+	}
+
+	private assertAuthorityActive(): void {
+		this.assertOwnerAlive();
+		if (this.#deadlineAtMs !== null && Date.now() >= this.#deadlineAtMs) {
+			void this.stop("deadline_exceeded", "unresponsive");
+		}
+		if (this.#stopping !== null) {
+			throw new Error("Codex provider authority ended during startup");
 		}
 	}
 
@@ -179,6 +215,7 @@ export class CodexProviderSupervisor {
 		observation: CodexProviderObservation,
 	): Promise<never> {
 		if (this.#heartbeatTimer !== null) clearInterval(this.#heartbeatTimer);
+		if (this.#deadlineTimer !== null) clearTimeout(this.#deadlineTimer);
 		const generationId = this.#generationId;
 		if (generationId !== null && this.#store !== null) {
 			await this.#store.requestStop(generationId, cause).catch(() => undefined);
@@ -186,7 +223,9 @@ export class CodexProviderSupervisor {
 		await requestProviderStop(this.#provider).catch(() => undefined);
 		if (generationId !== null && this.#store !== null) {
 			await this.#store.markQuiescent(generationId, cause, observation).catch(() => undefined);
-			await this.send(terminalSupervisorEvent(generationId, observation)).catch(() => undefined);
+			await this.send(terminalSupervisorEvent(generationId, cause, observation)).catch(
+				() => undefined,
+			);
 		}
 		return killSupervisorProcessGroup();
 	}
@@ -223,7 +262,13 @@ function assertInheritedProviderLock(path: string): void {
 }
 
 function terminationObservation(cause: CodexProviderStopCause): CodexProviderObservation {
-	if (cause === "heartbeat_timeout") return "unresponsive";
+	if (
+		cause === "deadline_exceeded" ||
+		cause === "heartbeat_timeout" ||
+		cause === "provider_unresponsive"
+	) {
+		return "unresponsive";
+	}
 	if (cause === "provider_failure" || cause === "startup_failure") return "crashed";
 	return "stopped";
 }

--- a/node/src/codex-provider-supervisor.ts
+++ b/node/src/codex-provider-supervisor.ts
@@ -1,0 +1,229 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { fstatSync, lstatSync, readFileSync } from "node:fs";
+import { performance } from "node:perf_hooks";
+import { CodexProviderGenerationStore } from "./codex-provider-generation-state.js";
+import type {
+	CodexProviderObservation,
+	CodexProviderStopCause,
+} from "./codex-provider-generation-state.js";
+import {
+	CodexSupervisorProcessError,
+	assertSupervisorProcessGroup,
+	killSupervisorProcessGroup,
+	requestProviderStop,
+	startPreparedCodexProvider,
+	verifyPreparedCodexVersion,
+} from "./codex-provider-supervisor-process.js";
+import {
+	type CodexProviderSupervisorEvent,
+	type CodexProviderSupervisorInit,
+	parseCodexProviderSupervisorCommand,
+	terminalSupervisorEvent,
+} from "./codex-provider-supervisor-protocol.js";
+
+const PROVIDER_LOCK_FD = 4;
+const STARTUP_MESSAGE_TIMEOUT_MS = 5_000;
+
+/** Runs only in the dedicated guardian process started by CodexProviderGuardian. */
+export class CodexProviderSupervisor {
+	#generationId: string | null = null;
+	#ownerPid: number | null = null;
+	#store: CodexProviderGenerationStore | null = null;
+	#provider: ChildProcessWithoutNullStreams | null = null;
+	#lastHeartbeat = performance.now();
+	#lastRecordedHeartbeat = performance.now();
+	#heartbeatTimer: NodeJS.Timeout | null = null;
+	#stopCause: CodexProviderStopCause | null = null;
+	#stopping: Promise<never> | null = null;
+	#initialized = false;
+
+	run(): void {
+		assertSupervisorProcessGroup();
+		const startupTimer = setTimeout(() => process.exit(1), STARTUP_MESSAGE_TIMEOUT_MS);
+		startupTimer.unref();
+		process.on("message", (value) => {
+			void this.handleMessage(value, startupTimer).catch(() =>
+				this.fail("internal", "startup_failure", "crashed"),
+			);
+		});
+		process.once("disconnect", () => void this.stop("owner_lost", "stopped"));
+		process.stdin.once("end", () => void this.stop("owner_lost", "stopped"));
+		process.stdin.once("error", () => void this.stop("owner_lost", "stopped"));
+		process.once("SIGINT", () => void this.stop("owner_lost", "stopped"));
+		process.once("SIGTERM", () => void this.stop(this.#stopCause ?? "owner_lost", "stopped"));
+	}
+
+	private async handleMessage(value: unknown, startupTimer: NodeJS.Timeout): Promise<void> {
+		const command = parseCodexProviderSupervisorCommand(value);
+		if (command.kind === "initialize") {
+			if (this.#initialized) throw new Error("Codex provider supervisor was initialized twice");
+			this.#initialized = true;
+			clearTimeout(startupTimer);
+			await this.initialize(command);
+			return;
+		}
+		if (this.#generationId === null || command.generation_id !== this.#generationId) return;
+		if (command.kind === "heartbeat") {
+			await this.recordHeartbeat();
+			return;
+		}
+		await this.stop(command.cause, terminationObservation(command.cause));
+	}
+
+	private async initialize(command: CodexProviderSupervisorInit): Promise<void> {
+		this.#generationId = command.generation_id;
+		this.#ownerPid = command.owner_pid;
+		try {
+			assertInheritedProviderLock(command.lock_path);
+			this.assertOwnerAlive();
+			this.#store = await CodexProviderGenerationStore.open(
+				command.state_directory,
+				command.capsule_id,
+			);
+			const state = await this.#store.snapshot();
+			if (state?.generation_id !== command.generation_id || state.phase !== "spawn_maybe_started") {
+				throw new Error("Codex provider generation start barrier is missing");
+			}
+			this.startHeartbeatWatchdog(command);
+			await verifyPreparedCodexVersion(command.version_probe);
+			this.assertOwnerAlive();
+			const provider = await startPreparedCodexProvider(command.app_server);
+			this.#provider = provider;
+			provider.stderr.resume();
+			process.stdin.pipe(provider.stdin);
+			provider.stdout.pipe(process.stdout);
+			provider.once("close", () => {
+				if (this.#stopping === null) void this.stop("provider_failure", "crashed");
+			});
+			provider.stdin.once("error", () => {
+				if (this.#stopping === null) void this.stop("provider_failure", "crashed");
+			});
+			await this.#store.markRunning(command.generation_id);
+			await this.send({
+				version: 1,
+				kind: "ready",
+				generation_id: command.generation_id,
+			});
+		} catch (error) {
+			const code =
+				error instanceof CodexSupervisorProcessError
+					? error.code
+					: this.#store === null
+						? "invalid_startup"
+						: "state";
+			await this.fail(code, "startup_failure", "crashed");
+		}
+	}
+
+	private startHeartbeatWatchdog(command: CodexProviderSupervisorInit): void {
+		this.#lastHeartbeat = performance.now();
+		this.#lastRecordedHeartbeat = this.#lastHeartbeat;
+		const intervalMs = Math.max(50, Math.floor(command.heartbeat_timeout_ms / 4));
+		this.#heartbeatTimer = setInterval(() => {
+			if (performance.now() - this.#lastHeartbeat >= command.heartbeat_timeout_ms) {
+				void this.stop("heartbeat_timeout", "unresponsive");
+			}
+		}, intervalMs);
+		this.#heartbeatTimer.unref();
+		this.#heartbeatRecordMs = command.heartbeat_record_ms;
+	}
+
+	#heartbeatRecordMs = 1_000;
+
+	private async recordHeartbeat(): Promise<void> {
+		this.#lastHeartbeat = performance.now();
+		if (
+			this.#store === null ||
+			this.#generationId === null ||
+			this.#lastHeartbeat - this.#lastRecordedHeartbeat < this.#heartbeatRecordMs
+		) {
+			return;
+		}
+		this.#lastRecordedHeartbeat = this.#lastHeartbeat;
+		await this.#store.recordHeartbeat(this.#generationId);
+	}
+
+	private assertOwnerAlive(): void {
+		if (this.#ownerPid === null || process.ppid !== this.#ownerPid || !process.connected) {
+			throw new Error("Codex provider supervisor owner disappeared during startup");
+		}
+	}
+
+	private async fail(
+		code: Extract<CodexProviderSupervisorEvent, { kind: "failure" }>["code"],
+		cause: CodexProviderStopCause,
+		observation: CodexProviderObservation,
+	): Promise<never> {
+		if (this.#generationId !== null) {
+			await this.send({
+				version: 1,
+				kind: "failure",
+				generation_id: this.#generationId,
+				code,
+			}).catch(() => undefined);
+		}
+		return this.stop(cause, observation);
+	}
+
+	private stop(
+		cause: CodexProviderStopCause,
+		observation: CodexProviderObservation,
+	): Promise<never> {
+		this.#stopCause ??= cause;
+		this.#stopping ??= this.performStop(this.#stopCause, observation);
+		return this.#stopping;
+	}
+
+	private async performStop(
+		cause: CodexProviderStopCause,
+		observation: CodexProviderObservation,
+	): Promise<never> {
+		if (this.#heartbeatTimer !== null) clearInterval(this.#heartbeatTimer);
+		const generationId = this.#generationId;
+		if (generationId !== null && this.#store !== null) {
+			await this.#store.requestStop(generationId, cause).catch(() => undefined);
+		}
+		await requestProviderStop(this.#provider).catch(() => undefined);
+		if (generationId !== null && this.#store !== null) {
+			await this.#store.markQuiescent(generationId, cause, observation).catch(() => undefined);
+			await this.send(terminalSupervisorEvent(generationId, observation)).catch(() => undefined);
+		}
+		return killSupervisorProcessGroup();
+	}
+
+	private send(event: CodexProviderSupervisorEvent): Promise<void> {
+		return new Promise((resolve, reject) => {
+			if (!process.connected || process.send === undefined) {
+				reject(new Error("Codex provider supervisor control channel is closed"));
+				return;
+			}
+			process.send(event, (error) => (error === null ? resolve() : reject(error)));
+		});
+	}
+}
+
+function assertInheritedProviderLock(path: string): void {
+	const descriptor = fstatSync(PROVIDER_LOCK_FD);
+	const published = lstatSync(path);
+	if (
+		published.isSymbolicLink() ||
+		!published.isFile() ||
+		descriptor.dev !== published.dev ||
+		descriptor.ino !== published.ino ||
+		descriptor.nlink !== 1 ||
+		(published.mode & 0o777) !== 0o600 ||
+		(process.getuid !== undefined && published.uid !== process.getuid())
+	) {
+		throw new Error("Codex provider supervisor did not inherit the expected private lock");
+	}
+	const decoded = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+	if (decoded.schema_version !== 2 || decoded.kind !== "agentrelay_provider_generation_lock") {
+		throw new Error("Codex provider supervisor lock kind is invalid");
+	}
+}
+
+function terminationObservation(cause: CodexProviderStopCause): CodexProviderObservation {
+	if (cause === "heartbeat_timeout") return "unresponsive";
+	if (cause === "provider_failure" || cause === "startup_failure") return "crashed";
+	return "stopped";
+}

--- a/node/src/codex-supervised-process-config.ts
+++ b/node/src/codex-supervised-process-config.ts
@@ -1,0 +1,122 @@
+import { buildCodexAppServerArguments } from "./codex-app-server-command.js";
+import type { CodexAppServerProcessOptions } from "./codex-app-server-process.js";
+import type { CodexProviderGenerationStore } from "./codex-provider-generation-state.js";
+import {
+	type CodexPreparedProcess,
+	codexPreparedProcessSchema,
+	sanitizePreparedEnvironment,
+} from "./codex-provider-supervisor-protocol.js";
+import type { ProcessLock } from "./process-lock.js";
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 15_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 500;
+const DEFAULT_HEARTBEAT_TIMEOUT_MS = 3_000;
+const DEFAULT_HEARTBEAT_RECORD_MS = 5_000;
+
+export interface CodexSupervisorCommand {
+	readonly executable: string;
+	readonly args: readonly string[];
+	readonly env?: NodeJS.ProcessEnv;
+}
+
+export interface CodexSupervisedProcessOptions {
+	readonly capsuleId: string;
+	readonly capsuleDirectory: string;
+	readonly generationId: string;
+	readonly supervisor: CodexSupervisorCommand;
+	readonly process: CodexAppServerProcessOptions;
+	readonly lock: ProcessLock;
+	readonly store: CodexProviderGenerationStore;
+	readonly startupTimeoutMs?: number;
+	readonly heartbeatIntervalMs?: number;
+	readonly heartbeatTimeoutMs?: number;
+	readonly heartbeatRecordMs?: number;
+}
+
+export type ResolvedCodexSupervisedProcessOptions = Omit<
+	CodexSupervisedProcessOptions,
+	"startupTimeoutMs" | "heartbeatIntervalMs" | "heartbeatTimeoutMs" | "heartbeatRecordMs"
+> & {
+	readonly startupTimeoutMs: number;
+	readonly heartbeatIntervalMs: number;
+	readonly heartbeatTimeoutMs: number;
+	readonly heartbeatRecordMs: number;
+};
+
+export async function prepareProviderCommands(options: CodexAppServerProcessOptions): Promise<{
+	readonly versionProbe: CodexPreparedProcess;
+	readonly appServer: CodexPreparedProcess;
+}> {
+	const base = {
+		executable: options.command.executable,
+		cwd: options.cwd,
+		env: options.env,
+	};
+	const versionProbe = await options.boundary.prepare({ ...base, argv: ["--version"] });
+	const appServer = await options.boundary.prepare({
+		...base,
+		argv: buildCodexAppServerArguments(),
+	});
+	return { versionProbe: preparedProcess(versionProbe), appServer: preparedProcess(appServer) };
+}
+
+export function resolveSupervisedProcessOptions(
+	options: CodexSupervisedProcessOptions,
+): ResolvedCodexSupervisedProcessOptions {
+	const heartbeatTimeoutMs = boundedMilliseconds(
+		options.heartbeatTimeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS,
+		250,
+		60_000,
+	);
+	return {
+		...options,
+		startupTimeoutMs: boundedMilliseconds(
+			options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
+			500,
+			120_000,
+		),
+		heartbeatIntervalMs: boundedMilliseconds(
+			options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
+			50,
+			Math.floor(heartbeatTimeoutMs / 2),
+		),
+		heartbeatTimeoutMs,
+		heartbeatRecordMs: boundedMilliseconds(
+			options.heartbeatRecordMs ?? DEFAULT_HEARTBEAT_RECORD_MS,
+			100,
+			60_000,
+		),
+	};
+}
+
+export function supervisorEnvironment(extra: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {};
+	for (const name of ["LANG", "LC_ALL", "TZ"]) {
+		if (process.env[name] !== undefined) env[name] = process.env[name];
+	}
+	for (const [name, value] of Object.entries(extra ?? {})) {
+		if (value !== undefined) env[name] = value;
+	}
+	return env;
+}
+
+function preparedProcess(value: {
+	readonly executable: string;
+	readonly argv: readonly string[];
+	readonly cwd: string;
+	readonly env: NodeJS.ProcessEnv;
+}): CodexPreparedProcess {
+	return codexPreparedProcessSchema.parse({
+		executable: value.executable,
+		argv: [...value.argv],
+		cwd: value.cwd,
+		env: sanitizePreparedEnvironment(value.env),
+	});
+}
+
+function boundedMilliseconds(value: number, minimum: number, maximum: number): number {
+	if (!Number.isInteger(value) || value < minimum || value > maximum) {
+		throw new Error("Codex provider guardian timing is outside its bound");
+	}
+	return value;
+}

--- a/node/src/codex-supervised-process-config.ts
+++ b/node/src/codex-supervised-process-config.ts
@@ -24,6 +24,7 @@ export interface CodexSupervisedProcessOptions {
 	readonly capsuleDirectory: string;
 	readonly generationId: string;
 	readonly supervisor: CodexSupervisorCommand;
+	readonly reaper?: CodexSupervisorCommand;
 	readonly process: CodexAppServerProcessOptions;
 	readonly lock: ProcessLock;
 	readonly store: CodexProviderGenerationStore;
@@ -36,8 +37,9 @@ export interface CodexSupervisedProcessOptions {
 
 export type ResolvedCodexSupervisedProcessOptions = Omit<
 	CodexSupervisedProcessOptions,
-	"startupTimeoutMs" | "heartbeatIntervalMs" | "heartbeatTimeoutMs" | "heartbeatRecordMs"
+	"reaper" | "startupTimeoutMs" | "heartbeatIntervalMs" | "heartbeatTimeoutMs" | "heartbeatRecordMs"
 > & {
+	readonly reaper: CodexSupervisorCommand;
 	readonly startupTimeoutMs: number;
 	readonly heartbeatIntervalMs: number;
 	readonly heartbeatTimeoutMs: number;
@@ -71,6 +73,10 @@ export function resolveSupervisedProcessOptions(
 	);
 	return {
 		...options,
+		reaper: options.reaper ?? {
+			executable: options.supervisor.executable,
+			args: [...options.supervisor.args, "--reaper"],
+		},
 		deadlineAtMs: deadlineMilliseconds(options.deadlineAtMs),
 		startupTimeoutMs: boundedMilliseconds(
 			options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,

--- a/node/src/codex-supervised-process-config.ts
+++ b/node/src/codex-supervised-process-config.ts
@@ -27,6 +27,7 @@ export interface CodexSupervisedProcessOptions {
 	readonly process: CodexAppServerProcessOptions;
 	readonly lock: ProcessLock;
 	readonly store: CodexProviderGenerationStore;
+	readonly deadlineAtMs: number;
 	readonly startupTimeoutMs?: number;
 	readonly heartbeatIntervalMs?: number;
 	readonly heartbeatTimeoutMs?: number;
@@ -70,6 +71,7 @@ export function resolveSupervisedProcessOptions(
 	);
 	return {
 		...options,
+		deadlineAtMs: deadlineMilliseconds(options.deadlineAtMs),
 		startupTimeoutMs: boundedMilliseconds(
 			options.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
 			500,
@@ -87,6 +89,13 @@ export function resolveSupervisedProcessOptions(
 			60_000,
 		),
 	};
+}
+
+function deadlineMilliseconds(value: number): number {
+	if (!Number.isSafeInteger(value) || value <= 0) {
+		throw new Error("Codex provider guardian deadline is invalid");
+	}
+	return value;
 }
 
 export function supervisorEnvironment(extra: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {

--- a/node/src/codex-supervised-process.ts
+++ b/node/src/codex-supervised-process.ts
@@ -1,6 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
 import type { CodexAppServerProcess } from "./codex-app-server-process.js";
+import type { CodexAppServerStopReason } from "./codex-app-server-process.js";
 import type {
 	CodexProviderObservation,
 	CodexProviderStopCause,
@@ -42,6 +43,7 @@ export class CodexSupervisedProcess {
 	readonly #exited: CodexAppServerProcess["exited"];
 	readonly #closed: CodexAppServerProcess["closed"];
 	#resolveTermination!: (value: { readonly kind: CodexProviderObservation }) => void;
+	#rejectTermination!: (error: Error) => void;
 	#heartbeat: NodeJS.Timeout | null = null;
 	#ready = false;
 	#observation: CodexProviderObservation | null = null;
@@ -56,21 +58,25 @@ export class CodexSupervisedProcess {
 		this.#child = child;
 		this.#exited = childExit(child);
 		this.#closed = childClose(child);
-		this.termination = new Promise((resolve) => {
+		this.termination = new Promise((resolve, reject) => {
 			this.#resolveTermination = resolve;
+			this.#rejectTermination = reject;
 		});
+		void this.termination.catch(() => undefined);
 		this.process = {
 			child,
 			cwd: options.process.cwd,
 			exited: this.#exited,
 			closed: this.#closed,
 			inputError: writableError(child),
-			stop: () =>
-				this.stop(this.#stopCause ?? (this.#ready ? "provider_failure" : "startup_failure")),
+			stop: (reason) => this.stop(this.#stopCause ?? stopCause(reason, this.#ready)),
 		};
 	}
 
-	static async start(options: CodexSupervisedProcessOptions): Promise<CodexSupervisedProcess> {
+	static async start(
+		options: CodexSupervisedProcessOptions,
+		onSpawned: (supervised: CodexSupervisedProcess) => void,
+	): Promise<CodexSupervisedProcess> {
 		const bounded = resolveSupervisedProcessOptions(options);
 		const commands = await prepareProviderCommands(options.process);
 		const child = spawn(options.supervisor.executable, [...options.supervisor.args], {
@@ -81,15 +87,11 @@ export class CodexSupervisedProcess {
 			shell: false,
 		}) as ChildProcessWithoutNullStreams;
 		const supervised = new CodexSupervisedProcess(bounded, child);
-		try {
-			await waitForChildSpawn(child);
-			child.stderr.resume();
-			await supervised.initialize(commands);
-			return supervised;
-		} catch (error) {
-			await supervised.stop("startup_failure").catch(() => undefined);
-			throw error;
-		}
+		await waitForChildSpawn(child);
+		child.stderr.resume();
+		onSpawned(supervised);
+		await supervised.initialize(commands);
+		return supervised;
 	}
 
 	activate(): void {
@@ -129,12 +131,17 @@ export class CodexSupervisedProcess {
 			if (event.kind === "failure") {
 				rejectReady(new Error(`Codex provider supervisor failed during ${event.code}`));
 			}
-			if (event.kind === "terminal") this.#observation ??= event.observation;
+			if (event.kind === "terminal") {
+				this.setStopCause(event.cause);
+				this.#observation ??= event.observation;
+			}
 		};
 		this.#child.on("message", onMessage);
 		void this.#closed.then(() => {
 			if (!this.#ready) rejectReady(new Error("Codex provider supervisor exited during startup"));
-			void this.stop(this.#stopCause ?? (this.#ready ? "provider_failure" : "startup_failure"));
+			void this.stop(
+				this.#stopCause ?? (this.#ready ? "provider_failure" : "startup_failure"),
+			).catch(() => undefined);
 		});
 
 		await sendSupervisorCommand(this.#child, {
@@ -145,6 +152,7 @@ export class CodexSupervisedProcess {
 			owner_pid: process.pid,
 			lock_path: this.#options.lock.path,
 			state_directory: this.#options.capsuleDirectory,
+			deadline_at_ms: this.#options.deadlineAtMs,
 			heartbeat_timeout_ms: this.#options.heartbeatTimeoutMs,
 			heartbeat_record_ms: this.#options.heartbeatRecordMs,
 			version_probe: commands.versionProbe,
@@ -155,7 +163,9 @@ export class CodexSupervisedProcess {
 				version: 1,
 				kind: "heartbeat",
 				generation_id: this.#options.generationId,
-			}).catch(() => this.stop("provider_failure"));
+			})
+				.catch(() => this.stop("provider_failure"))
+				.catch(() => undefined);
 		}, this.#options.heartbeatIntervalMs);
 		this.#heartbeat.unref();
 
@@ -179,8 +189,40 @@ export class CodexSupervisedProcess {
 			await stopSupervisorProcessGroup(this.#child, this.#exited, this.#closed);
 		}
 		const observation = this.#observation ?? observationForCause(cause);
-		await this.#options.store.markQuiescent(this.#options.generationId, cause, observation);
-		await this.#options.lock.release();
+		let failure: unknown;
+		try {
+			await this.#options.store.markQuiescentIfCurrent(
+				this.#options.generationId,
+				cause,
+				observation,
+			);
+		} catch (error) {
+			failure = error;
+		} finally {
+			try {
+				await this.#options.lock.release();
+			} catch (error) {
+				failure =
+					failure === undefined
+						? error
+						: new AggregateError([failure, error], "Codex guardian finalization failed");
+			}
+		}
+		if (failure !== undefined) {
+			const error = new Error("Codex provider termination could not be recorded", {
+				cause: failure,
+			});
+			this.#rejectTermination(error);
+			throw error;
+		}
 		this.#resolveTermination({ kind: observation });
 	}
+}
+
+function stopCause(
+	reason: CodexAppServerStopReason | undefined,
+	ready: boolean,
+): CodexProviderStopCause {
+	if (reason === "unresponsive") return "provider_unresponsive";
+	return ready ? "provider_failure" : "startup_failure";
 }

--- a/node/src/codex-supervised-process.ts
+++ b/node/src/codex-supervised-process.ts
@@ -6,10 +6,12 @@ import type {
 	CodexProviderObservation,
 	CodexProviderStopCause,
 } from "./codex-provider-generation-state.js";
+import { observationForProviderStopCause } from "./codex-provider-generation-state.js";
 import {
 	type CodexPreparedProcess,
 	type CodexProviderSupervisorEvent,
 	parseCodexProviderSupervisorEvent,
+	sanitizePreparedEnvironment,
 	terminateSupervisorCommand,
 } from "./codex-provider-supervisor-protocol.js";
 import {
@@ -24,7 +26,6 @@ import {
 	childClose,
 	childExit,
 	isSupervisorProcessGroupAlive,
-	observationForCause,
 	sendSupervisorCommand,
 	stopSupervisorProcessGroup,
 	waitForChildSpawn,
@@ -32,6 +33,7 @@ import {
 } from "./codex-supervisor-owner.js";
 
 const STOP_GRACE_MS = 2_000;
+const REAPER_FINALIZATION_TIMEOUT_MS = 10_000;
 
 export type { CodexSupervisedProcessOptions, CodexSupervisorCommand };
 
@@ -155,6 +157,12 @@ export class CodexSupervisedProcess {
 			deadline_at_ms: this.#options.deadlineAtMs,
 			heartbeat_timeout_ms: this.#options.heartbeatTimeoutMs,
 			heartbeat_record_ms: this.#options.heartbeatRecordMs,
+			reaper: {
+				executable: this.#options.reaper.executable,
+				argv: [...this.#options.reaper.args],
+				cwd: this.#options.capsuleDirectory,
+				env: sanitizePreparedEnvironment(supervisorEnvironment(this.#options.reaper.env)),
+			},
 			version_probe: commands.versionProbe,
 			app_server: commands.appServer,
 		});
@@ -180,42 +188,44 @@ export class CodexSupervisedProcess {
 	private async performStop(): Promise<void> {
 		if (this.#heartbeat !== null) clearInterval(this.#heartbeat);
 		const cause = this.#stopCause ?? "provider_failure";
-		await sendSupervisorCommand(
-			this.#child,
-			terminateSupervisorCommand(this.#options.generationId, cause),
-		).catch(() => undefined);
-		await Promise.race([this.#closed, delay(STOP_GRACE_MS + 250, undefined, { ref: false })]);
-		if (this.#child.pid !== undefined && isSupervisorProcessGroupAlive(this.#child.pid)) {
-			await stopSupervisorProcessGroup(this.#child, this.#exited, this.#closed);
-		}
-		const observation = this.#observation ?? observationForCause(cause);
-		let failure: unknown;
 		try {
-			await this.#options.store.markQuiescentIfCurrent(
-				this.#options.generationId,
-				cause,
-				observation,
-			);
-		} catch (error) {
-			failure = error;
-		} finally {
-			try {
-				await this.#options.lock.release();
-			} catch (error) {
-				failure =
-					failure === undefined
-						? error
-						: new AggregateError([failure, error], "Codex guardian finalization failed");
+			await sendSupervisorCommand(
+				this.#child,
+				terminateSupervisorCommand(this.#options.generationId, cause),
+			).catch(() => undefined);
+			await Promise.race([this.#closed, delay(STOP_GRACE_MS + 250, undefined, { ref: false })]);
+			if (this.#child.pid !== undefined && isSupervisorProcessGroupAlive(this.#child.pid)) {
+				await stopSupervisorProcessGroup(this.#child, this.#exited, this.#closed);
 			}
-		}
-		if (failure !== undefined) {
-			const error = new Error("Codex provider termination could not be recorded", {
-				cause: failure,
-			});
+			const finalized = await waitForReaperFinalization(
+				this.#options.store,
+				this.#options.generationId,
+			);
+			const observation =
+				finalized?.observation ?? this.#observation ?? observationForProviderStopCause(cause);
+			await this.#options.lock.release();
+			this.#resolveTermination({ kind: observation });
+		} catch (cause) {
+			const error = new Error("Codex provider termination could not be proven", { cause });
 			this.#rejectTermination(error);
 			throw error;
 		}
-		this.#resolveTermination({ kind: observation });
+	}
+}
+
+async function waitForReaperFinalization(
+	store: ResolvedCodexSupervisedProcessOptions["store"],
+	generationId: string,
+): Promise<Awaited<ReturnType<typeof store.snapshot>>> {
+	const deadline = Date.now() + REAPER_FINALIZATION_TIMEOUT_MS;
+	for (;;) {
+		const state = await store.snapshot();
+		if (state === null || state.generation_id !== generationId) return null;
+		if (state.phase === "quiescent") return state;
+		if (Date.now() >= deadline) {
+			throw new Error("Codex provider reaper did not finalize quiescence");
+		}
+		await delay(10);
 	}
 }
 

--- a/node/src/codex-supervised-process.ts
+++ b/node/src/codex-supervised-process.ts
@@ -171,7 +171,7 @@ export class CodexSupervisedProcess {
 
 		await Promise.race([
 			ready,
-			delay(this.#options.startupTimeoutMs).then(() => {
+			delay(this.#options.startupTimeoutMs, undefined, { ref: false }).then(() => {
 				throw new Error("Codex provider supervisor timed out during startup");
 			}),
 		]);
@@ -184,7 +184,7 @@ export class CodexSupervisedProcess {
 			this.#child,
 			terminateSupervisorCommand(this.#options.generationId, cause),
 		).catch(() => undefined);
-		await Promise.race([this.#closed, delay(STOP_GRACE_MS + 250)]);
+		await Promise.race([this.#closed, delay(STOP_GRACE_MS + 250, undefined, { ref: false })]);
 		if (this.#child.pid !== undefined && isSupervisorProcessGroupAlive(this.#child.pid)) {
 			await stopSupervisorProcessGroup(this.#child, this.#exited, this.#closed);
 		}

--- a/node/src/codex-supervised-process.ts
+++ b/node/src/codex-supervised-process.ts
@@ -1,0 +1,186 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import type { CodexAppServerProcess } from "./codex-app-server-process.js";
+import type {
+	CodexProviderObservation,
+	CodexProviderStopCause,
+} from "./codex-provider-generation-state.js";
+import {
+	type CodexPreparedProcess,
+	type CodexProviderSupervisorEvent,
+	parseCodexProviderSupervisorEvent,
+	terminateSupervisorCommand,
+} from "./codex-provider-supervisor-protocol.js";
+import {
+	type CodexSupervisedProcessOptions,
+	type CodexSupervisorCommand,
+	type ResolvedCodexSupervisedProcessOptions,
+	prepareProviderCommands,
+	resolveSupervisedProcessOptions,
+	supervisorEnvironment,
+} from "./codex-supervised-process-config.js";
+import {
+	childClose,
+	childExit,
+	isSupervisorProcessGroupAlive,
+	observationForCause,
+	sendSupervisorCommand,
+	stopSupervisorProcessGroup,
+	waitForChildSpawn,
+	writableError,
+} from "./codex-supervisor-owner.js";
+
+const STOP_GRACE_MS = 2_000;
+
+export type { CodexSupervisedProcessOptions, CodexSupervisorCommand };
+
+export class CodexSupervisedProcess {
+	readonly process: CodexAppServerProcess;
+	readonly termination: Promise<{ readonly kind: CodexProviderObservation }>;
+	readonly #options: ResolvedCodexSupervisedProcessOptions;
+	readonly #child: ChildProcessWithoutNullStreams;
+	readonly #exited: CodexAppServerProcess["exited"];
+	readonly #closed: CodexAppServerProcess["closed"];
+	#resolveTermination!: (value: { readonly kind: CodexProviderObservation }) => void;
+	#heartbeat: NodeJS.Timeout | null = null;
+	#ready = false;
+	#observation: CodexProviderObservation | null = null;
+	#stopCause: CodexProviderStopCause | null = null;
+	#stopPromise: Promise<void> | null = null;
+
+	private constructor(
+		options: ResolvedCodexSupervisedProcessOptions,
+		child: ChildProcessWithoutNullStreams,
+	) {
+		this.#options = options;
+		this.#child = child;
+		this.#exited = childExit(child);
+		this.#closed = childClose(child);
+		this.termination = new Promise((resolve) => {
+			this.#resolveTermination = resolve;
+		});
+		this.process = {
+			child,
+			cwd: options.process.cwd,
+			exited: this.#exited,
+			closed: this.#closed,
+			inputError: writableError(child),
+			stop: () =>
+				this.stop(this.#stopCause ?? (this.#ready ? "provider_failure" : "startup_failure")),
+		};
+	}
+
+	static async start(options: CodexSupervisedProcessOptions): Promise<CodexSupervisedProcess> {
+		const bounded = resolveSupervisedProcessOptions(options);
+		const commands = await prepareProviderCommands(options.process);
+		const child = spawn(options.supervisor.executable, [...options.supervisor.args], {
+			cwd: options.capsuleDirectory,
+			detached: true,
+			env: supervisorEnvironment(options.supervisor.env),
+			stdio: ["pipe", "pipe", "pipe", "ipc", options.lock.inheritFileDescriptor()],
+			shell: false,
+		}) as ChildProcessWithoutNullStreams;
+		const supervised = new CodexSupervisedProcess(bounded, child);
+		try {
+			await waitForChildSpawn(child);
+			child.stderr.resume();
+			await supervised.initialize(commands);
+			return supervised;
+		} catch (error) {
+			await supervised.stop("startup_failure").catch(() => undefined);
+			throw error;
+		}
+	}
+
+	activate(): void {
+		this.#ready = true;
+	}
+
+	setStopCause(cause: CodexProviderStopCause): void {
+		this.#stopCause ??= cause;
+	}
+
+	stop(cause: CodexProviderStopCause): Promise<void> {
+		this.setStopCause(cause);
+		this.#stopPromise ??= this.performStop();
+		return this.#stopPromise;
+	}
+
+	private async initialize(commands: {
+		readonly versionProbe: CodexPreparedProcess;
+		readonly appServer: CodexPreparedProcess;
+	}): Promise<void> {
+		let resolveReady!: () => void;
+		let rejectReady!: (error: Error) => void;
+		const ready = new Promise<void>((resolve, reject) => {
+			resolveReady = resolve;
+			rejectReady = reject;
+		});
+		const onMessage = (value: unknown) => {
+			let event: CodexProviderSupervisorEvent;
+			try {
+				event = parseCodexProviderSupervisorEvent(value);
+			} catch {
+				rejectReady(new Error("Codex provider supervisor returned an invalid control event"));
+				return;
+			}
+			if (event.generation_id !== this.#options.generationId) return;
+			if (event.kind === "ready") resolveReady();
+			if (event.kind === "failure") {
+				rejectReady(new Error(`Codex provider supervisor failed during ${event.code}`));
+			}
+			if (event.kind === "terminal") this.#observation ??= event.observation;
+		};
+		this.#child.on("message", onMessage);
+		void this.#closed.then(() => {
+			if (!this.#ready) rejectReady(new Error("Codex provider supervisor exited during startup"));
+			void this.stop(this.#stopCause ?? (this.#ready ? "provider_failure" : "startup_failure"));
+		});
+
+		await sendSupervisorCommand(this.#child, {
+			version: 1,
+			kind: "initialize",
+			capsule_id: this.#options.capsuleId,
+			generation_id: this.#options.generationId,
+			owner_pid: process.pid,
+			lock_path: this.#options.lock.path,
+			state_directory: this.#options.capsuleDirectory,
+			heartbeat_timeout_ms: this.#options.heartbeatTimeoutMs,
+			heartbeat_record_ms: this.#options.heartbeatRecordMs,
+			version_probe: commands.versionProbe,
+			app_server: commands.appServer,
+		});
+		this.#heartbeat = setInterval(() => {
+			void sendSupervisorCommand(this.#child, {
+				version: 1,
+				kind: "heartbeat",
+				generation_id: this.#options.generationId,
+			}).catch(() => this.stop("provider_failure"));
+		}, this.#options.heartbeatIntervalMs);
+		this.#heartbeat.unref();
+
+		await Promise.race([
+			ready,
+			delay(this.#options.startupTimeoutMs).then(() => {
+				throw new Error("Codex provider supervisor timed out during startup");
+			}),
+		]);
+	}
+
+	private async performStop(): Promise<void> {
+		if (this.#heartbeat !== null) clearInterval(this.#heartbeat);
+		const cause = this.#stopCause ?? "provider_failure";
+		await sendSupervisorCommand(
+			this.#child,
+			terminateSupervisorCommand(this.#options.generationId, cause),
+		).catch(() => undefined);
+		await Promise.race([this.#closed, delay(STOP_GRACE_MS + 250)]);
+		if (this.#child.pid !== undefined && isSupervisorProcessGroupAlive(this.#child.pid)) {
+			await stopSupervisorProcessGroup(this.#child, this.#exited, this.#closed);
+		}
+		const observation = this.#observation ?? observationForCause(cause);
+		await this.#options.store.markQuiescent(this.#options.generationId, cause, observation);
+		await this.#options.lock.release();
+		this.#resolveTermination({ kind: observation });
+	}
+}

--- a/node/src/codex-supervised-process.ts
+++ b/node/src/codex-supervised-process.ts
@@ -51,6 +51,7 @@ export class CodexSupervisedProcess {
 	#observation: CodexProviderObservation | null = null;
 	#stopCause: CodexProviderStopCause | null = null;
 	#stopPromise: Promise<void> | null = null;
+	#allowMissingGenerationState = false;
 
 	private constructor(
 		options: ResolvedCodexSupervisedProcessOptions,
@@ -129,11 +130,16 @@ export class CodexSupervisedProcess {
 				return;
 			}
 			if (event.generation_id !== this.#options.generationId) return;
-			if (event.kind === "ready") resolveReady();
+			if (event.kind === "ready") {
+				this.#allowMissingGenerationState = false;
+				resolveReady();
+			}
 			if (event.kind === "failure") {
+				this.#allowMissingGenerationState = event.code === "invalid_startup";
 				rejectReady(new Error(`Codex provider supervisor failed during ${event.code}`));
 			}
 			if (event.kind === "terminal") {
+				this.#allowMissingGenerationState = false;
 				this.setStopCause(event.cause);
 				this.#observation ??= event.observation;
 			}
@@ -200,6 +206,7 @@ export class CodexSupervisedProcess {
 			const finalized = await waitForReaperFinalization(
 				this.#options.store,
 				this.#options.generationId,
+				this.#allowMissingGenerationState,
 			);
 			const observation =
 				finalized?.observation ?? this.#observation ?? observationForProviderStopCause(cause);
@@ -216,11 +223,15 @@ export class CodexSupervisedProcess {
 async function waitForReaperFinalization(
 	store: ResolvedCodexSupervisedProcessOptions["store"],
 	generationId: string,
+	allowMissingGenerationState: boolean,
 ): Promise<Awaited<ReturnType<typeof store.snapshot>>> {
 	const deadline = Date.now() + REAPER_FINALIZATION_TIMEOUT_MS;
 	for (;;) {
 		const state = await store.snapshot();
-		if (state === null || state.generation_id !== generationId) return null;
+		if (state === null || state.generation_id !== generationId) {
+			if (allowMissingGenerationState) return null;
+			throw new Error("Codex provider generation state changed before teardown was proven");
+		}
 		if (state.phase === "quiescent") return state;
 		if (Date.now() >= deadline) {
 			throw new Error("Codex provider reaper did not finalize quiescence");

--- a/node/src/codex-supervised-process.ts
+++ b/node/src/codex-supervised-process.ts
@@ -33,7 +33,7 @@ import {
 } from "./codex-supervisor-owner.js";
 
 const STOP_GRACE_MS = 2_000;
-const REAPER_FINALIZATION_TIMEOUT_MS = 10_000;
+const REAPER_FINALIZATION_TIMEOUT_MS = 20_000;
 
 export type { CodexSupervisedProcessOptions, CodexSupervisorCommand };
 

--- a/node/src/codex-supervisor-owner.test.ts
+++ b/node/src/codex-supervisor-owner.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isSupervisorProcessGroupAlive, signalProcessGroup } from "./codex-supervisor-owner.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Codex supervisor process-group ownership", () => {
+	it("treats EPERM as present rather than quiescent", () => {
+		vi.spyOn(process, "kill").mockImplementation(() => {
+			throw processError("EPERM");
+		});
+
+		expect(isSupervisorProcessGroupAlive(42)).toBe(true);
+	});
+
+	it("treats only ESRCH as proof of process-group absence", () => {
+		vi.spyOn(process, "kill").mockImplementation(() => {
+			throw processError("ESRCH");
+		});
+
+		expect(isSupervisorProcessGroupAlive(42)).toBe(false);
+	});
+
+	it("leaves an EPERM group for the liveness loop to prove", () => {
+		const kill = vi.spyOn(process, "kill").mockImplementation(() => {
+			throw processError("EPERM");
+		});
+
+		expect(() => signalProcessGroup(42, "SIGKILL")).not.toThrow();
+		expect(kill).toHaveBeenCalledWith(-42, "SIGKILL");
+	});
+
+	it("does not hide unexpected process-group probe failures", () => {
+		const failure = processError("EINVAL");
+		vi.spyOn(process, "kill").mockImplementation(() => {
+			throw failure;
+		});
+
+		expect(() => isSupervisorProcessGroupAlive(42)).toThrow(failure);
+		expect(() => signalProcessGroup(42, "SIGTERM")).toThrow(failure);
+	});
+});
+
+function processError(code: string): NodeJS.ErrnoException {
+	return Object.assign(new Error(`kill ${code}`), { code });
+}

--- a/node/src/codex-supervisor-owner.ts
+++ b/node/src/codex-supervisor-owner.ts
@@ -42,7 +42,7 @@ export async function stopSupervisorProcessGroup(
 	const pid = child.pid;
 	if (pid === undefined) return;
 	signalProcessGroup(pid, "SIGTERM");
-	await Promise.race([exited, delay(STOP_GRACE_MS)]);
+	await Promise.race([exited, delay(STOP_GRACE_MS, undefined, { ref: false })]);
 	if (isSupervisorProcessGroupAlive(pid)) signalProcessGroup(pid, "SIGKILL");
 	const deadline = Date.now() + STOP_GRACE_MS;
 	while (isSupervisorProcessGroupAlive(pid)) {
@@ -51,7 +51,7 @@ export async function stopSupervisorProcessGroup(
 	}
 	await Promise.race([
 		closed,
-		delay(STOP_GRACE_MS).then(() => {
+		delay(STOP_GRACE_MS, undefined, { ref: false }).then(() => {
 			throw new Error("Codex provider supervisor pipes did not close");
 		}),
 	]);

--- a/node/src/codex-supervisor-owner.ts
+++ b/node/src/codex-supervisor-owner.ts
@@ -10,7 +10,13 @@ const STOP_GRACE_MS = 2_000;
 const GROUP_POLL_MS = 10;
 
 export function observationForCause(cause: CodexProviderStopCause): CodexProviderObservation {
-	if (cause === "heartbeat_timeout") return "unresponsive";
+	if (
+		cause === "deadline_exceeded" ||
+		cause === "heartbeat_timeout" ||
+		cause === "provider_unresponsive"
+	) {
+		return "unresponsive";
+	}
 	if (cause === "provider_failure" || cause === "startup_failure") return "crashed";
 	return "stopped";
 }

--- a/node/src/codex-supervisor-owner.ts
+++ b/node/src/codex-supervisor-owner.ts
@@ -1,25 +1,9 @@
 import type { ChildProcess, ChildProcessWithoutNullStreams } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
-import type {
-	CodexProviderObservation,
-	CodexProviderStopCause,
-} from "./codex-provider-generation-state.js";
 import type { CodexProviderSupervisorCommand } from "./codex-provider-supervisor-protocol.js";
 
 const STOP_GRACE_MS = 2_000;
 const GROUP_POLL_MS = 10;
-
-export function observationForCause(cause: CodexProviderStopCause): CodexProviderObservation {
-	if (
-		cause === "deadline_exceeded" ||
-		cause === "heartbeat_timeout" ||
-		cause === "provider_unresponsive"
-	) {
-		return "unresponsive";
-	}
-	if (cause === "provider_failure" || cause === "startup_failure") return "crashed";
-	return "stopped";
-}
 
 export async function sendSupervisorCommand(
 	child: ChildProcess,
@@ -90,7 +74,7 @@ export function writableError(child: ChildProcessWithoutNullStreams): Promise<Er
 	return new Promise((resolve) => child.stdin.once("error", resolve));
 }
 
-function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
+export function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
 	try {
 		process.kill(-pid, signal);
 	} catch (error) {

--- a/node/src/codex-supervisor-owner.ts
+++ b/node/src/codex-supervisor-owner.ts
@@ -1,0 +1,99 @@
+import type { ChildProcess, ChildProcessWithoutNullStreams } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import type {
+	CodexProviderObservation,
+	CodexProviderStopCause,
+} from "./codex-provider-generation-state.js";
+import type { CodexProviderSupervisorCommand } from "./codex-provider-supervisor-protocol.js";
+
+const STOP_GRACE_MS = 2_000;
+const GROUP_POLL_MS = 10;
+
+export function observationForCause(cause: CodexProviderStopCause): CodexProviderObservation {
+	if (cause === "heartbeat_timeout") return "unresponsive";
+	if (cause === "provider_failure" || cause === "startup_failure") return "crashed";
+	return "stopped";
+}
+
+export async function sendSupervisorCommand(
+	child: ChildProcess,
+	message: CodexProviderSupervisorCommand,
+): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		if (!child.connected || child.send === undefined) {
+			reject(new Error("Codex provider supervisor control channel is closed"));
+			return;
+		}
+		child.send(message, (error) => (error === null ? resolve() : reject(error)));
+	});
+}
+
+export async function stopSupervisorProcessGroup(
+	child: ChildProcess,
+	exited: Promise<unknown>,
+	closed: Promise<unknown>,
+): Promise<void> {
+	const pid = child.pid;
+	if (pid === undefined) return;
+	signalProcessGroup(pid, "SIGTERM");
+	await Promise.race([exited, delay(STOP_GRACE_MS)]);
+	if (isSupervisorProcessGroupAlive(pid)) signalProcessGroup(pid, "SIGKILL");
+	const deadline = Date.now() + STOP_GRACE_MS;
+	while (isSupervisorProcessGroupAlive(pid)) {
+		if (Date.now() >= deadline) throw new Error("Codex provider process group did not terminate");
+		await delay(GROUP_POLL_MS);
+	}
+	await Promise.race([
+		closed,
+		delay(STOP_GRACE_MS).then(() => {
+			throw new Error("Codex provider supervisor pipes did not close");
+		}),
+	]);
+}
+
+export function isSupervisorProcessGroupAlive(pid: number): boolean {
+	try {
+		process.kill(-pid, 0);
+		return true;
+	} catch (error) {
+		if (errorCode(error) === "ESRCH") return false;
+		throw error;
+	}
+}
+
+export function waitForChildSpawn(child: ChildProcess): Promise<void> {
+	return new Promise((resolve, reject) => {
+		child.once("spawn", resolve);
+		child.once("error", reject);
+	});
+}
+
+export function childExit(
+	child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+	return new Promise((resolve) => child.once("exit", (code, signal) => resolve({ code, signal })));
+}
+
+export function childClose(
+	child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+	return new Promise((resolve) => child.once("close", (code, signal) => resolve({ code, signal })));
+}
+
+export function writableError(child: ChildProcessWithoutNullStreams): Promise<Error> {
+	return new Promise((resolve) => child.stdin.once("error", resolve));
+}
+
+function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
+	try {
+		process.kill(-pid, signal);
+	} catch (error) {
+		if (errorCode(error) !== "ESRCH") throw error;
+	}
+}
+
+function errorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? String(error.code)
+		: undefined;
+}

--- a/node/src/codex-supervisor-owner.ts
+++ b/node/src/codex-supervisor-owner.ts
@@ -46,7 +46,11 @@ export function isSupervisorProcessGroupAlive(pid: number): boolean {
 		process.kill(-pid, 0);
 		return true;
 	} catch (error) {
-		if (errorCode(error) === "ESRCH") return false;
+		const code = errorCode(error);
+		if (code === "ESRCH") return false;
+		// macOS can report EPERM while a process group contains only zombies.
+		// That is still a present group, not proof of quiescence.
+		if (code === "EPERM") return true;
 		throw error;
 	}
 }
@@ -78,7 +82,10 @@ export function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
 	try {
 		process.kill(-pid, signal);
 	} catch (error) {
-		if (errorCode(error) !== "ESRCH") throw error;
+		const code = errorCode(error);
+		// EPERM is not absence. The caller must continue polling and fail closed
+		// unless a later liveness probe proves the process group disappeared.
+		if (code !== "ESRCH" && code !== "EPERM") throw error;
 	}
 }
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -7,6 +7,8 @@ export * from "./codex-capsule-prompt.js";
 export * from "./codex-capsule-runner.js";
 export * from "./codex-capsule-store.js";
 export * from "./codex-capsule-types.js";
+export * from "./codex-provider-generation-state.js";
+export * from "./codex-provider-guardian.js";
 export * from "./codex-process-boundary.js";
 export * from "./codex-sandbox-containment.js";
 export * from "./daemon.js";

--- a/node/src/process-lock-state.ts
+++ b/node/src/process-lock-state.ts
@@ -22,10 +22,17 @@ const legacyLockMetadataSchema = z
 	})
 	.strict();
 
+export const PROCESS_LOCK_KINDS = [
+	"agentrelay_node_kernel_lock",
+	"agentrelay_provider_generation_lock",
+] as const;
+
+export type ProcessLockKind = (typeof PROCESS_LOCK_KINDS)[number];
+
 const kernelLockFileSchema = z
 	.object({
 		schema_version: z.literal(2),
-		kind: z.literal("agentrelay_node_kernel_lock"),
+		kind: z.enum(PROCESS_LOCK_KINDS),
 	})
 	.strict();
 
@@ -41,10 +48,8 @@ export const ownerMetadataSchema = z
 export type LegacyLockMetadata = z.infer<typeof legacyLockMetadataSchema>;
 export type OwnerMetadata = z.infer<typeof ownerMetadataSchema>;
 
-const KERNEL_LOCK_FILE = Object.freeze({
-	schema_version: 2 as const,
-	kind: "agentrelay_node_kernel_lock" as const,
-});
+export const NODE_PROCESS_LOCK_KIND: ProcessLockKind = "agentrelay_node_kernel_lock";
+export const PROVIDER_GENERATION_LOCK_KIND: ProcessLockKind = "agentrelay_provider_generation_lock";
 
 interface OpenLockFile {
 	readonly handle: FileHandle;
@@ -66,12 +71,15 @@ export class ProcessLockError extends Error {
 	}
 }
 
-export async function openStableProcessLock(path: string): Promise<FileHandle> {
+export async function openStableProcessLock(
+	path: string,
+	kind: ProcessLockKind = NODE_PROCESS_LOCK_KIND,
+): Promise<FileHandle> {
 	await prepareLockDirectory(path);
 	for (let attempt = 0; attempt < ACQUISITION_ATTEMPTS; attempt += 1) {
-		const existing = await openLockFile(path);
+		const existing = await openLockFile(path, kind);
 		if (existing === null) {
-			await publishKernelLockFile(path);
+			await publishKernelLockFile(path, kind);
 			continue;
 		}
 		if (existing.contents.kind === "kernel") return existing.handle;
@@ -136,7 +144,7 @@ export async function writeOwnerMetadata(path: string, metadata: OwnerMetadata):
 	await writePrivateJson(ownerMetadataPath(path), metadata);
 }
 
-async function openLockFile(path: string): Promise<OpenLockFile | null> {
+async function openLockFile(path: string, kind: ProcessLockKind): Promise<OpenLockFile | null> {
 	let handle: FileHandle;
 	try {
 		handle = await open(path, constants.O_RDWR | constants.O_NOFOLLOW);
@@ -156,7 +164,8 @@ async function openLockFile(path: string): Promise<OpenLockFile | null> {
 		await assertPathReferencesHandle(path, handle);
 		const decoded = await readLockJson(path, handle, stats.size);
 
-		if (kernelLockFileSchema.safeParse(decoded).success) {
+		const kernelFile = kernelLockFileSchema.safeParse(decoded);
+		if (kernelFile.success && kernelFile.data.kind === kind) {
 			if (stats.nlink !== 1) await removePublishedTemporaryLinks(path, handle);
 			return { handle, contents: { kind: "kernel" } };
 		}
@@ -171,7 +180,7 @@ async function openLockFile(path: string): Promise<OpenLockFile | null> {
 	}
 }
 
-async function publishKernelLockFile(path: string): Promise<void> {
+async function publishKernelLockFile(path: string, kind: ProcessLockKind): Promise<void> {
 	const directory = dirname(path);
 	const temporaryPath = join(directory, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
 	let temporaryExists = false;
@@ -185,7 +194,7 @@ async function publishKernelLockFile(path: string): Promise<void> {
 		temporaryExists = true;
 		try {
 			await handle.chmod(0o600);
-			await handle.writeFile(`${JSON.stringify(KERNEL_LOCK_FILE, null, 2)}\n`, "utf8");
+			await handle.writeFile(`${JSON.stringify({ schema_version: 2, kind }, null, 2)}\n`, "utf8");
 			await handle.sync();
 		} finally {
 			await handle.close();

--- a/node/src/process-lock.test.ts
+++ b/node/src/process-lock.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { kernelFileLock } from "./kernel-file-lock.js";
-import { acquireProcessLock } from "./process-lock.js";
+import { PROVIDER_GENERATION_LOCK_KIND, acquireProcessLock } from "./process-lock.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -81,6 +81,28 @@ describe("acquireProcessLock", () => {
 		});
 
 		await first.release();
+	});
+
+	it("keeps provider generation ownership distinct from Node ownership", async () => {
+		const root = await temporaryDirectory();
+		const path = join(root, "provider.lock");
+		const provider = await acquireProcessLock(path, {
+			...fixedOptions(),
+			kind: PROVIDER_GENERATION_LOCK_KIND,
+		});
+
+		expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+			schema_version: 2,
+			kind: PROVIDER_GENERATION_LOCK_KIND,
+		});
+		expect(provider.inheritFileDescriptor()).toBeGreaterThanOrEqual(0);
+		await expect(acquireProcessLock(path, fixedOptions())).rejects.toMatchObject({
+			name: "ProcessLockError",
+			reason: "invalid_lock",
+		});
+
+		await provider.release();
+		expect(() => provider.inheritFileDescriptor()).toThrow("already releasing");
 	});
 
 	it("fails closed on schema-1 ownership even when its PID appears absent", async () => {

--- a/node/src/process-lock.ts
+++ b/node/src/process-lock.ts
@@ -2,8 +2,10 @@ import { randomUUID } from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
 import { type KernelFileLock, kernelFileLock } from "./kernel-file-lock.js";
 import {
+	NODE_PROCESS_LOCK_KIND,
 	type OwnerMetadata,
 	ProcessLockError,
+	type ProcessLockKind,
 	assertStableProcessLock,
 	openStableProcessLock,
 	ownerMetadataSchema,
@@ -11,11 +13,18 @@ import {
 	writeOwnerMetadata,
 } from "./process-lock-state.js";
 
-export { ProcessLockError } from "./process-lock-state.js";
+export {
+	NODE_PROCESS_LOCK_KIND,
+	PROVIDER_GENERATION_LOCK_KIND,
+	ProcessLockError,
+} from "./process-lock-state.js";
+export type { ProcessLockKind } from "./process-lock-state.js";
 
 export interface ProcessLock {
 	readonly path: string;
 	readonly metadata: Readonly<OwnerMetadata>;
+	/** Duplicate this descriptor into a supervised child to retain the same kernel ownership. */
+	inheritFileDescriptor(): number;
 	release(): Promise<void>;
 }
 
@@ -24,6 +33,7 @@ export interface AcquireProcessLockOptions {
 	readonly now?: () => Date;
 	readonly id?: () => string;
 	readonly kernelLock?: KernelFileLock;
+	readonly kind?: ProcessLockKind;
 }
 
 export async function acquireProcessLock(
@@ -36,7 +46,8 @@ export async function acquireProcessLock(
 		pid: options.pid ?? process.pid,
 		started_at: (options.now ?? (() => new Date()))().toISOString(),
 	});
-	const handle = await openStableProcessLock(path);
+	const kind = options.kind ?? NODE_PROCESS_LOCK_KIND;
+	const handle = await openStableProcessLock(path, kind);
 	const lock = options.kernelLock ?? kernelFileLock;
 
 	let acquired: boolean;
@@ -60,8 +71,8 @@ export async function acquireProcessLock(
 			"already_running",
 			path,
 			owner === undefined
-				? `AgentRelay Node ownership is already held at ${path}; owner diagnostics are unavailable`
-				: `AgentRelay Node ownership is already held at ${path}; last reported owner PID ${owner.pid}`,
+				? `${ownerLabel(kind)} ownership is already held at ${path}; owner diagnostics are unavailable`
+				: `${ownerLabel(kind)} ownership is already held at ${path}; last reported owner PID ${owner.pid}`,
 			owner,
 		);
 	}
@@ -95,11 +106,21 @@ function processLock(
 	return {
 		path,
 		metadata: Object.freeze({ ...metadata }),
+		inheritFileDescriptor(): number {
+			if (releasePromise !== undefined) {
+				throw new ProcessLockError("unavailable", path, "Process ownership is already releasing");
+			}
+			return handle.fd;
+		},
 		release(): Promise<void> {
 			releasePromise ??= releaseKernelLock(handle, lock);
 			return releasePromise;
 		},
 	};
+}
+
+function ownerLabel(kind: ProcessLockKind): string {
+	return kind === NODE_PROCESS_LOCK_KIND ? "AgentRelay Node" : "AgentRelay provider generation";
 }
 
 async function releaseKernelLock(handle: FileHandle, lock: KernelFileLock): Promise<void> {

--- a/node/src/runtime-containment.process.test.ts
+++ b/node/src/runtime-containment.process.test.ts
@@ -16,13 +16,14 @@ import {
 	unlink,
 	writeFile,
 } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 import { resolvePinnedCodex, sha256File } from "../test-support/pinned-codex.js";
-import { CodexAppServerClient } from "./codex-app-server-client.js";
+import { SupervisedCodexProviderGuardian } from "./codex-provider-guardian.js";
 import {
 	prepareCodexSandboxContainment,
 	recoverCodexSandboxContainment,
@@ -161,7 +162,7 @@ describe.runIf(
 		).rejects.toThrow("authorize this exact workspace and policy");
 	}, 60_000);
 
-	it("starts the pinned Codex version probe and app-server inside the real boundary", async () => {
+	it("starts pinned Codex through the guardian and real boundary", async () => {
 		const fixture = await createFixture();
 		const launcher = await resolvePinnedCodex();
 		const containment = await prepareCodexSandboxContainment({
@@ -174,15 +175,25 @@ describe.runIf(
 			policyGrantSha256: "b".repeat(64),
 		});
 
-		const client = await CodexAppServerClient.start({
+		const generation = await new SupervisedCodexProviderGuardian({
+			capsuleId: randomUUID(),
 			command: { executable: launcher.executable },
 			cwd: fixture.workspace.root,
 			capsuleDirectory: fixture.runtime,
 			env: {},
 			boundary: containment.boundary,
+			deadlineAtMs: Date.now() + 55_000,
 			requestTimeoutMs: PROCESS_TIMEOUT_MS,
-		});
-		await client.close();
+			supervisor: {
+				executable: process.execPath,
+				args: [
+					"--import",
+					createRequire(import.meta.url).resolve("tsx"),
+					fileURLToPath(new URL("./bin/agentrelay-codex-guardian.ts", import.meta.url)),
+				],
+			},
+		}).openGeneration();
+		await generation.terminate("capsule_shutdown");
 	}, 60_000);
 });
 

--- a/node/test-support/codex-guardian-owner-worker.ts
+++ b/node/test-support/codex-guardian-owner-worker.ts
@@ -1,0 +1,47 @@
+import { writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { SupervisedCodexProviderGuardian } from "../src/codex-provider-guardian.js";
+import { directCodexProcessBoundaryForTests } from "./direct-codex-process-boundary.js";
+
+const capsuleId = requiredEnvironment("AGENTRELAY_TEST_CAPSULE_ID");
+const directory = requiredEnvironment("AGENTRELAY_TEST_CAPSULE_DIRECTORY");
+const executable = requiredEnvironment("AGENTRELAY_TEST_CODEX_BIN");
+const readyPath = requiredEnvironment("AGENTRELAY_TEST_READY_PATH");
+
+const guardian = new SupervisedCodexProviderGuardian({
+	capsuleId,
+	command: { executable },
+	cwd: directory,
+	capsuleDirectory: directory,
+	env: process.env,
+	boundary: directCodexProcessBoundaryForTests,
+	supervisor: {
+		executable: process.execPath,
+		args: [
+			"--import",
+			createRequire(import.meta.url).resolve("tsx"),
+			fileURLToPath(new URL("../src/bin/agentrelay-codex-guardian.ts", import.meta.url)),
+		],
+	},
+	startupTimeoutMs: 5_000,
+	heartbeatIntervalMs: 50,
+	heartbeatTimeoutMs: 500,
+	heartbeatRecordMs: 100,
+});
+
+const generation = await guardian.openGeneration();
+await generation.client.startThread();
+await writeFile(
+	readyPath,
+	`${JSON.stringify({ generation_id: generation.generationId, owner_pid: process.pid })}\n`,
+	{ mode: 0o600 },
+);
+
+await new Promise(() => undefined);
+
+function requiredEnvironment(name: string): string {
+	const value = process.env[name];
+	if (value === undefined || value.length === 0) throw new Error(`${name} is required`);
+	return value;
+}

--- a/node/test-support/codex-guardian-owner-worker.ts
+++ b/node/test-support/codex-guardian-owner-worker.ts
@@ -38,10 +38,6 @@ const guardian = new SupervisedCodexProviderGuardian({
 			fileURLToPath(new URL("../src/bin/agentrelay-codex-guardian.ts", import.meta.url)),
 		],
 	},
-	startupTimeoutMs: 5_000,
-	heartbeatIntervalMs: 50,
-	heartbeatTimeoutMs: 500,
-	heartbeatRecordMs: 100,
 });
 
 const generation = await guardian.openGeneration();

--- a/node/test-support/codex-guardian-owner-worker.ts
+++ b/node/test-support/codex-guardian-owner-worker.ts
@@ -1,5 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { SupervisedCodexProviderGuardian } from "../src/codex-provider-guardian.js";
 import { directCodexProcessBoundaryForTests } from "./direct-codex-process-boundary.js";
@@ -8,6 +9,18 @@ const capsuleId = requiredEnvironment("AGENTRELAY_TEST_CAPSULE_ID");
 const directory = requiredEnvironment("AGENTRELAY_TEST_CAPSULE_DIRECTORY");
 const executable = requiredEnvironment("AGENTRELAY_TEST_CODEX_BIN");
 const readyPath = requiredEnvironment("AGENTRELAY_TEST_READY_PATH");
+const prepareStartedPath = process.env.AGENTRELAY_TEST_PREPARE_STARTED_PATH;
+const prepareDelayMs = Number(process.env.AGENTRELAY_TEST_PREPARE_DELAY_MS ?? 0);
+
+const boundary = {
+	async prepare(request: Parameters<typeof directCodexProcessBoundaryForTests.prepare>[0]) {
+		if (prepareStartedPath !== undefined) {
+			await writeFile(prepareStartedPath, "started\n", { mode: 0o600 });
+		}
+		if (prepareDelayMs > 0) await delay(prepareDelayMs);
+		return directCodexProcessBoundaryForTests.prepare(request);
+	},
+};
 
 const guardian = new SupervisedCodexProviderGuardian({
 	capsuleId,
@@ -15,7 +28,8 @@ const guardian = new SupervisedCodexProviderGuardian({
 	cwd: directory,
 	capsuleDirectory: directory,
 	env: process.env,
-	boundary: directCodexProcessBoundaryForTests,
+	boundary,
+	deadlineAtMs: Date.now() + 60_000,
 	supervisor: {
 		executable: process.execPath,
 		args: [

--- a/node/test-support/fake-codex-app-server.ts
+++ b/node/test-support/fake-codex-app-server.ts
@@ -22,6 +22,8 @@ export interface FakeAppServerOptions {
 	readonly requestApproval?: boolean;
 	readonly spawnDescendant?: boolean;
 	readonly ignoreSigterm?: boolean;
+	readonly continuousOutput?: boolean;
+	readonly gateContinuousOutput?: boolean;
 }
 
 export interface FakeAppServerFixture {
@@ -31,6 +33,7 @@ export interface FakeAppServerFixture {
 	readonly childPidPath: string;
 	readonly argvPath: string;
 	readonly environmentPath: string;
+	readonly continuousOutputGatePath: string;
 	readonly env: NodeJS.ProcessEnv;
 	remove(): Promise<void>;
 }
@@ -44,6 +47,7 @@ export async function createFakeAppServer(
 	const childPidPath = join(directory, "child.pid");
 	const argvPath = join(directory, "argv.json");
 	const environmentPath = join(directory, "environment.json");
+	const continuousOutputGatePath = join(directory, "continuous-output-go");
 	const configPath = join(directory, "fake-app-server-config.json");
 	await writeFile(scriptPath, `#!${process.execPath}\n${FAKE_APP_SERVER_SOURCE}`, { mode: 0o700 });
 	await writeFile(
@@ -63,6 +67,8 @@ export async function createFakeAppServer(
 			requestApproval: options.requestApproval ?? false,
 			spawnDescendant: options.spawnDescendant ?? false,
 			ignoreSigterm: options.ignoreSigterm ?? false,
+			continuousOutput: options.continuousOutput ?? false,
+			continuousOutputGatePath: options.gateContinuousOutput ? continuousOutputGatePath : null,
 			logPath,
 			childPidPath,
 			argvPath,
@@ -77,6 +83,7 @@ export async function createFakeAppServer(
 		childPidPath,
 		argvPath,
 		environmentPath,
+		continuousOutputGatePath,
 		env: {
 			PATH: process.env.PATH,
 			TMPDIR: process.env.TMPDIR,
@@ -159,7 +166,7 @@ export function isProcessAlive(pid: number): boolean {
 
 const FAKE_APP_SERVER_SOURCE = `
 import { spawn } from "node:child_process";
-import { appendFileSync, closeSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, closeSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import readline from "node:readline";
 
@@ -192,6 +199,7 @@ const closeInputAfterRead = config.closeInputAfterRead;
 const unsafePolicy = config.unsafePolicy;
 const requestApproval = config.requestApproval;
 if (config.ignoreSigterm) process.on("SIGTERM", () => undefined);
+let continuousOutputStarted = false;
 if (config.spawnDescendant) {
   const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
     stdio: "ignore",
@@ -259,6 +267,21 @@ rl.on("line", (line) => {
     case "thread/resume":
       send({ id: message.id, result: threadResult() });
       send({ method: "thread/started", params: { thread: baseThread() } });
+      if (config.continuousOutput && !continuousOutputStarted) {
+        continuousOutputStarted = true;
+        process.stdout.on("error", () => undefined);
+        const startContinuousOutput = () =>
+          setInterval(() => process.stdout.write("x".repeat(4096)), 1);
+        if (config.continuousOutputGatePath === null) {
+          setTimeout(startContinuousOutput, 100);
+        } else {
+          const gate = setInterval(() => {
+            if (!existsSync(config.continuousOutputGatePath)) return;
+            clearInterval(gate);
+            startContinuousOutput();
+          }, 10);
+        }
+      }
       if (notificationMode === "valid") {
         send({
           method: "turn/completed",

--- a/node/test-support/fake-codex-app-server.ts
+++ b/node/test-support/fake-codex-app-server.ts
@@ -9,6 +9,7 @@ import {
 
 export interface FakeAppServerOptions {
 	readonly version?: string;
+	readonly versionDelayMs?: number;
 	readonly codexHome?: string;
 	readonly mismatchedThreadId?: boolean;
 	readonly readErrorCode?: number;
@@ -49,6 +50,7 @@ export async function createFakeAppServer(
 		configPath,
 		JSON.stringify({
 			version: options.version ?? SUPPORTED_CODEX_CLI_VERSION,
+			versionDelayMs: options.versionDelayMs ?? 0,
 			codexHome: options.codexHome ?? null,
 			threadId: options.mismatchedThreadId ? "thread-other" : "thread-1",
 			readErrorCode: options.readErrorCode ?? null,
@@ -168,9 +170,14 @@ const config = JSON.parse(readFileSync(
 const version = config.version;
 writeFileSync(config.environmentPath, JSON.stringify(process.env), { mode: 0o600 });
 if (process.argv.includes("--version")) {
-  process.stdout.write("codex-cli " + version + "\\n");
-  process.exit(0);
+  setTimeout(() => {
+    process.stdout.write("codex-cli " + version + "\\n");
+    process.exit(0);
+  }, config.versionDelayMs);
+} else {
+  startAppServer();
 }
+function startAppServer() {
 writeFileSync(config.argvPath, JSON.stringify(process.argv.slice(2)), { mode: 0o600 });
 const logPath = config.logPath;
 const cwd = process.cwd();
@@ -203,6 +210,7 @@ const baseThread = (turns = []) => ({
   cliVersion: version,
   turns,
 });
+
 const turn = (id, status, items = []) => ({
   id,
   items,
@@ -310,6 +318,7 @@ rl.on("line", (line) => {
       }
   }
 });
+}
 `;
 
 function errorCode(error: unknown): string | undefined {

--- a/node/test-support/fake-codex-app-server.ts
+++ b/node/test-support/fake-codex-app-server.ts
@@ -20,6 +20,7 @@ export interface FakeAppServerOptions {
 	readonly unsafePolicy?: boolean;
 	readonly requestApproval?: boolean;
 	readonly spawnDescendant?: boolean;
+	readonly ignoreSigterm?: boolean;
 }
 
 export interface FakeAppServerFixture {
@@ -59,6 +60,7 @@ export async function createFakeAppServer(
 			unsafePolicy: options.unsafePolicy ?? false,
 			requestApproval: options.requestApproval ?? false,
 			spawnDescendant: options.spawnDescendant ?? false,
+			ignoreSigterm: options.ignoreSigterm ?? false,
 			logPath,
 			childPidPath,
 			argvPath,
@@ -135,8 +137,8 @@ export async function waitForEnvironment(path: string): Promise<Record<string, s
 	throw new Error("Timed out waiting for fake app-server environment");
 }
 
-export async function waitForProcessExit(pid: number): Promise<void> {
-	const deadline = Date.now() + 2_000;
+export async function waitForProcessExit(pid: number, timeoutMs = 2_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		if (!isProcessAlive(pid)) return;
 		await delay(10);
@@ -182,6 +184,7 @@ const exitAfterRead = config.exitAfterRead;
 const closeInputAfterRead = config.closeInputAfterRead;
 const unsafePolicy = config.unsafePolicy;
 const requestApproval = config.requestApproval;
+if (config.ignoreSigterm) process.on("SIGTERM", () => undefined);
 if (config.spawnDescendant) {
   const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
     stdio: "ignore",


### PR DESCRIPTION
## Summary

- add one stable kernel-locked Codex provider generation per Capsule
- prearm a detached teardown witness before the durable start barrier or provider spawn
- enforce owner heartbeat, deadline, local revocation, process-group cleanup, and post-absence quiescence
- route ambiguous-start and inherited-interrupt recovery through fresh guardian-owned generations
- add macOS/Linux lifecycle fault coverage, including owner death, joint owner/guardian death, and durable-state corruption
- update architecture, roadmap, RFC, Node, and research documentation

## Safety boundary

This lands the issue #96 guardian as an **unactivated library/process boundary**. Current commands still select deterministic fake runtimes; no real Mission or model turn is activated by this PR.

Follow-up ownership remains explicit:

- #97: verified lease/fence/expiry/revocation authority and local capability enforcement
- #98: descriptor/CLI activation plus durable exact containment-instance recovery
- #120: installed OS supervision, cgroup/process containment, all-owner loss, escaped descendants, and restart/upgrade/rollback

## Verification

- `pnpm lint` — passes with four pre-existing unused-suppression warnings in Relay integration tests
- `pnpm --filter agentrelay-node typecheck`
- `pnpm -r build`
- full Node suite — 39 files passed, 2 skipped; 289 tests passed, 7 platform/live skips
- database-free multi-package suite — protocol 125, MCP 164, Relay 69, Node 289; DB-backed Relay tests self-skip without `RELAY_TEST_DATABASE_URL`
- package tarball contains `dist/bin/agentrelay-codex-guardian.js` and its declaration

Linux-only corruption and joint-owner fault cases are wired into the PR containment job; macOS process ownership has its own matrix lane.

Closes #96